### PR TITLE
feat: ensure unique stream_id generation for each create_stream call

### DIFF
--- a/contracts/stream/src/test.rs
+++ b/contracts/stream/src/test.rs
@@ -3525,13 +3525,31 @@ fn test_stream_id_increments_by_one() {
     ctx.env.ledger().set_timestamp(0);
 
     let id0 = ctx.client().create_stream(
-        &ctx.sender, &ctx.recipient, &100_i128, &1_i128, &0u64, &0u64, &100u64,
+        &ctx.sender,
+        &ctx.recipient,
+        &100_i128,
+        &1_i128,
+        &0u64,
+        &0u64,
+        &100u64,
     );
     let id1 = ctx.client().create_stream(
-        &ctx.sender, &ctx.recipient, &100_i128, &1_i128, &0u64, &0u64, &100u64,
+        &ctx.sender,
+        &ctx.recipient,
+        &100_i128,
+        &1_i128,
+        &0u64,
+        &0u64,
+        &100u64,
     );
     let id2 = ctx.client().create_stream(
-        &ctx.sender, &ctx.recipient, &100_i128, &1_i128, &0u64, &0u64, &100u64,
+        &ctx.sender,
+        &ctx.recipient,
+        &100_i128,
+        &1_i128,
+        &0u64,
+        &0u64,
+        &100u64,
     );
 
     assert_eq!(id0, 0, "first id must be 0");
@@ -3615,7 +3633,13 @@ fn test_failed_create_stream_does_not_advance_counter() {
 
     // First successful stream → id = 0
     let id0 = ctx.client().create_stream(
-        &ctx.sender, &ctx.recipient, &100_i128, &1_i128, &0u64, &0u64, &100u64,
+        &ctx.sender,
+        &ctx.recipient,
+        &100_i128,
+        &1_i128,
+        &0u64,
+        &0u64,
+        &100u64,
     );
     assert_eq!(id0, 0);
 
@@ -3635,7 +3659,13 @@ fn test_failed_create_stream_does_not_advance_counter() {
 
     // Next successful stream must still be id = 1, not 2
     let id1 = ctx.client().create_stream(
-        &ctx.sender, &ctx.recipient, &100_i128, &1_i128, &0u64, &0u64, &100u64,
+        &ctx.sender,
+        &ctx.recipient,
+        &100_i128,
+        &1_i128,
+        &0u64,
+        &0u64,
+        &100u64,
     );
     assert_eq!(
         id1, 1,
@@ -3656,13 +3686,31 @@ fn test_stream_ids_unique_across_different_senders() {
     ctx.sac.mint(&sender2, &1_000_i128);
 
     let id_a = ctx.client().create_stream(
-        &ctx.sender, &ctx.recipient, &100_i128, &1_i128, &0u64, &0u64, &100u64,
+        &ctx.sender,
+        &ctx.recipient,
+        &100_i128,
+        &1_i128,
+        &0u64,
+        &0u64,
+        &100u64,
     );
     let id_b = ctx.client().create_stream(
-        &sender2, &recipient2, &100_i128, &1_i128, &0u64, &0u64, &100u64,
+        &sender2,
+        &recipient2,
+        &100_i128,
+        &1_i128,
+        &0u64,
+        &0u64,
+        &100u64,
     );
     let id_c = ctx.client().create_stream(
-        &ctx.sender, &recipient2, &100_i128, &1_i128, &0u64, &0u64, &100u64,
+        &ctx.sender,
+        &recipient2,
+        &100_i128,
+        &1_i128,
+        &0u64,
+        &0u64,
+        &100u64,
     );
 
     assert_eq!(id_a, 0, "first stream (sender1→recipient1) must be 0");
@@ -3682,13 +3730,31 @@ fn test_stream_id_stability_after_state_changes() {
     ctx.env.ledger().set_timestamp(0);
 
     let id0 = ctx.client().create_stream(
-        &ctx.sender, &ctx.recipient, &200_i128, &2_i128, &0u64, &0u64, &100u64,
+        &ctx.sender,
+        &ctx.recipient,
+        &200_i128,
+        &2_i128,
+        &0u64,
+        &0u64,
+        &100u64,
     );
     let id1 = ctx.client().create_stream(
-        &ctx.sender, &ctx.recipient, &200_i128, &2_i128, &0u64, &0u64, &100u64,
+        &ctx.sender,
+        &ctx.recipient,
+        &200_i128,
+        &2_i128,
+        &0u64,
+        &0u64,
+        &100u64,
     );
     let id2 = ctx.client().create_stream(
-        &ctx.sender, &ctx.recipient, &200_i128, &2_i128, &0u64, &0u64, &100u64,
+        &ctx.sender,
+        &ctx.recipient,
+        &200_i128,
+        &2_i128,
+        &0u64,
+        &0u64,
+        &100u64,
     );
 
     // Mutate stream 1: pause then cancel
@@ -3702,7 +3768,16 @@ fn test_stream_id_stability_after_state_changes() {
 
     // The global counter must continue from 3
     let id3 = ctx.client().create_stream(
-        &ctx.sender, &ctx.recipient, &200_i128, &2_i128, &0u64, &0u64, &100u64,
+        &ctx.sender,
+        &ctx.recipient,
+        &200_i128,
+        &2_i128,
+        &0u64,
+        &0u64,
+        &100u64,
     );
-    assert_eq!(id3, 3, "counter must continue monotonically after state mutations");
+    assert_eq!(
+        id3, 3,
+        "counter must continue monotonically after state mutations"
+    );
 }

--- a/contracts/stream/tests/integration_suite.rs
+++ b/contracts/stream/tests/integration_suite.rs
@@ -805,7 +805,10 @@ fn integration_stream_ids_are_unique_and_sequential() {
         );
 
         // Returned id must be sequential
-        assert_eq!(id, expected, "stream {expected}: id must equal counter value");
+        assert_eq!(
+            id, expected,
+            "stream {expected}: id must equal counter value"
+        );
 
         // Id stored inside the struct must match the returned id
         let state = ctx.client().get_stream_state(&id);


### PR DESCRIPTION


Soroban smart contracts for the Fluxora treasury streaming protocol on Stellar. Stream USDC from a treasury to recipients over time with configurable rate, duration, and cliff.

Close #4 

## What's in this repo

- **Stream contract** (`contracts/stream`) — Lock USDC, accrue per second, withdraw on demand.
- **Data model** — `Stream` (sender, recipient, deposit_amount, rate_per_second, start/cliff/end time, withdrawn_amount, status).
- **Status** — Active, Paused, Completed, Cancelled.
- **Methods (stubs)** — `init`, `create_stream`, `pause_stream`, `resume_stream`, `cancel_stream`, `withdraw`, `calculate_accrued`, `get_stream_state`.

Implementation is scaffolded; storage, token transfers, and events are left for you to complete.

## Tech stack

- Rust (edition 2021)
- [soroban-sdk](https://docs.rs/soroban-sdk) (Stellar Soroban)
- Build target: `wasm32-unknown-unknown` for deployment

## Local setup

### Prerequisites

- Rust 1.70+
- [Stellar CLI](https://developers.stellar.org/docs/tools/developer-tools) (optional, for deploy/test on network)

```bash
rustup target add wasm32-unknown-unknown
```

### Build

From the repo root:

```bash
cargo build --release -p fluxora_stream
```

WASM output is under `target/wasm32-unknown-unknown/release/fluxora_stream.wasm`.

### Test

```bash
cargo test -p fluxora_stream
```

This runs both:
- Unit tests in `contracts/stream/src/test.rs`
- Integration tests in `contracts/stream/tests/integration_suite.rs`

The integration suite invokes the contract with Soroban `testutils` and covers:
- `init`
- `create_stream`
- `withdraw`
- `get_stream_state`
- A full stream lifecycle from create to completed withdrawal
- Key edge cases (`init` twice, pre-cliff withdrawal, unknown stream id, underfunded deposit)

### Deploy (after Stellar CLI setup)

```bash
stellar contract deploy \
  --wasm-file target/wasm32-unknown-unknown/release/fluxora_stream.wasm \
  --network testnet
```

Then invoke `init` with token and admin addresses, and use `create_stream`, `withdraw`, etc. as needed.

## Project structure

```
fluxora-contracts/
  Cargo.toml              # workspace
  contracts/
    stream/
      Cargo.toml
      src/
        lib.rs            # contract types and impl
        test.rs           # unit tests
      tests/
        integration_suite.rs  # integration tests (Soroban testutils)
```

## Accrual formula (reference)

- **Accrued** = `min((current_time - start_time) * rate_per_second, deposit_amount)`
- **Withdrawable** = `Accrued - withdrawn_amount`
- Before `cliff_time`: withdrawable = 0.

## Related repos

- **fluxora-backend** — API and Horizon sync
- **fluxora-frontend** — Dashboard and recipient UI

Each is a separate Git repository.
