### PR TITLE
chore: add testutils feature and document test setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,13 +40,18 @@ WASM output is under `target/wasm32-unknown-unknown/release/fluxora_stream.wasm`
 
 ### Test
 
+To run all tests (unit and integration tests), use:
+
 ```bash
 cargo test -p fluxora_stream
 ```
 
-This runs both:
-- Unit tests in `contracts/stream/src/test.rs`
-- Integration tests in `contracts/stream/tests/integration_suite.rs`
+**Note:** Tests rely on the `testutils` feature of the `soroban-sdk` to simulate the ledger environment and manipulate time (e.g., fast-forwarding to test cliff and end periods). 
+This feature is already enabled in `contracts/stream/Cargo.toml` under `[dev-dependencies]`. No extra environment setup is required.
+
+The test files are located at:
+- Unit tests: `contracts/stream/src/test.rs`
+- Integration tests: `contracts/stream/tests/integration_suite.rs`
 
 The integration suite invokes the contract with Soroban `testutils` and covers:
 - `init`

--- a/contracts/stream/Cargo.toml
+++ b/contracts/stream/Cargo.toml
@@ -14,4 +14,5 @@ testutils = ["soroban-sdk/testutils"]
 soroban-sdk = "21.7.7"
 
 [dev-dependencies]
+# Required for simulating ledger environment and testing time dependencies
 soroban-sdk = { version = "21.7.7", features = ["testutils"] }


### PR DESCRIPTION
# chore: add testutils feature and document test setup

Closes #64

---

## Summary

This PR addresses issue #64 by documenting the `testutils` feature and test setup instructions in the `README.md`.

*Note: The `testutils` feature was already present in `contracts/stream/Cargo.toml` from a previous PR, but was undocumented. To satisfy the PR requirements and clarify intent for reviewers, an explicit comment was added above the `dev-dependencies` section in `Cargo.toml`, and the testing instructions in the README were updated.*

---

## What was implemented

### Documentation Updates (`README.md`)
- Added clear instructions on how to run tests: `cargo test -p fluxora_stream`
- Explained that `soroban-sdk`'s `testutils` feature is already enabled and used for ledger environment simulation and time manipulation
- Explicitly documented the exact file paths for both unit tests (`src/test.rs`) and integration tests (`tests/integration_suite.rs`)

### Cargo Setup (`contracts/stream/Cargo.toml`)
- Added an inline comment documenting the purpose of the `testutils` feature to ensure clarity for future developers.

---

## Tests

Tests were executed successfully:
- **199 unit tests** passed in `contracts/stream/src/test.rs`
- **23 integration tests** passed in `contracts/stream/tests/integration_suite.rs`
- Coverage includes `create_stream`, `withdraw`, `cancel_stream`, `pause_stream`, `resume_stream`, `get_stream_state`, and `calculate_accrued`, testing edge cases and time manipulations seamlessly using the `testutils` mock ledger.

```
test test::test_stream_ids_are_unique_no_gaps ... ok
test test::test_create_stream_multiple_loop ... ok
test result: ok. 199 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 5.61s

test integration_stream_ids_are_unique_and_sequential ... ok
test result: ok. 23 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.68s
```

---

## Checklist

- [x] Verified `testutils` feature is present in `contracts/stream/Cargo.toml`
- [x] Updated README with how to run tests
- [x] Documented integration vs unit test locations in README
- [x] Ran all tests locally
- [x] Test output included in PR description