### PR TITLE
feat: add get_withdrawable view function for stream balance

### DIFF
--- a/contracts/stream/src/test.rs
+++ b/contracts/stream/src/test.rs
@@ -7066,3 +7066,118 @@ fn test_create_stream_past_start_no_token_transfer() {
         "sender balance must not change on validation failure"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Tests — get_withdrawable
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_get_withdrawable_stream_not_found() {
+    let ctx = TestContext::setup();
+    let result = ctx.client().try_get_withdrawable(&999);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_get_withdrawable_before_cliff() {
+    let ctx = TestContext::setup();
+    let stream_id = ctx.create_cliff_stream(); // cliff at t=500
+
+    // Check before cliff
+    ctx.env.ledger().set_timestamp(100);
+    let withdrawable = ctx.client().get_withdrawable(&stream_id);
+
+    assert_eq!(withdrawable, 0, "withdrawable should be 0 before cliff");
+}
+
+#[test]
+fn test_get_withdrawable_after_cliff() {
+    let ctx = TestContext::setup();
+    let stream_id = ctx.create_cliff_stream(); // cliff at t=500, rate=1
+
+    // Check after cliff
+    ctx.env.ledger().set_timestamp(600);
+    let withdrawable = ctx.client().get_withdrawable(&stream_id);
+
+    assert_eq!(
+        withdrawable, 600,
+        "withdrawable should equal full accrual after cliff"
+    );
+}
+
+#[test]
+fn test_get_withdrawable_after_partial_withdraw() {
+    let ctx = TestContext::setup();
+    let stream_id = ctx.create_default_stream();
+
+    // Withdraw at t=300
+    ctx.env.ledger().set_timestamp(300);
+    ctx.client().withdraw(&stream_id);
+
+    // Advance time to t=800 and check withdrawable
+    ctx.env.ledger().set_timestamp(800);
+    let withdrawable = ctx.client().get_withdrawable(&stream_id);
+
+    // Accrued (800) - Withdrawn (300) = 500
+    assert_eq!(
+        withdrawable, 500,
+        "withdrawable should subtract already withdrawn amount"
+    );
+}
+
+#[test]
+fn test_get_withdrawable_paused_stream_returns_zero() {
+    let ctx = TestContext::setup();
+    let stream_id = ctx.create_default_stream();
+
+    ctx.env.ledger().set_timestamp(500);
+
+    // Pause the stream
+    ctx.client().pause_stream(&stream_id);
+
+    // Even though 500 is accrued, pause blocks withdrawals
+    let withdrawable = ctx.client().get_withdrawable(&stream_id);
+    assert_eq!(
+        withdrawable, 0,
+        "withdrawable must be 0 when stream is Paused"
+    );
+}
+
+#[test]
+fn test_get_withdrawable_completed_stream_returns_zero() {
+    let ctx = TestContext::setup();
+    let stream_id = ctx.create_default_stream();
+
+    // Fully withdraw to mark stream as Completed
+    ctx.env.ledger().set_timestamp(1000);
+    ctx.client().withdraw(&stream_id);
+
+    let state = ctx.client().get_stream_state(&stream_id);
+    assert_eq!(state.status, StreamStatus::Completed);
+
+    let withdrawable = ctx.client().get_withdrawable(&stream_id);
+    assert_eq!(
+        withdrawable, 0,
+        "withdrawable must be 0 when stream is Completed"
+    );
+}
+
+#[test]
+fn test_get_withdrawable_cancelled_stream_returns_accrued() {
+    let ctx = TestContext::setup();
+    let stream_id = ctx.create_default_stream();
+
+    // Cancel stream midway
+    ctx.env.ledger().set_timestamp(400);
+    ctx.client().cancel_stream(&stream_id);
+
+    let state = ctx.client().get_stream_state(&stream_id);
+    assert_eq!(state.status, StreamStatus::Cancelled);
+
+    // The recipient should still be able to see and withdraw the accrued amount prior to cancellation
+    let withdrawable = ctx.client().get_withdrawable(&stream_id);
+    assert_eq!(
+        withdrawable, 400,
+        "withdrawable must equal frozen accrued amount on Cancelled stream"
+    );
+}


### PR DESCRIPTION
# Add `get_withdrawable` view function for UI integration

Closes #107

## Description
This PR introduces a new public, read-only function `get_withdrawable(env, stream_id)` to the `FluxoraStream` contract. This allows integrators and frontends to safely query the exact amount of tokens currently available for a recipient to withdraw, without needing to invoke the state-changing `withdraw()` function or manually reconstruct the accrual math client-side.

## Implementation Details
* **Accrual Integration:** Leverages the existing `calculate_accrued` helper and simply subtracts `stream.withdrawn_amount`.
* **State Safety:** Strictly a view function; it modifies no state and initiates no token transfers.
* **Status Handling:** * Returns `0` if the stream is in a `Paused` or `Completed` state, mirroring the strict availability rules enforced by the actual `withdraw()` function.
  * Returns `0` if queried before the `cliff_time` has been reached.
  * Returns `ContractError::StreamNotFound` for invalid or non-existent stream IDs.

## Testing & Verification
Added a dedicated test suite (`get_withdrawable_tests`) to `src/test.rs` covering all core behaviors and edge cases:
- [x] Rejects missing/invalid stream IDs with the correct error.
- [x] Returns `0` before the cliff time.
- [x] Accurately calculates the positive withdrawable amount after the cliff time and accounts for partial withdrawals.
- [x] correctly returns `0` when the stream is actively `Paused`.
- [x] correctly returns `0` when the stream is `Completed` (fully withdrawn).

<img width="926" height="877" alt="test4" src="https://github.com/user-attachments/assets/07e7dbf3-7ebf-4079-90a4-59523de4e39c" />
