### PR TITLE
test: calculate_accrued after cliff and before end_time (#46)

### DIFF
--- a/contracts/stream/src/test.rs
+++ b/contracts/stream/src/test.rs
@@ -1277,6 +1277,37 @@ fn test_calculate_accrued_after_cliff() {
 }
 
 #[test]
+fn test_accrued_after_cliff_before_end() {
+    let ctx = TestContext::setup();
+    ctx.env.ledger().set_timestamp(0);
+
+    let stream_id = ctx.client().create_stream(
+        &ctx.sender,
+        &ctx.recipient,
+        &10000_i128,
+        &10_i128,
+        &0u64,
+        &500u64,
+        &1000u64,
+    );
+
+    ctx.env.ledger().set_timestamp(500);
+    assert_eq!(ctx.client().calculate_accrued(&stream_id), 5000);
+
+    ctx.env.ledger().set_timestamp(750);
+    assert_eq!(ctx.client().calculate_accrued(&stream_id), 7500);
+
+    ctx.env.ledger().set_timestamp(999);
+    assert_eq!(ctx.client().calculate_accrued(&stream_id), 9990);
+
+    ctx.env.ledger().set_timestamp(1000);
+    assert_eq!(ctx.client().calculate_accrued(&stream_id), 10000);
+
+    ctx.env.ledger().set_timestamp(1500);
+    assert_eq!(ctx.client().calculate_accrued(&stream_id), 10000);
+}
+
+#[test]
 fn test_calculate_accrued_max_values() {
     let ctx = TestContext::setup();
     ctx.sac.mint(&ctx.sender, &(i128::MAX - 10_000_i128));


### PR DESCRIPTION
### Description
Implemented unit tests to verify the accrual formula during the interval between `cliff_time` and `end_time`.

### Key Validations
- **At Cliff (t=500)**: Confirmed retrospective accrual from `start_time`.
- **Linear Growth**: Verified constant rate (10 tokens/sec) at t=750 and t=999.
- **Capping Logic**: Confirmed accrual is strictly capped at `deposit_amount` (10,000) at and beyond `end_time`.

### Results
- ✅ Test `test_accrued_after_cliff_before_end` passed successfully.
<img width="1384" height="1069" alt="fluxoxy1" src="https://github.com/user-attachments/assets/7fa4280c-ce28-4db0-b115-649843940c99" />

- ✅ 200/200 total tests passed (zero regressions).

<img width="1561" height="1071" alt="Fluxoxy" src="https://github.com/user-attachments/assets/93a8ddd1-7854-403b-ba8d-082ae10c2d6c" />

- ✅ JSON snapshot generated for state consistency.

closes #46 
