### PR TITLE
feat: document no-cap policy for deposit and duration in create_stream (#123)

### DIFF
--- a/contracts/stream/src/lib.rs
+++ b/contracts/stream/src/lib.rs
@@ -197,6 +197,19 @@ impl FluxoraStream {
     /// - Setting `cliff_time = start_time` means no cliff (immediate vesting)
     /// - Deposit can exceed minimum required (excess remains in contract)
     /// - Sender must have sufficient token balance and approve contract
+    /// ## Stream Limits Policy
+    /// No hard upper bounds are enforced on `deposit_amount` or stream duration.
+    /// Rationale:
+    /// - Overflow in accrual math is already prevented via `checked_mul` and clamping.
+    /// - A fixed cap would require a contract upgrade to change and conflicts with
+    ///   the overflow test suite, which exercises values up to `i128::MAX`.
+    /// - Protocol-specific limits (e.g. "max 10 M USDC per stream") belong at the
+    ///   application layer (UI or an admin-gated factory contract), where business
+    ///   context is available.
+    ///
+    /// Senders are responsible for the correctness of the values they supply.
+    /// The validations above (`deposit > 0`, `rate > 0`, `deposit >= rate × duration`,
+    /// valid time window) are the contract's complete set of creation constraints.
     ///
     /// # Examples
     /// - Linear stream: 1000 tokens over 1000 seconds, no cliff


### PR DESCRIPTION
Closes #123

## Decision
After reviewing the codebase, the decision is to not add hard upper bounds
on `deposit_amount` or stream duration at the contract level.

## Reasoning
- Overflow is already prevented: `calculate_accrued_amount` uses `checked_mul`
  and clamps the result to `[0, deposit_amount]` — no code path produces an
  incorrect payout regardless of input magnitude.
- Any meaningful cap would conflict with the existing overflow test suite,
  which intentionally creates streams with deposits up to `i128::MAX - 1` to
  verify the math is safe at extremes. Introducing a cap would silently
  invalidate those tests without making the contract more correct.
- The existing `deposit_amount >= rate × duration` validation already rejects
  the most common accidental mis-configuration (rate too high, deposit too low).
- Hard-coded caps belong at the application layer (UI or admin-gated factory),
  where business context (token decimals, protocol limits) is available and
  can be updated without a contract upgrade.

## Changes
- Added "Stream Limits Policy" section to the `create_stream` doc comment
  explicitly stating the no-cap decision and its rationale.
- Added `test_create_stream_large_deposit_accepted` — verifies streams with
  10^18-token deposits are accepted (policy enforcement test).
- Added `test_create_stream_long_duration_accepted` — verifies 100-year
  duration streams are accepted (policy enforcement test).
