### PR TITLE
test: calculate_accrued returns 0 before cliff_time

### DIFF
--- a/contracts/stream/src/test.rs
+++ b/contracts/stream/src/test.rs
@@ -796,6 +796,24 @@ fn test_calculate_accrued_at_start() {
 }
 
 #[test]
+fn test_calculate_accrued_before_cliff() {
+    let ctx = TestContext::setup();
+    ctx.env.ledger().set_timestamp(0);
+    let stream_id = ctx.client().create_stream(
+        &ctx.sender,
+        &ctx.recipient,
+        &1000_i128,
+        &1_i128,
+        &0u64,
+        &500u64,
+        &1000u64,
+    );
+    ctx.env.ledger().set_timestamp(300);
+    let accrued = ctx.client().calculate_accrued(&stream_id);
+    assert_eq!(accrued, 0);
+}
+
+#[test]
 fn test_calculate_accrued_mid_stream() {
     let ctx = TestContext::setup();
     let stream_id = ctx.create_default_stream();


### PR DESCRIPTION
## Unit Test: calculate_accrued Before Cliff

### Description
Adds unit test to verify that `calculate_accrued` returns 0 when called before the cliff time, ensuring cliff behavior is correctly implemented.

### Changes
- Added `test_calculate_accrued_before_cliff` in `contracts/stream/src/test.rs`
- Creates stream with cliff at t=500
- Calls `calculate_accrued` at t=300 (before cliff)
- Asserts result is 0

### Test Output

running 148 tests
...
test test::test_calculate_accrued_before_cliff ... ok
...
test result: ok. 148 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

running 21 tests
...
test result: ok. 21 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

**Total: 169 tests passing (148 unit + 21 integration)**

### Closes: #45 