### PR TITLE
feat: Unit tests for initialization and storage (#43)

### DIFF
--- a/contracts/stream/src/test.rs
+++ b/contracts/stream/src/test.rs
@@ -173,6 +173,47 @@ impl<'a> TestContext<'a> {
 // ---------------------------------------------------------------------------
 
 #[test]
+fn test_init_stores_token_and_admin() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, FluxoraStream);
+    let client = FluxoraStreamClient::new(&env, &contract_id);
+
+    let token = Address::generate(&env);
+    let admin = Address::generate(&env);
+
+    client.init(&token, &admin);
+
+    let config = client.get_config();
+    assert_eq!(config.token, token);
+    assert_eq!(config.admin, admin);
+}
+
+#[test]
+#[should_panic(expected = "already initialised")]
+fn test_init_second_call_fails() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, FluxoraStream);
+    let client = FluxoraStreamClient::new(&env, &contract_id);
+
+    let token = Address::generate(&env);
+    let admin = Address::generate(&env);
+
+    client.init(&token, &admin);
+
+    client.init(&Address::generate(&env), &Address::generate(&env));
+}
+
+#[test]
+#[should_panic(expected = "contract not initialised: missing config")]
+fn test_get_config_before_init_fails() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, FluxoraStream);
+    let client = FluxoraStreamClient::new(&env, &contract_id);
+
+    client.get_config();
+}
+
+#[test]
 fn test_init_stores_config() {
     let env = Env::default();
     env.mock_all_auths();


### PR DESCRIPTION
### Description
Implemented a suite of unit tests to verify the `init` function's behavior regarding token/admin storage, re-initialization security, and initial state access.

### Key Validations
* **Storage Integrity**: Verified that `token` and `admin` addresses are correctly persisted in `DataKey::Config` and retrievable via `get_config()`.
* **Re-initialization Guard**: Confirmed that the contract panics with `"already initialised"` if `init` is called a second time, ensuring immutability.
* **Pre-init State**: Validated that calls to `get_config()` before initialization fail with the expected error message.

### Technical Implementation
* **Minimalist Approach**: Tests follow the existing repository's aesthetic, avoiding unnecessary boilerplate like `mock_all_auths()` for public or setup-only functions.
* **Address Isolation**: Used `Address::generate(&env)` to ensure unique identities for testing distinct administrative roles.

### Results
- ✅ `test_init_stores_token_and_admin`: **PASS**
- ✅ `test_init_second_call_fails`: **PASS** (Panic verified)
- ✅ `test_get_config_before_init_fails`: **PASS** (Panic verified)
- ✅ **Total Regression**: 202/202 tests passed successfully.

---
###  Evidence
<img width="1378" height="1080" alt="test2y3" src="https://github.com/user-attachments/assets/9fb211fc-eee9-4655-9ea0-bd77cf52b160" />

closes #43 
