### PR TITLE
feat: add create_stream_relative helper entrypoint for safer scheduling

### DIFF
--- a/contracts/stream/src/lib.rs
+++ b/contracts/stream/src/lib.rs
@@ -269,6 +269,33 @@ pub struct CreateStreamParams {
     pub end_time: u64,
 }
 
+/// Parameters for creating a payment stream with relative (offset-based) times.
+///
+/// Computes `start_time`, `cliff_time`, and `end_time` by adding offsets to the
+/// current ledger timestamp (`env.ledger().timestamp()`). This eliminates off-chain
+/// calculation errors that lead to `StartTimeInPast` failures.
+///
+/// # Time offsets
+/// - `start_delay`: Seconds to add to current timestamp for stream start
+/// - `cliff_delay`: Seconds to add to current timestamp for cliff time (must be >= start_delay)
+/// - `duration`: Total duration of stream in seconds (end_time = start_time + duration)
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CreateStreamRelativeParams {
+    /// Address that will receive streamed tokens for this stream entry.
+    pub recipient: Address,
+    /// Total amount escrowed for this stream entry.
+    pub deposit_amount: i128,
+    /// Streaming speed in tokens per second for this stream entry.
+    pub rate_per_second: i128,
+    /// Delay (in seconds) before stream accrual starts, relative to current timestamp.
+    pub start_delay: u64,
+    /// Delay (in seconds) before withdrawals are allowed, relative to current timestamp.
+    pub cliff_delay: u64,
+    /// Total duration the stream runs (in seconds) from start_time to end_time.
+    pub duration: u64,
+}
+
 /// Namespace for all contract storage keys.
 ///
 /// # Evolution policy
@@ -857,6 +884,105 @@ impl FluxoraStream {
         ))
     }
 
+    /// Create a new payment stream with relative (offset-based) timing.
+    ///
+    /// Computes absolute timestamps by adding delays to the current ledger timestamp,
+    /// eliminating off-chain calculation errors that cause `StartTimeInPast` failures.
+    /// Internally delegates to `create_stream` with computed absolute times.
+    ///
+    /// # Parameters
+    /// - `sender`: Address funding and authorizing the stream
+    /// - `recipient`: Address receiving streamed tokens
+    /// - `deposit_amount`: Total amount escrowed for the stream
+    /// - `rate_per_second`: Streaming speed in tokens per second
+    /// - `start_delay`: Seconds until stream starts (relative to current timestamp)
+    /// - `cliff_delay`: Seconds until cliff time (relative to current timestamp)
+    /// - `duration`: Total duration stream runs (in seconds)
+    ///
+    /// # Computation
+    /// Uses `current_time = env.ledger().timestamp()`:
+    /// - `start_time = current_time + start_delay`
+    /// - `cliff_time = current_time + cliff_delay`
+    /// - `end_time = start_time + duration`
+    ///
+    /// # Returns
+    /// - `u64`: Unique stream ID
+    ///
+    /// # Authorization
+    /// - Requires authorization from `sender`
+    ///
+    /// # Success Semantics
+    /// - All validation invariants from `create_stream` are preserved
+    /// - Batch `create_streams_relative` can use this via parameter conversion
+    /// - Contract paused state is checked (blocks creation if paused)
+    ///
+    /// # Failure Semantics
+    /// - `StartTimeInPast`: Never occurs (times are always relative to current)
+    /// - `InvalidParams`: If delays/duration cause arithmetic overflow or invalid constraints
+    /// - `ContractPaused`: If creation is globally paused
+    /// - Other errors inherited from `create_stream` validation
+    ///
+    /// # Errors
+    /// Delegates to `create_stream`; see its documentation for full error list.
+    ///
+    /// # Panics
+    /// - If `start_delay + current_time` overflows `u64` (arithmetic overflow)
+    /// - If token transfer fails
+    ///
+    /// # Security Notes
+    /// - Relative timing removes the need for precise off-chain clock synchronization
+    /// - All deposit and rate validation proceeds as-is; relative delays do not bypass checks
+    /// - Self-streaming (`sender == recipient`) is still rejected by `create_stream`
+    ///
+    /// # Example
+    /// ```
+    /// // Create a stream starting in 2 days, cliff in 5 days, running for 30 days
+    /// let stream_id = contract.create_stream_relative(
+    ///     &sender,
+    ///     &recipient,
+    ///     &100_000_000,        // 100M tokens
+    ///     &1_157_407,           // ~1% per day at 86400s/day
+    ///     &(2 * 86400),         // 2 days delay
+    ///     &(5 * 86400),         // 5 days cliff
+    ///     &(30 * 86400),        // 30 days duration
+    /// )?;
+    /// ```
+    pub fn create_stream_relative(
+        env: Env,
+        sender: Address,
+        recipient: Address,
+        deposit_amount: i128,
+        rate_per_second: i128,
+        start_delay: u64,
+        cliff_delay: u64,
+        duration: u64,
+    ) -> Result<u64, ContractError> {
+        let current_time = env.ledger().timestamp();
+
+        // Compute absolute times with overflow checks
+        let start_time = current_time
+            .checked_add(start_delay)
+            .ok_or(ContractError::InvalidParams)?;
+        let cliff_time = current_time
+            .checked_add(cliff_delay)
+            .ok_or(ContractError::InvalidParams)?;
+        let end_time = start_time
+            .checked_add(duration)
+            .ok_or(ContractError::InvalidParams)?;
+
+        // Delegate to standard create_stream with computed absolute times
+        Self::create_stream(
+            env,
+            sender,
+            recipient,
+            deposit_amount,
+            rate_per_second,
+            start_time,
+            cliff_time,
+            end_time,
+        )
+    }
+
     /// Create multiple payment streams in a single transaction.
     ///
     /// Optimizes gas usage by authorizing once and doing a single bulk token transfer
@@ -1038,6 +1164,109 @@ impl FluxoraStream {
         }
 
         Ok(created_ids)
+    }
+
+    /// Create multiple payment streams with relative (offset-based) timing.
+    ///
+    /// Batch version of `create_stream_relative` that converts relative time offsets
+    /// to absolute timestamps and delegates to `create_streams`. Provides the same
+    /// atomicity and gas efficiency as `create_streams` while eliminating off-chain
+    /// timestamp calculation errors.
+    ///
+    /// # Parameters
+    /// - `sender`: Address funding all streams in the batch
+    /// - `streams_relative`: Vector of `CreateStreamRelativeParams` with relative time offsets
+    ///
+    /// # Returns
+    /// - `Vec<u64>`: Stream IDs in the same order as `streams_relative` input entries
+    ///
+    /// # Authorization
+    /// - Requires authorization from `sender` exactly once for the entire batch
+    ///
+    /// # Time Computation
+    /// Uses `current_time = env.ledger().timestamp()`:
+    /// For each entry:
+    /// - `start_time = current_time + start_delay`
+    /// - `cliff_time = current_time + cliff_delay`
+    /// - `end_time = start_time + duration`
+    ///
+    /// # Success Semantics
+    /// - Empty batch returns `Ok(Vec::new())` without side effects
+    /// - All validation invariants from `create_streams` are preserved
+    /// - Relative timing eliminates `StartTimeInPast` errors
+    /// - Single token transfer for all streams (atomic)
+    ///
+    /// # Failure Semantics
+    /// - Any entry's time offset causes arithmetic overflow → `InvalidParams`
+    /// - Any validation failure → entire batch fails atomically
+    /// - Any token transfer failure → no state change
+    /// - No events emitted on failure
+    ///
+    /// # Security Notes
+    /// - Relative timing removes need for off-chain clock synchronization
+    /// - All deposit, rate, and deposit-coverage validation proceeds as-is
+    /// - Self-streaming still rejected per entry
+    ///
+    /// # Example
+    /// ```ignore
+    /// let params = vec![
+    ///     CreateStreamRelativeParams {
+    ///         recipient: alice,
+    ///         deposit_amount: 1000,
+    ///         rate_per_second: 1,
+    ///         start_delay: 86400,      // 1 day
+    ///         cliff_delay: 259200,     // 3 days
+    ///         duration: 2592000,       // 30 days
+    ///     },
+    ///     CreateStreamRelativeParams {
+    ///         recipient: bob,
+    ///         deposit_amount: 2000,
+    ///         rate_per_second: 2,
+    ///         start_delay: 0,          // Immediate
+    ///         cliff_delay: 0,          // Immediate
+    ///         duration: 2592000,       // 30 days
+    ///     },
+    /// ];
+    /// let ids = contract.create_streams_relative(&sender, &params)?;
+    /// // ids = [0, 1] (assuming first batch)
+    /// ```
+    pub fn create_streams_relative(
+        env: Env,
+        sender: Address,
+        streams_relative: soroban_sdk::Vec<CreateStreamRelativeParams>,
+    ) -> Result<soroban_sdk::Vec<u64>, ContractError> {
+        if streams_relative.is_empty() {
+            return Ok(soroban_sdk::Vec::new(&env));
+        }
+
+        let current_time = env.ledger().timestamp();
+        let mut absolute_streams = soroban_sdk::Vec::new(&env);
+
+        // Convert relative parameters to absolute times
+        for rel_params in streams_relative.iter() {
+            let start_time = current_time
+                .checked_add(rel_params.start_delay)
+                .ok_or(ContractError::InvalidParams)?;
+            let cliff_time = current_time
+                .checked_add(rel_params.cliff_delay)
+                .ok_or(ContractError::InvalidParams)?;
+            let end_time = start_time
+                .checked_add(rel_params.duration)
+                .ok_or(ContractError::InvalidParams)?;
+
+            let absolute_params = CreateStreamParams {
+                recipient: rel_params.recipient,
+                deposit_amount: rel_params.deposit_amount,
+                rate_per_second: rel_params.rate_per_second,
+                start_time,
+                cliff_time,
+                end_time,
+            };
+            absolute_streams.push_back(absolute_params);
+        }
+
+        // Delegate to standard create_streams with converted absolute times
+        Self::create_streams(env, sender, absolute_streams)
     }
 
     /// Pause an active payment stream.

--- a/contracts/stream/tests/create_stream_relative.rs
+++ b/contracts/stream/tests/create_stream_relative.rs
@@ -1,0 +1,562 @@
+extern crate std;
+
+use fluxora_stream::{
+    ContractError, CreateStreamRelativeParams, FluxoraStream, FluxoraStreamClient, StreamStatus,
+};
+use soroban_sdk::{
+    testutils::{Address as _, Ledger},
+    token::{Client as TokenClient, StellarAssetClient},
+    vec, Address, Env,
+};
+
+struct TestContext<'a> {
+    env: Env,
+    contract_id: Address,
+    token_id: Address,
+    admin: Address,
+    sender: Address,
+    recipient: Address,
+    token: TokenClient<'a>,
+}
+
+impl<'a> TestContext<'a> {
+    fn setup() -> Self {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register_contract(None, FluxoraStream);
+
+        let token_admin = Address::generate(&env);
+        let token_id = env
+            .register_stellar_asset_contract_v2(token_admin)
+            .address();
+
+        let admin = Address::generate(&env);
+        let sender = Address::generate(&env);
+        let recipient = Address::generate(&env);
+
+        let client = FluxoraStreamClient::new(&env, &contract_id);
+        client.init(&token_id, &admin);
+
+        let sac = StellarAssetClient::new(&env, &token_id);
+        sac.mint(&sender, &10_000_i128);
+
+        let token = TokenClient::new(&env, &token_id);
+
+        Self {
+            env,
+            contract_id,
+            token_id,
+            admin,
+            sender,
+            recipient,
+            token,
+        }
+    }
+
+    fn client(&self) -> FluxoraStreamClient<'_> {
+        FluxoraStreamClient::new(&self.env, &self.contract_id)
+    }
+}
+
+// ============================================================================
+// Tests: create_stream_relative
+// ============================================================================
+
+/// Test that create_stream_relative with zero delays creates an immediate stream.
+/// This is the simplest case: start_delay=0, cliff_delay=0, duration=X.
+#[test]
+fn create_stream_relative_zero_delays_immediate_start() {
+    let ctx = TestContext::setup();
+    ctx.env.ledger().set_timestamp(1000);
+
+    let stream_id = ctx.client().create_stream_relative(
+        &ctx.sender,
+        &ctx.recipient,
+        &1000_i128,
+        &1_i128,
+        &0u64,  // start_delay: 0 -> start_time = 1000
+        &0u64,  // cliff_delay: 0 -> cliff_time = 1000
+        &1000u64, // duration: 1000 -> end_time = 1000 + 1000 = 2000
+    );
+
+    let state = ctx.client().get_stream_state(&stream_id);
+    assert_eq!(state.stream_id, 0);
+    assert_eq!(state.start_time, 1000);
+    assert_eq!(state.cliff_time, 1000);
+    assert_eq!(state.end_time, 2000);
+    assert_eq!(state.status, StreamStatus::Active);
+    assert_eq!(ctx.token.balance(&ctx.sender), 9_000);
+    assert_eq!(ctx.token.balance(&ctx.contract_id), 1_000);
+}
+
+/// Test that create_stream_relative with positive delays correctly offsets times.
+#[test]
+fn create_stream_relative_positive_delays_future_start() {
+    let ctx = TestContext::setup();
+    ctx.env.ledger().set_timestamp(1000);
+
+    let stream_id = ctx.client().create_stream_relative(
+        &ctx.sender,
+        &ctx.recipient,
+        &2000_i128,
+        &2_i128,
+        &100u64,  // start_delay: 100 -> start_time = 1100
+        &500u64,  // cliff_delay: 500 -> cliff_time = 1500
+        &2000u64, // duration: 2000 -> end_time = 1100 + 2000 = 3100
+    );
+
+    let state = ctx.client().get_stream_state(&stream_id);
+    assert_eq!(state.start_time, 1100);
+    assert_eq!(state.cliff_time, 1500);
+    assert_eq!(state.end_time, 3100);
+}
+
+/// Test that create_stream_relative validates duration > 0.
+/// When start_delay = cliff_delay, the duration must still be positive.
+#[test]
+fn create_stream_relative_zero_duration_rejected() {
+    let ctx = TestContext::setup();
+    ctx.env.ledger().set_timestamp(1000);
+
+    let result = ctx.client().try_create_stream_relative(
+        &ctx.sender,
+        &ctx.recipient,
+        &1000_i128,
+        &1_i128,
+        &100u64,  // start_delay
+        &100u64,  // cliff_delay
+        &0u64,    // duration: 0 -> INVALID (start_time == end_time)
+    );
+
+    // Should fail because end_time would equal start_time
+    assert_eq!(result, Err(Ok(ContractError::InvalidParams)));
+}
+
+/// Test cliff bounds: cliff_delay must correspond to cliff_time in range [start_time, end_time).
+#[test]
+fn create_stream_relative_cliff_less_than_start_rejected() {
+    let ctx = TestContext::setup();
+    ctx.env.ledger().set_timestamp(1000);
+
+    let result = ctx.client().try_create_stream_relative(
+        &ctx.sender,
+        &ctx.recipient,
+        &1000_i128,
+        &1_i128,
+        &500u64,  // start_delay -> start_time = 1500
+        &100u64,  // cliff_delay -> cliff_time = 1100 (< start_time)
+        &1000u64, // duration
+    );
+
+    assert_eq!(result, Err(Ok(ContractError::InvalidParams)));
+}
+
+/// Test cliff bounds: cliff_delay must correspond to cliff_time in range [start_time, end_time].
+#[test]
+fn create_stream_relative_cliff_greater_than_end_rejected() {
+    let ctx = TestContext::setup();
+    ctx.env.ledger().set_timestamp(1000);
+
+    // start_time = 1100, end_time = 2100
+    // cliff_time = 3000 (> end_time) -> INVALID
+    let result = ctx.client().try_create_stream_relative(
+        &ctx.sender,
+        &ctx.recipient,
+        &1000_i128,
+        &1_i128,
+        &100u64,   // start_delay -> start_time = 1100
+        &2000u64,  // cliff_delay -> cliff_time = 3000 (> end_time = 2100)
+        &1000u64,  // duration -> end_time = 2100
+    );
+
+    assert_eq!(result, Err(Ok(ContractError::InvalidParams)));
+}
+
+/// Test underflow prevention: start_delay overflow check.
+/// Adding delay to current_time should not cause u64 overflow.
+#[test]
+fn create_stream_relative_start_delay_overflow_rejected() {
+    let ctx = TestContext::setup();
+    ctx.env.ledger().set_timestamp(u64::MAX - 100);
+
+    let result = ctx.client().try_create_stream_relative(
+        &ctx.sender,
+        &ctx.recipient,
+        &1000_i128,
+        &1_i128,
+        &u64::MAX, // start_delay overflow -> INVALID
+        &0u64,
+        &1000u64,
+    );
+
+    assert_eq!(result, Err(Ok(ContractError::InvalidParams)));
+}
+
+/// Test underflow prevention: duration overflow check.
+/// Adding duration to start_time should not cause u64 overflow.
+#[test]
+fn create_stream_relative_duration_overflow_rejected() {
+    let ctx = TestContext::setup();
+    ctx.env.ledger().set_timestamp(1000);
+
+    let result = ctx.client().try_create_stream_relative(
+        &ctx.sender,
+        &ctx.recipient,
+        &1000_i128,
+        &1_i128,
+        &(u64::MAX - 500), // start_delay -> start_time near u64::MAX
+        &0u64,
+        &1000u64, // duration overflow -> INVALID
+    );
+
+    assert_eq!(result, Err(Ok(ContractError::InvalidParams)));
+}
+
+/// Test that create_stream_relative never produces StartTimeInPast errors.
+/// Even with current_time at ledger timestamp, all computed times are >= current_time.
+#[test]
+fn create_stream_relative_never_start_time_in_past() {
+    let ctx = TestContext::setup();
+    ctx.env.ledger().set_timestamp(5000);
+
+    // Even with zero delays, start_time = current_time (not past)
+    let stream_id = ctx.client().create_stream_relative(
+        &ctx.sender,
+        &ctx.recipient,
+        &1000_i128,
+        &1_i128,
+        &0u64,
+        &0u64,
+        &1000u64,
+    );
+
+    let state = ctx.client().get_stream_state(&stream_id);
+    // start_time = 5000, which is == current_time (not < current_time)
+    assert_eq!(state.start_time, 5000);
+    assert!(state.start_time >= 5000, "start_time must be >= current_time");
+}
+
+/// Test that create_stream_relative preserves deposit validation.
+/// Deposit must cover the total streamable amount.
+#[test]
+fn create_stream_relative_insufficient_deposit_rejected() {
+    let ctx = TestContext::setup();
+    ctx.env.ledger().set_timestamp(1000);
+
+    let result = ctx.client().try_create_stream_relative(
+        &ctx.sender,
+        &ctx.recipient,
+        &500_i128,        // deposit_amount: 500
+        &2_i128,          // rate_per_second: 2
+        &0u64,
+        &0u64,
+        &300u64,          // duration: 300 -> streamable = 2 * 300 = 600 > 500
+    );
+
+    assert_eq!(result, Err(Ok(ContractError::InsufficientDeposit)));
+}
+
+/// Test that create_stream_relative rejects self-streaming.
+#[test]
+fn create_stream_relative_rejects_self_stream() {
+    let ctx = TestContext::setup();
+    ctx.env.ledger().set_timestamp(1000);
+
+    let result = ctx.client().try_create_stream_relative(
+        &ctx.sender,
+        &ctx.sender, // invalid: sender == recipient
+        &1000_i128,
+        &1_i128,
+        &0u64,
+        &0u64,
+        &1000u64,
+    );
+
+    assert_eq!(result, Err(Ok(ContractError::InvalidParams)));
+}
+
+// ============================================================================
+// Tests: create_streams_relative (batch)
+// ============================================================================
+
+/// Test that create_streams_relative with a single entry creates a stream correctly.
+#[test]
+fn create_streams_relative_single_entry() {
+    let ctx = TestContext::setup();
+    ctx.env.ledger().set_timestamp(2000);
+
+    let params = vec![&ctx.env, CreateStreamRelativeParams {
+        recipient: ctx.recipient,
+        deposit_amount: 1000,
+        rate_per_second: 1,
+        start_delay: 100,
+        cliff_delay: 200,
+        duration: 1000,
+    }];
+
+    let ids = ctx.client().create_streams_relative(&ctx.sender, &params);
+    assert_eq!(ids.len(), 1);
+    assert_eq!(ids.get_unchecked(0), 0);
+
+    let state = ctx.client().get_stream_state(&0);
+    assert_eq!(state.start_time, 2100);    // 2000 + 100
+    assert_eq!(state.cliff_time, 2200);    // 2000 + 200
+    assert_eq!(state.end_time, 3100);      // 2100 + 1000
+}
+
+/// Test that create_streams_relative with multiple entries creates all streams atomically.
+#[test]
+fn create_streams_relative_multiple_entries_sequential_ids() {
+    let ctx = TestContext::setup();
+    ctx.env.ledger().set_timestamp(1000);
+
+    let recipient2 = Address::generate(&ctx.env);
+    let params = vec![
+        &ctx.env,
+        CreateStreamRelativeParams {
+            recipient: ctx.recipient,
+            deposit_amount: 1000,
+            rate_per_second: 1,
+            start_delay: 0,
+            cliff_delay: 0,
+            duration: 1000,
+        },
+        CreateStreamRelativeParams {
+            recipient: recipient2,
+            deposit_amount: 2000,
+            rate_per_second: 2,
+            start_delay: 100,
+            cliff_delay: 100,
+            duration: 2000,
+        },
+    ];
+
+    let ids = ctx.client().create_streams_relative(&ctx.sender, &params);
+    assert_eq!(ids.len(), 2);
+    assert_eq!(ids.get_unchecked(0), 0);
+    assert_eq!(ids.get_unchecked(1), 1);
+
+    let state0 = ctx.client().get_stream_state(&0);
+    assert_eq!(state0.recipient, ctx.recipient);
+    assert_eq!(state0.start_time, 1000);
+
+    let state1 = ctx.client().get_stream_state(&1);
+    assert_eq!(state1.recipient, recipient2);
+    assert_eq!(state1.start_time, 1100);
+}
+
+/// Test that create_streams_relative with an empty vector succeeds without side effects.
+#[test]
+fn create_streams_relative_empty_batch_succeeds() {
+    let ctx = TestContext::setup();
+    ctx.env.ledger().set_timestamp(1000);
+
+    let stream_count_before = ctx.client().get_stream_count();
+    let sender_balance_before = ctx.token.balance(&ctx.sender);
+    let contract_balance_before = ctx.token.balance(&ctx.contract_id);
+
+    let params: soroban_sdk::Vec<CreateStreamRelativeParams> = soroban_sdk::Vec::new(&ctx.env);
+    let ids = ctx.client().create_streams_relative(&ctx.sender, &params);
+
+    assert_eq!(ids.len(), 0);
+    assert_eq!(ctx.client().get_stream_count(), stream_count_before);
+    assert_eq!(ctx.token.balance(&ctx.sender), sender_balance_before);
+    assert_eq!(ctx.token.balance(&ctx.contract_id), contract_balance_before);
+}
+
+/// Test that create_streams_relative is atomic: if one entry is invalid, all streams fail.
+#[test]
+fn create_streams_relative_invalid_entry_fails_atomically() {
+    let ctx = TestContext::setup();
+    ctx.env.ledger().set_timestamp(1000);
+
+    let stream_count_before = ctx.client().get_stream_count();
+    let sender_balance_before = ctx.token.balance(&ctx.sender);
+
+    let recipient2 = Address::generate(&ctx.env);
+    let params = vec![
+        &ctx.env,
+        CreateStreamRelativeParams {
+            recipient: ctx.recipient,
+            deposit_amount: 1000,
+            rate_per_second: 1,
+            start_delay: 0,
+            cliff_delay: 0,
+            duration: 1000,
+        },
+        CreateStreamRelativeParams {
+            recipient: recipient2,
+            deposit_amount: 500,
+            rate_per_second: 2,
+            start_delay: 0,
+            cliff_delay: 0,
+            duration: 0, // INVALID: duration = 0
+        },
+    ];
+
+    let result = ctx.client().try_create_streams_relative(&ctx.sender, &params);
+    assert_eq!(result, Err(Ok(ContractError::InvalidParams)));
+
+    // Verify atomicity: no streams created, no tokens transferred
+    assert_eq!(ctx.client().get_stream_count(), stream_count_before);
+    assert_eq!(ctx.token.balance(&ctx.sender), sender_balance_before);
+}
+
+/// Test that create_streams_relative with all entries having unique recipients and times.
+#[test]
+fn create_streams_relative_diverse_schedules() {
+    let ctx = TestContext::setup();
+    ctx.env.ledger().set_timestamp(10000);
+
+    let r1 = Address::generate(&ctx.env);
+    let r2 = Address::generate(&ctx.env);
+    let r3 = Address::generate(&ctx.env);
+
+    let params = vec![
+        &ctx.env,
+        CreateStreamRelativeParams {
+            recipient: r1,
+            deposit_amount: 1000,
+            rate_per_second: 1,
+            start_delay: 0,
+            cliff_delay: 0,
+            duration: 1000,
+        },
+        CreateStreamRelativeParams {
+            recipient: r2,
+            deposit_amount: 2000,
+            rate_per_second: 2,
+            start_delay: 500,
+            cliff_delay: 1000,
+            duration: 2000,
+        },
+        CreateStreamRelativeParams {
+            recipient: r3,
+            deposit_amount: 3000,
+            rate_per_second: 3,
+            start_delay: 1000,
+            cliff_delay: 2000,
+            duration: 3000,
+        },
+    ];
+
+    let ids = ctx.client().create_streams_relative(&ctx.sender, &params);
+    assert_eq!(ids.len(), 3);
+
+    // Verify all three streams created with correct schedules
+    let s0 = ctx.client().get_stream_state(&ids.get_unchecked(0));
+    assert_eq!(s0.start_time, 10000);
+    assert_eq!(s0.end_time, 11000);
+
+    let s1 = ctx.client().get_stream_state(&ids.get_unchecked(1));
+    assert_eq!(s1.start_time, 10500);
+    assert_eq!(s1.cliff_time, 11000);
+    assert_eq!(s1.end_time, 12500);
+
+    let s2 = ctx.client().get_stream_state(&ids.get_unchecked(2));
+    assert_eq!(s2.start_time, 11000);
+    assert_eq!(s2.cliff_time, 12000);
+    assert_eq!(s2.end_time, 14000);
+
+    // Verify total deposit transferred
+    assert_eq!(ctx.token.balance(&ctx.sender), 4_000); // 10000 - 6000
+    assert_eq!(ctx.token.balance(&ctx.contract_id), 6_000);
+}
+
+/// Test that create_streams_relative correctly computes cliff times independently per entry.
+#[test]
+fn create_streams_relative_independent_cliff_times() {
+    let ctx = TestContext::setup();
+    ctx.env.ledger().set_timestamp(1000);
+
+    let r1 = Address::generate(&ctx.env);
+    let r2 = Address::generate(&ctx.env);
+
+    let params = vec![
+        &ctx.env,
+        CreateStreamRelativeParams {
+            recipient: r1,
+            deposit_amount: 1000,
+            rate_per_second: 1,
+            start_delay: 0,
+            cliff_delay: 0,  // cliff at current time
+            duration: 1000,
+        },
+        CreateStreamRelativeParams {
+            recipient: r2,
+            deposit_amount: 2000,
+            rate_per_second: 1,
+            start_delay: 500,
+            cliff_delay: 1500, // cliff 500 seconds after start
+            duration: 1000,
+        },
+    ];
+
+    let ids = ctx.client().create_streams_relative(&ctx.sender, &params);
+
+    let s0 = ctx.client().get_stream_state(&ids.get_unchecked(0));
+    assert_eq!(s0.start_time, 1000);
+    assert_eq!(s0.cliff_time, 1000);
+
+    let s1 = ctx.client().get_stream_state(&ids.get_unchecked(1));
+    assert_eq!(s1.start_time, 1500);
+    assert_eq!(s1.cliff_time, 2500);
+}
+
+/// Test that overflow in batch parameters is caught for each entry.
+#[test]
+fn create_streams_relative_batch_overflow_detection() {
+    let ctx = TestContext::setup();
+    ctx.env.ledger().set_timestamp(u64::MAX - 100);
+
+    let r1 = Address::generate(&ctx.env);
+
+    let params = vec![
+        &ctx.env,
+        CreateStreamRelativeParams {
+            recipient: r1,
+            deposit_amount: 1000,
+            rate_per_second: 1,
+            start_delay: u64::MAX, // overflow
+            cliff_delay: 0,
+            duration: 1000,
+        },
+    ];
+
+    let result = ctx.client().try_create_streams_relative(&ctx.sender, &params);
+    assert_eq!(result, Err(Ok(ContractError::InvalidParams)));
+}
+
+/// Test deposit and rate validation still applied in batch relative creation.
+#[test]
+fn create_streams_relative_batch_validates_amounts() {
+    let ctx = TestContext::setup();
+    ctx.env.ledger().set_timestamp(1000);
+
+    let r1 = Address::generate(&ctx.env);
+    let r2 = Address::generate(&ctx.env);
+
+    let params = vec![
+        &ctx.env,
+        CreateStreamRelativeParams {
+            recipient: r1,
+            deposit_amount: 1000,
+            rate_per_second: 1,
+            start_delay: 0,
+            cliff_delay: 0,
+            duration: 1000,
+        },
+        CreateStreamRelativeParams {
+            recipient: r2,
+            deposit_amount: -100, // Invalid: negative amount
+            rate_per_second: 1,
+            start_delay: 0,
+            cliff_delay: 0,
+            duration: 1000,
+        },
+    ];
+
+    let result = ctx.client().try_create_streams_relative(&ctx.sender, &params);
+    assert_eq!(result, Err(Ok(ContractError::InvalidParams)));
+}

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -337,6 +337,118 @@ On failure (`InvalidParams` or `InvalidState`):
 - Rationale: Accrual math (in `accrual.rs`) is already overflow-safe via `checked_mul` and clamping.
 - Application-specific limits should be handled in the frontend or factory contracts.
 
+### Relative-Time Helpers: `create_stream_relative` and `create_streams_relative`
+
+The contract provides convenience entry points that compute stream times relative to the current ledger timestamp, eliminating off-chain calculation errors that lead to `StartTimeInPast` failures.
+
+#### Motivation
+
+Off-chain applications often construct stream parameters ahead of time, e.g., "start 1 day from now". If there is clock drift between the application server and the Soroban ledger, the calculated `start_time` may already be in the past when the transaction is executed, causing `StartTimeInPast` rejection.
+
+Relative-time helpers avoid this by deferring timestamp computation to the contract itself, which always has the authoritative ledger timestamp.
+
+#### `create_stream_relative`
+
+**Signature:**
+```rust
+pub fn create_stream_relative(
+    env: Env,
+    sender: Address,
+    recipient: Address,
+    deposit_amount: i128,
+    rate_per_second: i128,
+    start_delay: u64,     // Seconds to add to current timestamp
+    cliff_delay: u64,     // Seconds to add to current timestamp
+    duration: u64,        // Total seconds from start_time to end_time
+) -> Result<u64, ContractError>
+```
+
+**Computation:**
+```
+current_time = env.ledger().timestamp()
+start_time   = current_time + start_delay
+cliff_time   = current_time + cliff_delay
+end_time     = start_time + duration
+```
+
+**Validation:**
+- Checks for overflow/underflow in all additions
+- Delegates to `create_stream` with computed absolute times
+- Inherits all validation rules: deposit sufficiency, cliff bounds, etc.
+- **Never produces `StartTimeInPast`** error (computed times are always >= current_time)
+
+**Example:**
+```
+// Create a stream starting in 1 day, cliff in 3 days, running for 30 days
+contract.create_stream_relative(
+    &sender,
+    &recipient,
+    &100_000_000,           // 100M tokens
+    &1_157_407,             // ~1% per day
+    &86400,                 // start_delay: 1 day
+    &259200,                // cliff_delay: 3 days
+    &2_592_000,             // duration: 30 days
+)?;
+```
+
+#### `create_streams_relative`
+
+**Signature:**
+```rust
+pub fn create_streams_relative(
+    env: Env,
+    sender: Address,
+    streams_relative: Vec<CreateStreamRelativeParams>,
+) -> Result<Vec<u64>, ContractError>
+```
+
+**Parameters (per entry):**
+```rust
+pub struct CreateStreamRelativeParams {
+    pub recipient: Address,
+    pub deposit_amount: i128,
+    pub rate_per_second: i128,
+    pub start_delay: u64,
+    pub cliff_delay: u64,
+    pub duration: u64,
+}
+```
+
+**Batch semantics:**
+- Empty batch returns `Ok(Vec::new())` with no side effects
+- All entries are converted to absolute times (overflow checks per entry)
+- Delegates to `create_streams` with converted parameters
+- Atomic: all or nothing (any validation failure aborts entire batch)
+- Single authorization and token transfer for all streams (gas efficient)
+
+**Example:**
+```
+let params = vec![
+    CreateStreamRelativeParams {
+        recipient: alice,
+        deposit_amount: 1000,
+        rate_per_second: 1,
+        start_delay: 0,           // Immediate
+        cliff_delay: 0,           // Immediate
+        duration: 86400,          // 1 day
+    },
+    CreateStreamRelativeParams {
+        recipient: bob,
+        deposit_amount: 2000,
+        rate_per_second: 2,
+        start_delay: 86400,       // 1 day delay
+        cliff_delay: 172800,      // 2 day cliff
+        duration: 2592000,        // 30 days
+    },
+];
+contract.create_streams_relative(&sender, &params)?;
+```
+
+**Error handling:**
+- `InvalidParams`: If any time offset causes u64 overflow, or if other validation fails (rate, deposit, cliff bounds, etc.)
+- `ContractPaused`: If creation is globally paused
+- All other errors: Same as `create_stream` / `create_streams`
+
 ---
 
 ## 4. Access Control
@@ -346,6 +458,8 @@ On failure (`InvalidParams` or `InvalidState`):
 | `init`                    | Bootstrap admin signer (once) | `admin.require_auth()`                      |
 | `create_stream`           | Sender                        | `sender.require_auth()`                     |
 | `create_streams`          | Sender                        | `sender.require_auth()` (once per batch)    |
+| `create_stream_relative`  | Sender                        | `sender.require_auth()`                     |
+| `create_streams_relative` | Sender                        | `sender.require_auth()` (once per batch)    |
 | `pause_stream`            | Sender                        | `sender.require_auth()`                     |
 | `resume_stream`           | Sender                        | `sender.require_auth()`                     |
 | `cancel_stream`           | Sender                        | `sender.require_auth()`                     |


### PR DESCRIPTION
i Add CreateStreamRelativeParams struct for relative time parameters
- Implement create_stream_relative for single stream with relative timing
- Implement create_streams_relative for batch creation with relative timing
- Add comprehensive test suite (16 tests) covering:
  * Zero delays and immediate start
  * Positive delays and future start
  * Duration validation
  * Cliff bounds validation
  * Overflow prevention on time computations
  * Batch atomicity and empty batch handling
  * All validation invariants preserved
- Update docs/streaming.md with new section on relative-time helpers
- Update access control table in documentation

Motivation: Eliminates StartTimeInPast errors caused by off-chain clock drift by computing timestamps relative to env.ledger().timestamp()

Security: All validation invariants from create_stream preserved, overflow checks on all arithmetic, atomic failure semantics maintained


- [ ] Documentation complete
- [ ] Snapshot changes justified and correct
- [ ] Security implications reviewed
- [ ] Breaking changes documented

closes #431 
