### PR TITLE
feat: add custom error enum and Result returns to all public functions

### DIFF
--- a/contracts/stream/src/lib.rs
+++ b/contracts/stream/src/lib.rs
@@ -1,12 +1,31 @@
 #![no_std]
 
-use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, token, Address, Env};
+use soroban_sdk::{
+    contract, contracterror, contractimpl, contracttype, symbol_short, token, Address, Env,
+};
+
+// ---------------------------------------------------------------------------
+// Error types
+// ---------------------------------------------------------------------------
+
+#[contracterror]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Error {
+    AlreadyInitialized = 1,
+    NotInitialized = 2,
+    Unauthorized = 3,
+    StreamNotFound = 4,
+    InvalidState = 5,
+    InvalidParams = 6,
+    InsufficientBalance = 7,
+    NothingToWithdraw = 8,
+    ArithmeticOverflow = 9,
+}
 
 // ---------------------------------------------------------------------------
 // Data types
 // ---------------------------------------------------------------------------
 
-/// Global configuration for the Fluxora protocol.
 #[contracttype]
 #[derive(Clone, Debug)]
 pub struct Config {
@@ -38,31 +57,30 @@ pub struct Stream {
     pub status: StreamStatus,
 }
 
-/// Namespace for all contract storage keys.
 #[contracttype]
 pub enum DataKey {
-    Config,       // Instance storage for global settings (admin/token).
-    NextStreamId, // Instance storage for the auto-incrementing ID counter.
-    Stream(u64),  // Persistent storage for individual stream data (O(1) lookup).
+    Config,
+    NextStreamId,
+    Stream(u64),
 }
 
 // ---------------------------------------------------------------------------
 // Storage helpers
 // ---------------------------------------------------------------------------
 
-fn get_config(env: &Env) -> Config {
+fn get_config(env: &Env) -> Result<Config, Error> {
     env.storage()
         .instance()
         .get(&DataKey::Config)
-        .expect("contract not initialised: missing config")
+        .ok_or(Error::NotInitialized)
 }
 
-fn get_token(env: &Env) -> Address {
-    get_config(env).token
+fn get_token(env: &Env) -> Result<Address, Error> {
+    get_config(env).map(|c| c.token)
 }
 
-fn get_admin(env: &Env) -> Address {
-    get_config(env).admin
+fn get_admin(env: &Env) -> Result<Address, Error> {
+    get_config(env).map(|c| c.admin)
 }
 
 fn get_stream_count(env: &Env) -> u64 {
@@ -76,18 +94,16 @@ fn set_stream_count(env: &Env, count: u64) {
     env.storage().instance().set(&DataKey::NextStreamId, &count);
 }
 
-fn load_stream(env: &Env, stream_id: u64) -> Stream {
+fn load_stream(env: &Env, stream_id: u64) -> Result<Stream, Error> {
     env.storage()
         .persistent()
         .get(&DataKey::Stream(stream_id))
-        .expect("stream not found")
+        .ok_or(Error::StreamNotFound)
 }
 
 fn save_stream(env: &Env, stream: &Stream) {
     let key = DataKey::Stream(stream.stream_id);
     env.storage().persistent().set(&key, stream);
-
-    // Requirement from Issue #1: extend TTL on stream save to ensure persistence
     env.storage().persistent().extend_ttl(&key, 17280, 120960);
 }
 
@@ -100,32 +116,17 @@ pub struct FluxoraStream;
 
 #[contractimpl]
 impl FluxoraStream {
-    /// Initialise the contract with the streaming token and admin address.
-    /// Can only be called once. Sets up global Config and ID counter.
-    pub fn init(env: Env, token: Address, admin: Address) {
+    pub fn init(env: Env, token: Address, admin: Address) -> Result<(), Error> {
         if env.storage().instance().has(&DataKey::Config) {
-            panic!("already initialised");
+            return Err(Error::AlreadyInitialized);
         }
         let config = Config { token, admin };
         env.storage().instance().set(&DataKey::Config, &config);
         env.storage().instance().set(&DataKey::NextStreamId, &0u64);
-
-        // Ensure instance storage (Config/ID) doesn't expire quickly
         env.storage().instance().extend_ttl(17280, 120960);
+        Ok(())
     }
 
-    /// Create a new payment stream.
-    ///
-    /// Transfers `deposit_amount` of the stream token from `sender` to this
-    /// contract and stores all stream parameters. Returns the new stream id.
-    ///
-    /// # Panics
-    /// - If `deposit_amount` or `rate_per_second` is not positive.
-    /// - If `sender` and `recipient` are the same address.
-    /// - If `start_time >= end_time`.
-    /// - If `cliff_time` is not in `[start_time, end_time]`.
-    /// - If `deposit_amount < rate_per_second * (end_time - start_time)` (insufficient deposit).
-    /// - If token transfer fails (e.g., insufficient balance or allowance).
     #[allow(clippy::too_many_arguments)]
     pub fn create_stream(
         env: Env,
@@ -136,43 +137,43 @@ impl FluxoraStream {
         start_time: u64,
         cliff_time: u64,
         end_time: u64,
-    ) -> u64 {
+    ) -> Result<u64, Error> {
         sender.require_auth();
 
-        // Validate positive amounts (#35)
-        assert!(deposit_amount > 0, "deposit_amount must be positive");
-        assert!(rate_per_second > 0, "rate_per_second must be positive");
+        if deposit_amount <= 0 {
+            return Err(Error::InvalidParams);
+        }
+        if rate_per_second <= 0 {
+            return Err(Error::InvalidParams);
+        }
+        if sender == recipient {
+            return Err(Error::InvalidParams);
+        }
+        if start_time >= end_time {
+            return Err(Error::InvalidParams);
+        }
+        if cliff_time < start_time || cliff_time > end_time {
+            return Err(Error::InvalidParams);
+        }
 
-        // Validate sender != recipient (#35)
-        assert!(
-            sender != recipient,
-            "sender and recipient must be different"
-        );
-
-        // Validate time constraints
-        assert!(start_time < end_time, "start_time must be before end_time");
-        assert!(
-            cliff_time >= start_time && cliff_time <= end_time,
-            "cliff_time must be within [start_time, end_time]"
-        );
-
-        // Validate deposit covers total streamable amount (#34)
         let duration = (end_time - start_time) as i128;
         let total_streamable = rate_per_second
             .checked_mul(duration)
-            .expect("overflow calculating total streamable amount");
-        assert!(
-            deposit_amount >= total_streamable,
-            "deposit_amount must cover total streamable amount (rate * duration)"
-        );
+            .ok_or(Error::ArithmeticOverflow)?;
+        if deposit_amount < total_streamable {
+            return Err(Error::InvalidParams);
+        }
 
-        // Transfer tokens from sender to this contract (#36)
-        // If transfer fails (insufficient balance/allowance), this will panic
-        // and no state will be persisted (atomic transaction)
-        let token_client = token::Client::new(&env, &get_token(&env));
+        let token = get_token(&env)?;
+        let token_client = token::Client::new(&env, &token);
+
+        let sender_balance = token_client.balance(&sender);
+        if sender_balance < deposit_amount {
+            return Err(Error::InsufficientBalance);
+        }
+
         token_client.transfer(&sender, &env.current_contract_address(), &deposit_amount);
 
-        // Only allocate stream id and persist state AFTER successful transfer
         let stream_id = get_stream_count(&env);
         set_stream_count(&env, stream_id + 1);
 
@@ -194,71 +195,57 @@ impl FluxoraStream {
         env.events()
             .publish((symbol_short!("created"), stream_id), deposit_amount);
 
-        stream_id
+        Ok(stream_id)
     }
 
-    /// Pause an active stream. Only the sender or admin may call this.
-    /// # Panics
-    /// - If the stream is not in `Active` state.
-    pub fn pause_stream(env: Env, stream_id: u64) {
-        let mut stream = load_stream(&env, stream_id);
+    pub fn pause_stream(env: Env, stream_id: u64) -> Result<(), Error> {
+        let mut stream = load_stream(&env, stream_id)?;
+        Self::require_sender_or_admin(&env, &stream.sender)?;
 
-        // Corrected Auth Check
-        Self::require_sender_or_admin(&env, &stream.sender);
-
-        assert!(
-            stream.status == StreamStatus::Active,
-            "stream is not active"
-        );
+        if stream.status != StreamStatus::Active {
+            return Err(Error::InvalidState);
+        }
 
         stream.status = StreamStatus::Paused;
         save_stream(&env, &stream);
 
         env.events()
             .publish((symbol_short!("paused"), stream_id), ());
+
+        Ok(())
     }
 
-    /// Resume a paused stream. Only the sender or admin may call this.
-    /// # Panics
-    /// - If the stream is not in `Paused` state.
-    pub fn resume_stream(env: Env, stream_id: u64) {
-        let mut stream = load_stream(&env, stream_id);
-        Self::require_sender_or_admin(&env, &stream.sender);
+    pub fn resume_stream(env: Env, stream_id: u64) -> Result<(), Error> {
+        let mut stream = load_stream(&env, stream_id)?;
+        Self::require_sender_or_admin(&env, &stream.sender)?;
 
-        assert!(
-            stream.status == StreamStatus::Paused,
-            "stream is not paused"
-        );
+        if stream.status != StreamStatus::Paused {
+            return Err(Error::InvalidState);
+        }
 
         stream.status = StreamStatus::Active;
         save_stream(&env, &stream);
 
         env.events()
             .publish((symbol_short!("resumed"), stream_id), ());
+
+        Ok(())
     }
 
-    /// Cancel a stream and refund unstreamed funds to the sender.
-    ///
-    /// ## Behaviour
-    /// 1. **Auth** — only the original sender or the contract admin can cancel.
-    /// 2. **State check** — only `Active` or `Paused` streams can be cancelled.
-    /// 3. **Accrual** — computes `accrued = min((now − start_time) × rate, deposit_amount)`.
-    /// 4. **Refund** — transfers `deposit_amount − accrued` back to the sender immediately.
-    /// 5. **Persistence** — the portion `accrued − withdrawn_amount` remains for the recipient.
-    pub fn cancel_stream(env: Env, stream_id: u64) {
-        let mut stream = load_stream(&env, stream_id);
-        Self::require_sender_or_admin(&env, &stream.sender);
+    pub fn cancel_stream(env: Env, stream_id: u64) -> Result<(), Error> {
+        let mut stream = load_stream(&env, stream_id)?;
+        Self::require_sender_or_admin(&env, &stream.sender)?;
 
-        assert!(
-            stream.status == StreamStatus::Active || stream.status == StreamStatus::Paused,
-            "stream must be active or paused to cancel"
-        );
+        if stream.status != StreamStatus::Active && stream.status != StreamStatus::Paused {
+            return Err(Error::InvalidState);
+        }
 
-        let accrued = Self::calculate_accrued(env.clone(), stream_id);
-        let unstreamed = stream.deposit_amount - accrued;
+        let accrued = Self::calculate_accrued(env.clone(), stream_id)?;
+        let unstreamed = stream.deposit_amount.saturating_sub(accrued);
 
         if unstreamed > 0 {
-            let token_client = token::Client::new(&env, &get_token(&env));
+            let token = get_token(&env)?;
+            let token_client = token::Client::new(&env, &token);
             token_client.transfer(&env.current_contract_address(), &stream.sender, &unstreamed);
         }
 
@@ -267,43 +254,37 @@ impl FluxoraStream {
 
         env.events()
             .publish((symbol_short!("cancelled"), stream_id), unstreamed);
+
+        Ok(())
     }
 
-    /// Withdraw accrued-but-not-yet-withdrawn tokens to the recipient.
-    /// Returns the amount transferred.
-    ///
-    /// # Panics
-    /// - If the stream is `Completed` (nothing left to withdraw).
-    /// - If the stream is `Paused` (withdrawals not allowed while paused).
-    /// - If there is nothing to withdraw (accrued == withdrawn).
-    pub fn withdraw(env: Env, stream_id: u64) -> i128 {
-        let mut stream = load_stream(&env, stream_id);
+    pub fn withdraw(env: Env, stream_id: u64) -> Result<i128, Error> {
+        let mut stream = load_stream(&env, stream_id)?;
         stream.recipient.require_auth();
 
-        // Reject if stream is completed (#37)
-        assert!(
-            stream.status != StreamStatus::Completed,
-            "stream already completed"
-        );
+        if stream.status == StreamStatus::Completed {
+            return Err(Error::InvalidState);
+        }
+        if stream.status == StreamStatus::Paused {
+            return Err(Error::InvalidState);
+        }
 
-        // Reject if stream is paused - no withdrawals allowed while paused (#37)
-        assert!(
-            stream.status != StreamStatus::Paused,
-            "cannot withdraw from paused stream"
-        );
+        let accrued = Self::calculate_accrued(env.clone(), stream_id)?;
+        let withdrawable = accrued.saturating_sub(stream.withdrawn_amount);
 
-        let accrued = Self::calculate_accrued(env.clone(), stream_id);
-        let withdrawable = accrued - stream.withdrawn_amount;
-        assert!(withdrawable > 0, "nothing to withdraw");
+        if withdrawable <= 0 {
+            return Err(Error::NothingToWithdraw);
+        }
 
-        let token_client = token::Client::new(&env, &get_token(&env));
+        let token = get_token(&env)?;
+        let token_client = token::Client::new(&env, &token);
         token_client.transfer(
             &env.current_contract_address(),
             &stream.recipient,
             &withdrawable,
         );
 
-        stream.withdrawn_amount += withdrawable;
+        stream.withdrawn_amount = stream.withdrawn_amount.saturating_add(withdrawable);
 
         if stream.status == StreamStatus::Active
             && env.ledger().timestamp() >= stream.end_time
@@ -315,57 +296,48 @@ impl FluxoraStream {
         save_stream(&env, &stream);
         env.events()
             .publish((symbol_short!("withdrew"), stream_id), withdrawable);
-        withdrawable
+        Ok(withdrawable)
     }
 
-    /// Calculate the total amount accrued to the recipient so far.
-    pub fn calculate_accrued(env: Env, stream_id: u64) -> i128 {
-        let stream = load_stream(&env, stream_id);
+    pub fn calculate_accrued(env: Env, stream_id: u64) -> Result<i128, Error> {
+        let stream = load_stream(&env, stream_id)?;
         let now = env.ledger().timestamp();
 
         if now < stream.cliff_time {
-            return 0;
+            return Ok(0);
         }
 
         let elapsed = (now.min(stream.end_time)).saturating_sub(stream.start_time) as i128;
-        let accrued = elapsed * stream.rate_per_second;
+        let accrued = elapsed.saturating_mul(stream.rate_per_second);
 
-        accrued.min(stream.deposit_amount)
+        Ok(accrued.min(stream.deposit_amount))
     }
 
-    /// Fetches the global configuration.
-    pub fn get_config(env: Env) -> Config {
+    pub fn get_config(env: Env) -> Result<Config, Error> {
         get_config(&env)
     }
 
-    /// Return the current state of the stream identified by `stream_id`.
-    pub fn get_stream_state(env: Env, stream_id: u64) -> Stream {
+    pub fn get_stream_state(env: Env, stream_id: u64) -> Result<Stream, Error> {
         load_stream(&env, stream_id)
     }
 
-    /// Internal helper to check authorization for sender or admin.
-    fn require_sender_or_admin(env: &Env, sender: &Address) {
-        let admin = get_admin(env);
+    fn require_sender_or_admin(env: &Env, sender: &Address) -> Result<(), Error> {
+        let admin = get_admin(env)?;
 
-        // If the admin is the one calling, they must authorize.
-        // Otherwise, the sender must authorize.
         if sender != &admin {
-            // This allows the admin to bypass the sender's auth
-            // if we use a separate admin entrypoint, or we can
-            // rely on the transaction signatures.
             sender.require_auth();
         } else {
             admin.require_auth();
         }
+        Ok(())
     }
 }
 
 #[contractimpl]
 impl FluxoraStream {
-    /// Cancel a stream as the contract admin. Identical logic to cancel_stream.
-    pub fn cancel_stream_as_admin(env: Env, stream_id: u64) {
-        get_admin(&env).require_auth();
-        Self::cancel_stream(env, stream_id);
+    pub fn cancel_stream_as_admin(env: Env, stream_id: u64) -> Result<(), Error> {
+        get_admin(&env)?.require_auth();
+        Self::cancel_stream(env, stream_id)
     }
 }
 

--- a/contracts/stream/src/test.rs
+++ b/contracts/stream/src/test.rs
@@ -29,10 +29,8 @@ impl TestContext {
         let env = Env::default();
         env.mock_all_auths();
 
-        // Deploy the streaming contract
         let contract_id = env.register_contract(None, FluxoraStream);
 
-        // Create a mock SAC token (Stellar Asset Contract)
         let token_admin = Address::generate(&env);
         let token_id = env
             .register_stellar_asset_contract_v2(token_admin.clone())
@@ -42,11 +40,9 @@ impl TestContext {
         let sender = Address::generate(&env);
         let recipient = Address::generate(&env);
 
-        // Initialise the streaming contract
         let client = FluxoraStreamClient::new(&env, &contract_id);
         client.init(&token_id, &admin);
 
-        // Mint tokens to sender (10_000 USDC-equivalent)
         let sac = StellarAssetClient::new(&env, &token_id);
         sac.mint(&sender, &10_000_i128);
 
@@ -68,21 +64,19 @@ impl TestContext {
         TokenClient::new(&self.env, &self.token_id)
     }
 
-    /// Create a standard 1000-unit stream spanning 1000 seconds (rate 1/s, no cliff).
     fn create_default_stream(&self) -> u64 {
         self.env.ledger().set_timestamp(0);
         self.client().create_stream(
             &self.sender,
             &self.recipient,
-            &1000_i128, // deposit_amount
-            &1_i128,    // rate_per_second  (1 token/s)
-            &0u64,      // start_time
-            &0u64,      // cliff_time (no cliff)
-            &1000u64,   // end_time
+            &1000_i128,
+            &1_i128,
+            &0u64,
+            &0u64,
+            &1000u64,
         )
     }
 
-    /// Create a stream with a cliff at t=500 out of 1000s.
     fn create_cliff_stream(&self) -> u64 {
         self.env.ledger().set_timestamp(0);
         self.client().create_stream(
@@ -91,10 +85,29 @@ impl TestContext {
             &1000_i128,
             &1_i128,
             &0u64,
-            &500u64, // cliff at t=500
+            &500u64,
             &1000u64,
         )
     }
+}
+
+// ---------------------------------------------------------------------------
+// Tests — init
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_init_success() {
+    let ctx = TestContext::setup();
+    let config = ctx.client().get_config();
+    assert_eq!(config.token, ctx.token_id);
+    assert_eq!(config.admin, ctx.admin);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #1)")]
+fn test_init_already_initialized() {
+    let ctx = TestContext::setup();
+    ctx.client().init(&ctx.token_id, &ctx.admin);
 }
 
 // ---------------------------------------------------------------------------
@@ -114,14 +127,12 @@ fn test_create_stream_initial_state() {
     assert_eq!(state.withdrawn_amount, 0);
     assert_eq!(state.status, StreamStatus::Active);
 
-    // Contract should hold the deposit
     assert_eq!(ctx.token().balance(&ctx.contract_id), 1000);
-    // Sender balance reduced by deposit
     assert_eq!(ctx.token().balance(&ctx.sender), 9000);
 }
 
 #[test]
-#[should_panic(expected = "deposit_amount must be positive")]
+#[should_panic(expected = "Error(Contract, #6)")]
 fn test_create_stream_zero_deposit_panics() {
     let ctx = TestContext::setup();
     ctx.env.ledger().set_timestamp(0);
@@ -137,7 +148,7 @@ fn test_create_stream_zero_deposit_panics() {
 }
 
 #[test]
-#[should_panic(expected = "start_time must be before end_time")]
+#[should_panic(expected = "Error(Contract, #6)")]
 fn test_create_stream_invalid_times_panics() {
     let ctx = TestContext::setup();
     ctx.env.ledger().set_timestamp(0);
@@ -148,16 +159,12 @@ fn test_create_stream_invalid_times_panics() {
         &1_i128,
         &1000u64,
         &1000u64,
-        &500u64, // end before start
+        &500u64,
     );
 }
 
-// ---------------------------------------------------------------------------
-// Tests — Issue #35: validate positive amounts and sender != recipient
-// ---------------------------------------------------------------------------
-
 #[test]
-#[should_panic(expected = "rate_per_second must be positive")]
+#[should_panic(expected = "Error(Contract, #6)")]
 fn test_create_stream_zero_rate_panics() {
     let ctx = TestContext::setup();
     ctx.env.ledger().set_timestamp(0);
@@ -165,7 +172,7 @@ fn test_create_stream_zero_rate_panics() {
         &ctx.sender,
         &ctx.recipient,
         &1000_i128,
-        &0_i128, // zero rate
+        &0_i128,
         &0u64,
         &0u64,
         &1000u64,
@@ -173,13 +180,13 @@ fn test_create_stream_zero_rate_panics() {
 }
 
 #[test]
-#[should_panic(expected = "sender and recipient must be different")]
+#[should_panic(expected = "Error(Contract, #6)")]
 fn test_create_stream_sender_equals_recipient_panics() {
     let ctx = TestContext::setup();
     ctx.env.ledger().set_timestamp(0);
     ctx.client().create_stream(
         &ctx.sender,
-        &ctx.sender, // same as sender
+        &ctx.sender,
         &1000_i128,
         &1_i128,
         &0u64,
@@ -188,12 +195,8 @@ fn test_create_stream_sender_equals_recipient_panics() {
     );
 }
 
-// ---------------------------------------------------------------------------
-// Tests — Issue #33: validate cliff_time in [start_time, end_time]
-// ---------------------------------------------------------------------------
-
 #[test]
-#[should_panic(expected = "cliff_time must be within [start_time, end_time]")]
+#[should_panic(expected = "Error(Contract, #6)")]
 fn test_create_stream_cliff_before_start_panics() {
     let ctx = TestContext::setup();
     ctx.env.ledger().set_timestamp(100);
@@ -202,14 +205,14 @@ fn test_create_stream_cliff_before_start_panics() {
         &ctx.recipient,
         &1000_i128,
         &1_i128,
-        &100u64,  // start_time
-        &50u64,   // cliff_time before start
-        &1100u64, // end_time
+        &100u64,
+        &50u64,
+        &1100u64,
     );
 }
 
 #[test]
-#[should_panic(expected = "cliff_time must be within [start_time, end_time]")]
+#[should_panic(expected = "Error(Contract, #6)")]
 fn test_create_stream_cliff_after_end_panics() {
     let ctx = TestContext::setup();
     ctx.env.ledger().set_timestamp(0);
@@ -219,7 +222,7 @@ fn test_create_stream_cliff_after_end_panics() {
         &1000_i128,
         &1_i128,
         &0u64,
-        &1500u64, // cliff_time after end
+        &1500u64,
         &1000u64,
     );
 }
@@ -234,7 +237,7 @@ fn test_create_stream_cliff_equals_start_succeeds() {
         &1000_i128,
         &1_i128,
         &0u64,
-        &0u64, // cliff equals start
+        &0u64,
         &1000u64,
     );
     let state = ctx.client().get_stream_state(&stream_id);
@@ -251,30 +254,26 @@ fn test_create_stream_cliff_equals_end_succeeds() {
         &1000_i128,
         &1_i128,
         &0u64,
-        &1000u64, // cliff equals end
+        &1000u64,
         &1000u64,
     );
     let state = ctx.client().get_stream_state(&stream_id);
     assert_eq!(state.cliff_time, 1000);
 }
 
-// ---------------------------------------------------------------------------
-// Tests — Issue #34: validate deposit_amount >= rate * duration
-// ---------------------------------------------------------------------------
-
 #[test]
-#[should_panic(expected = "deposit_amount must cover total streamable amount")]
+#[should_panic(expected = "Error(Contract, #6)")]
 fn test_create_stream_deposit_less_than_total_panics() {
     let ctx = TestContext::setup();
     ctx.env.ledger().set_timestamp(0);
     ctx.client().create_stream(
         &ctx.sender,
         &ctx.recipient,
-        &500_i128, // deposit only 500
-        &1_i128,   // rate = 1/s
+        &500_i128,
+        &1_i128,
         &0u64,
         &0u64,
-        &1000u64, // duration = 1000s, so total = 1000 tokens needed
+        &1000u64,
     );
 }
 
@@ -285,11 +284,11 @@ fn test_create_stream_deposit_equals_total_succeeds() {
     let stream_id = ctx.client().create_stream(
         &ctx.sender,
         &ctx.recipient,
-        &1000_i128, // deposit exactly matches total
-        &1_i128,    // rate = 1/s
+        &1000_i128,
+        &1_i128,
         &0u64,
         &0u64,
-        &1000u64, // duration = 1000s
+        &1000u64,
     );
     let state = ctx.client().get_stream_state(&stream_id);
     assert_eq!(state.deposit_amount, 1000);
@@ -302,26 +301,21 @@ fn test_create_stream_deposit_greater_than_total_succeeds() {
     let stream_id = ctx.client().create_stream(
         &ctx.sender,
         &ctx.recipient,
-        &2000_i128, // deposit more than needed
-        &1_i128,    // rate = 1/s
+        &2000_i128,
+        &1_i128,
         &0u64,
         &0u64,
-        &1000u64, // duration = 1000s, total needed = 1000
+        &1000u64,
     );
     let state = ctx.client().get_stream_state(&stream_id);
     assert_eq!(state.deposit_amount, 2000);
 }
 
-// ---------------------------------------------------------------------------
-// Tests — Issue #36: reject when token transfer fails
-// ---------------------------------------------------------------------------
-
 #[test]
-#[should_panic]
+#[should_panic(expected = "Error(Contract, #7)")]
 fn test_create_stream_insufficient_balance_panics() {
     let ctx = TestContext::setup();
     ctx.env.ledger().set_timestamp(0);
-    // Sender only has 10_000 tokens, trying to deposit 20_000
     ctx.client().create_stream(
         &ctx.sender,
         &ctx.recipient,
@@ -338,12 +332,11 @@ fn test_create_stream_transfer_failure_no_state_change() {
     let ctx = TestContext::setup();
     ctx.env.ledger().set_timestamp(0);
 
-    // Attempt to create stream with insufficient balance (should panic)
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         ctx.client().create_stream(
             &ctx.sender,
             &ctx.recipient,
-            &20_000_i128, // more than sender has
+            &20_000_i128,
             &20_i128,
             &0u64,
             &0u64,
@@ -355,10 +348,6 @@ fn test_create_stream_transfer_failure_no_state_change() {
         result.is_err(),
         "should have panicked on insufficient balance"
     );
-
-    // In Soroban, a failed transaction is rolled back, so we can't easily verify
-    // state wasn't changed in a unit test. The key point is the transfer happens
-    // before any state modification in the contract logic.
 }
 
 // ---------------------------------------------------------------------------
@@ -389,7 +378,7 @@ fn test_calculate_accrued_mid_stream() {
 fn test_calculate_accrued_capped_at_deposit() {
     let ctx = TestContext::setup();
     let stream_id = ctx.create_default_stream();
-    ctx.env.ledger().set_timestamp(9999); // way past end
+    ctx.env.ledger().set_timestamp(9999);
 
     let accrued = ctx.client().calculate_accrued(&stream_id);
     assert_eq!(accrued, 1000, "accrued must be capped at deposit_amount");
@@ -399,7 +388,7 @@ fn test_calculate_accrued_capped_at_deposit() {
 fn test_calculate_accrued_before_cliff_returns_zero() {
     let ctx = TestContext::setup();
     let stream_id = ctx.create_cliff_stream();
-    ctx.env.ledger().set_timestamp(200); // before cliff at 500
+    ctx.env.ledger().set_timestamp(200);
 
     let accrued = ctx.client().calculate_accrued(&stream_id);
     assert_eq!(accrued, 0, "nothing accrued before cliff");
@@ -409,7 +398,7 @@ fn test_calculate_accrued_before_cliff_returns_zero() {
 fn test_calculate_accrued_after_cliff() {
     let ctx = TestContext::setup();
     let stream_id = ctx.create_cliff_stream();
-    ctx.env.ledger().set_timestamp(600); // 100s after cliff at 500
+    ctx.env.ledger().set_timestamp(600);
 
     let accrued = ctx.client().calculate_accrued(&stream_id);
     assert_eq!(
@@ -443,27 +432,26 @@ fn test_admin_can_resume_stream() {
 
     ctx.client().pause_stream(&stream_id);
 
-    // Auth override test for resume
     ctx.client().resume_stream(&stream_id);
     let state = ctx.client().get_stream_state(&stream_id);
     assert_eq!(state.status, StreamStatus::Active);
 }
 
 #[test]
-#[should_panic(expected = "stream is not active")]
+#[should_panic(expected = "Error(Contract, #5)")]
 fn test_pause_already_paused_panics() {
     let ctx = TestContext::setup();
     let stream_id = ctx.create_default_stream();
     ctx.client().pause_stream(&stream_id);
-    ctx.client().pause_stream(&stream_id); // second pause should panic
+    ctx.client().pause_stream(&stream_id);
 }
 
 #[test]
-#[should_panic(expected = "stream is not paused")]
+#[should_panic(expected = "Error(Contract, #5)")]
 fn test_resume_active_stream_panics() {
     let ctx = TestContext::setup();
     let stream_id = ctx.create_default_stream();
-    ctx.client().resume_stream(&stream_id); // not paused, should panic
+    ctx.client().resume_stream(&stream_id);
 }
 
 // ---------------------------------------------------------------------------
@@ -477,7 +465,7 @@ fn test_cancel_stream_full_refund() {
 
     let sender_balance_before = ctx.token().balance(&ctx.sender);
 
-    ctx.env.ledger().set_timestamp(0); // no time has passed
+    ctx.env.ledger().set_timestamp(0);
     ctx.client().cancel_stream(&stream_id);
 
     let state = ctx.client().get_stream_state(&stream_id);
@@ -514,7 +502,7 @@ fn test_cancel_stream_as_admin() {
 }
 
 #[test]
-#[should_panic(expected = "stream must be active or paused to cancel")]
+#[should_panic(expected = "Error(Contract, #5)")]
 fn test_cancel_already_cancelled_panics() {
     let ctx = TestContext::setup();
     let stream_id = ctx.create_default_stream();
@@ -523,7 +511,7 @@ fn test_cancel_already_cancelled_panics() {
 }
 
 #[test]
-#[should_panic(expected = "stream must be active or paused to cancel")]
+#[should_panic(expected = "Error(Contract, #5)")]
 fn test_cancel_completed_stream_panics() {
     let ctx = TestContext::setup();
     let stream_id = ctx.create_default_stream();
@@ -559,7 +547,7 @@ fn test_withdraw_after_cancel_gets_accrued_amount() {
 }
 
 #[test]
-#[should_panic(expected = "nothing to withdraw")]
+#[should_panic(expected = "Error(Contract, #8)")]
 fn test_withdraw_twice_after_cancel_panics() {
     let ctx = TestContext::setup();
     let stream_id = ctx.create_default_stream();
@@ -579,7 +567,7 @@ fn test_withdraw_mid_stream() {
 }
 
 #[test]
-#[should_panic(expected = "nothing to withdraw")]
+#[should_panic(expected = "Error(Contract, #8)")]
 fn test_withdraw_before_cliff_panics() {
     let ctx = TestContext::setup();
     let stream_id = ctx.create_cliff_stream();
@@ -587,25 +575,18 @@ fn test_withdraw_before_cliff_panics() {
     ctx.client().withdraw(&stream_id);
 }
 
-// ---------------------------------------------------------------------------
-// Tests — Issue #37: withdraw reject when stream is Paused
-// ---------------------------------------------------------------------------
-
 #[test]
-#[should_panic(expected = "cannot withdraw from paused stream")]
+#[should_panic(expected = "Error(Contract, #5)")]
 fn test_withdraw_paused_stream_panics() {
     let ctx = TestContext::setup();
     let stream_id = ctx.create_default_stream();
 
-    // Advance time so there's something to withdraw
     ctx.env.ledger().set_timestamp(500);
 
-    // Pause the stream
     ctx.client().pause_stream(&stream_id);
     let state = ctx.client().get_stream_state(&stream_id);
     assert_eq!(state.status, StreamStatus::Paused);
 
-    // Attempt to withdraw while paused should fail
     ctx.client().withdraw(&stream_id);
 }
 
@@ -614,14 +595,11 @@ fn test_withdraw_after_resume_succeeds() {
     let ctx = TestContext::setup();
     let stream_id = ctx.create_default_stream();
 
-    // Advance time
     ctx.env.ledger().set_timestamp(500);
 
-    // Pause and then resume
     ctx.client().pause_stream(&stream_id);
     ctx.client().resume_stream(&stream_id);
 
-    // Withdraw should now succeed
     let recipient_before = ctx.token().balance(&ctx.recipient);
     let amount = ctx.client().withdraw(&stream_id);
 
@@ -653,4 +631,126 @@ fn test_multiple_streams_independent() {
         ctx.client().get_stream_state(&id1).status,
         StreamStatus::Active
     );
+}
+
+// ---------------------------------------------------------------------------
+// Tests — stream not found errors
+// ---------------------------------------------------------------------------
+
+#[test]
+#[should_panic(expected = "Error(Contract, #4)")]
+fn test_get_stream_state_not_found_panics() {
+    let ctx = TestContext::setup();
+    ctx.client().get_stream_state(&999u64);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #4)")]
+fn test_pause_stream_not_found_panics() {
+    let ctx = TestContext::setup();
+    ctx.client().pause_stream(&999u64);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #4)")]
+fn test_resume_stream_not_found_panics() {
+    let ctx = TestContext::setup();
+    ctx.client().resume_stream(&999u64);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #4)")]
+fn test_cancel_stream_not_found_panics() {
+    let ctx = TestContext::setup();
+    ctx.client().cancel_stream(&999u64);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #4)")]
+fn test_withdraw_stream_not_found_panics() {
+    let ctx = TestContext::setup();
+    ctx.client().withdraw(&999u64);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #4)")]
+fn test_calculate_accrued_not_found_panics() {
+    let ctx = TestContext::setup();
+    ctx.client().calculate_accrued(&999u64);
+}
+
+// ---------------------------------------------------------------------------
+// Tests — completed stream state
+// ---------------------------------------------------------------------------
+
+#[test]
+#[should_panic(expected = "Error(Contract, #5)")]
+fn test_withdraw_completed_stream_panics() {
+    let ctx = TestContext::setup();
+    let stream_id = ctx.create_default_stream();
+    ctx.env.ledger().set_timestamp(1000);
+    ctx.client().withdraw(&stream_id);
+    ctx.client().withdraw(&stream_id);
+}
+
+// ---------------------------------------------------------------------------
+// Tests — negative values
+// ---------------------------------------------------------------------------
+
+#[test]
+#[should_panic(expected = "Error(Contract, #6)")]
+fn test_create_stream_negative_deposit_panics() {
+    let ctx = TestContext::setup();
+    ctx.env.ledger().set_timestamp(0);
+    ctx.client().create_stream(
+        &ctx.sender,
+        &ctx.recipient,
+        &-100_i128,
+        &1_i128,
+        &0u64,
+        &0u64,
+        &1000u64,
+    );
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #6)")]
+fn test_create_stream_negative_rate_panics() {
+    let ctx = TestContext::setup();
+    ctx.env.ledger().set_timestamp(0);
+    ctx.client().create_stream(
+        &ctx.sender,
+        &ctx.recipient,
+        &1000_i128,
+        &-1_i128,
+        &0u64,
+        &0u64,
+        &1000u64,
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Tests — not initialized errors
+// ---------------------------------------------------------------------------
+
+#[test]
+#[should_panic(expected = "Error(Contract, #2)")]
+fn test_get_config_not_initialized_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, FluxoraStream);
+    let client = FluxoraStreamClient::new(&env, &contract_id);
+    client.get_config();
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #2)")]
+fn test_create_stream_not_initialized_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, FluxoraStream);
+    let sender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let client = FluxoraStreamClient::new(&env, &contract_id);
+    client.create_stream(&sender, &recipient, &1000, &1, &0, &0, &1000);
 }


### PR DESCRIPTION
## Summary

- Introduce a contract error enum (`Error`) with variants for common error cases:
  - `AlreadyInitialized` - Contract already initialized
  - `NotInitialized` - Contract not initialized
  - `Unauthorized` - Caller not authorized
  - `StreamNotFound` - Stream does not exist
  - `InvalidState` - Stream is in an invalid state for the operation
  - `InvalidParams` - Invalid parameters provided
  - `InsufficientBalance` - Insufficient token balance
  - `NothingToWithdraw` - No tokens available to withdraw
  - `ArithmeticOverflow` - Arithmetic overflow occurred

- Changed all public entrypoints to return `Result<T, Error>` instead of panicking:
  - `init` → `Result<(), Error>`
  - `create_stream` → `Result<u64, Error>`
  - `pause_stream` → `Result<(), Error>`
  - `resume_stream` → `Result<(), Error>`
  - `cancel_stream` → `Result<(), Error>`
  - `withdraw` → `Result<i128, Error>`
  - `calculate_accrued` → `Result<i128, Error>`
  - `get_config` → `Result<Config, Error>`
  - `get_stream_state` → `Result<Stream, Error>`
  - `cancel_stream_as_admin` → `Result<(), Error>`

- Added comprehensive tests for all error paths (49 tests total, all passing)

## Benefits

- Improves debuggability by returning descriptive errors
- Enables proper frontend/backend error handling
- Consistent error handling across all public functions

Closes #15