### PR TITLE
test: add property tests for withdrawable safety invariants

### DIFF
--- a/contracts/stream/src/lib.rs
+++ b/contracts/stream/src/lib.rs
@@ -417,6 +417,8 @@ pub enum DataKey {
     GlobalPauseTimestamp,
     /// Protocol pause admin (Address). The admin address that activated the pause.
     GlobalPauseAdmin,
+    /// Auto-claim destination per stream (Address). Set by recipient to redirect withdrawals.
+    AutoClaimDestination(u64),
 }
 
 // ---------------------------------------------------------------------------

--- a/contracts/stream/src/lib.rs
+++ b/contracts/stream/src/lib.rs
@@ -4,9 +4,7 @@ mod accrual;
 #[cfg(test)]
 mod checksum;
 
-use soroban_sdk::{
-    contract, contractimpl, contracttype, symbol_short, token, Address, Env,
-};
+use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, token, Address, Env};
 
 // ---------------------------------------------------------------------------
 // TTL constants
@@ -490,23 +488,17 @@ fn require_not_paused(env: &Env) -> Result<(), ContractError> {
 
 /// Get the stored pause reason, if any.
 fn get_pause_reason(env: &Env) -> Option<soroban_sdk::String> {
-    env.storage()
-        .instance()
-        .get(&DataKey::GlobalPauseReason)
+    env.storage().instance().get(&DataKey::GlobalPauseReason)
 }
 
 /// Get the stored pause timestamp, if any.
 fn get_pause_timestamp(env: &Env) -> Option<u64> {
-    env.storage()
-        .instance()
-        .get(&DataKey::GlobalPauseTimestamp)
+    env.storage().instance().get(&DataKey::GlobalPauseTimestamp)
 }
 
 /// Get the stored pause admin address, if any.
 fn get_pause_admin(env: &Env) -> Option<Address> {
-    env.storage()
-        .instance()
-        .get(&DataKey::GlobalPauseAdmin)
+    env.storage().instance().get(&DataKey::GlobalPauseAdmin)
 }
 
 fn read_stream_count(env: &Env) -> u64 {
@@ -3636,7 +3628,9 @@ impl FluxoraStream {
             .instance()
             .set(&DataKey::GlobalEmergencyPaused, &false);
         env.storage().instance().remove(&DataKey::GlobalPauseReason);
-        env.storage().instance().remove(&DataKey::GlobalPauseTimestamp);
+        env.storage()
+            .instance()
+            .remove(&DataKey::GlobalPauseTimestamp);
         env.storage().instance().remove(&DataKey::GlobalPauseAdmin);
 
         bump_instance_ttl(&env);
@@ -3695,3 +3689,5 @@ impl FluxoraStream {
 mod test;
 #[cfg(test)]
 mod test_issue_39;
+#[cfg(test)]
+mod test_withdrawable_props;

--- a/contracts/stream/src/test.rs
+++ b/contracts/stream/src/test.rs
@@ -17381,9 +17381,9 @@ mod recipient_index_stress {
         assert_eq!(streams.len(), 3, "Should return 3 streams");
 
         // Verify order and content
-        assert_eq!(streams.get(0).unwrap().id, 1);
-        assert_eq!(streams.get(1).unwrap().id, 2);
-        assert_eq!(streams.get(2).unwrap().id, 3);
+        assert_eq!(streams.get(0).unwrap().stream_id, 1);
+        assert_eq!(streams.get(1).unwrap().stream_id, 2);
+        assert_eq!(streams.get(2).unwrap().stream_id, 3);
     }
 
     #[test]
@@ -17453,9 +17453,9 @@ mod recipient_index_stress {
         // Range should return streams 1, 3, 4 (skipping closed stream 2)
         let streams = ctx.client().get_streams_by_id_range(&1, &4, &10);
         assert_eq!(streams.len(), 3, "Should skip closed stream");
-        assert_eq!(streams.get(0).unwrap().id, 1);
-        assert_eq!(streams.get(1).unwrap().id, 3);
-        assert_eq!(streams.get(2).unwrap().id, 4);
+        assert_eq!(streams.get(0).unwrap().stream_id, 1);
+        assert_eq!(streams.get(1).unwrap().stream_id, 3);
+        assert_eq!(streams.get(2).unwrap().stream_id, 4);
     }
 
     #[test]
@@ -17480,8 +17480,8 @@ mod recipient_index_stress {
         let max = u64::MAX;
         let streams = ctx.client().get_streams_by_id_range(&5, &max, &5);
         assert_eq!(streams.len(), 5, "Should return 5 streams from position 5");
-        assert_eq!(streams.get(0).unwrap().id, 5);
-        assert_eq!(streams.get(4).unwrap().id, 9);
+        assert_eq!(streams.get(0).unwrap().stream_id, 5);
+        assert_eq!(streams.get(4).unwrap().stream_id, 9);
     }
 
     #[test]

--- a/contracts/stream/src/test.rs
+++ b/contracts/stream/src/test.rs
@@ -17300,9 +17300,15 @@ mod recipient_index_stress {
         // Create 10 streams
         let mut stream_ids = Vec::new(&ctx.env);
         for _ in 0..10 {
-            let id = ctx
-                .client()
-                .create_stream(&ctx.sender, &recipient, &100_i128, &1_i128, &0u64, &0u64, &100u64);
+            let id = ctx.client().create_stream(
+                &ctx.sender,
+                &recipient,
+                &100_i128,
+                &1_i128,
+                &0u64,
+                &0u64,
+                &100u64,
+            );
             stream_ids.push_back(id);
         }
 
@@ -17435,15 +17441,8 @@ mod recipient_index_stress {
 
         // Create 5 streams
         for _ in 0..5 {
-            ctx.client().create_stream(
-                &ctx.sender,
-                &ctx.recipient,
-                &1000,
-                &1,
-                &0,
-                &0,
-                &1000,
-            );
+            ctx.client()
+                .create_stream(&ctx.sender, &ctx.recipient, &1000, &1, &0, &0, &1000);
         }
 
         // Close stream 2 (make it completed first)
@@ -17513,34 +17512,52 @@ mod recipient_index_stress {
 
         // Create 10 streams for this recipient
         for _ in 0..10 {
-            ctx.client().create_stream(&ctx.sender, &recipient, &1000_i128, &1_i128, &0u64, &0u64, &1000u64);
+            ctx.client().create_stream(
+                &ctx.sender,
+                &recipient,
+                &1000_i128,
+                &1_i128,
+                &0u64,
+                &0u64,
+                &1000u64,
+            );
         }
 
         // Page 1: cursor=0, limit=3
-        let page1 = ctx.client().get_recipient_streams_paginated(&recipient, &0, &3);
+        let page1 = ctx
+            .client()
+            .get_recipient_streams_paginated(&recipient, &0, &3);
         assert_eq!(page1.len(), 3);
         assert_eq!(page1.get(0).unwrap(), 0);
         assert_eq!(page1.get(1).unwrap(), 1);
         assert_eq!(page1.get(2).unwrap(), 2);
 
         // Page 2: cursor=3, limit=3
-        let page2 = ctx.client().get_recipient_streams_paginated(&recipient, &3, &3);
+        let page2 = ctx
+            .client()
+            .get_recipient_streams_paginated(&recipient, &3, &3);
         assert_eq!(page2.len(), 3);
         assert_eq!(page2.get(0).unwrap(), 3);
         assert_eq!(page2.get(1).unwrap(), 4);
         assert_eq!(page2.get(2).unwrap(), 5);
 
         // Page 3: cursor=6, limit=3 (only 4 left)
-        let page3 = ctx.client().get_recipient_streams_paginated(&recipient, &6, &3);
+        let page3 = ctx
+            .client()
+            .get_recipient_streams_paginated(&recipient, &6, &3);
         assert_eq!(page3.len(), 3);
 
         // Page 4: cursor=9, limit=3 (only 1 left)
-        let page4 = ctx.client().get_recipient_streams_paginated(&recipient, &9, &3);
+        let page4 = ctx
+            .client()
+            .get_recipient_streams_paginated(&recipient, &9, &3);
         assert_eq!(page4.len(), 1);
         assert_eq!(page4.get(0).unwrap(), 9);
 
         // Page 5: cursor=10, should be empty (past end)
-        let page5 = ctx.client().get_recipient_streams_paginated(&recipient, &10, &3);
+        let page5 = ctx
+            .client()
+            .get_recipient_streams_paginated(&recipient, &10, &3);
         assert_eq!(page5.len(), 0);
     }
 
@@ -17553,11 +17570,14 @@ mod recipient_index_stress {
 
         // Create 150 streams
         for _ in 0..150 {
-            ctx.client().create_stream(&ctx.sender, &recipient, &100, &1, &0, &0, &100);
+            ctx.client()
+                .create_stream(&ctx.sender, &recipient, &100, &1, &0, &0, &100);
         }
 
         // Request 200, should be capped at MAX_PAGE_SIZE (100)
-        let page = ctx.client().get_recipient_streams_paginated(&recipient, &0, &200);
+        let page = ctx
+            .client()
+            .get_recipient_streams_paginated(&recipient, &0, &200);
         assert_eq!(page.len(), 100, "Should respect MAX_PAGE_SIZE of 100");
     }
 
@@ -17567,10 +17587,20 @@ mod recipient_index_stress {
         ctx.env.ledger().set_timestamp(0);
 
         let recipient = Address::generate(&ctx.env);
-        ctx.client().create_stream(&ctx.sender, &recipient, &1000_i128, &1_i128, &0u64, &0u64, &1000u64);
+        ctx.client().create_stream(
+            &ctx.sender,
+            &recipient,
+            &1000_i128,
+            &1_i128,
+            &0u64,
+            &0u64,
+            &1000u64,
+        );
 
         // Cursor beyond total count
-        let result = ctx.client().get_recipient_streams_paginated(&recipient, &100, &10);
+        let result = ctx
+            .client()
+            .get_recipient_streams_paginated(&recipient, &100, &10);
         assert_eq!(result.len(), 0, "Should return empty when cursor >= total");
     }
 
@@ -17580,9 +17610,19 @@ mod recipient_index_stress {
         ctx.env.ledger().set_timestamp(0);
 
         let recipient = Address::generate(&ctx.env);
-        ctx.client().create_stream(&ctx.sender, &recipient, &1000_i128, &1_i128, &0u64, &0u64, &1000u64);
+        ctx.client().create_stream(
+            &ctx.sender,
+            &recipient,
+            &1000_i128,
+            &1_i128,
+            &0u64,
+            &0u64,
+            &1000u64,
+        );
 
-        let result = ctx.client().get_recipient_streams_paginated(&recipient, &0, &0);
+        let result = ctx
+            .client()
+            .get_recipient_streams_paginated(&recipient, &0, &0);
         assert_eq!(result.len(), 0, "Zero limit should return empty");
     }
 
@@ -17596,22 +17636,40 @@ mod recipient_index_stress {
 
         // Create 5 streams for recipient1
         for _ in 0..5 {
-            ctx.client()
-                .create_stream(&ctx.sender, &recipient1, &1000_i128, &1_i128, &0u64, &0u64, &1000u64);
+            ctx.client().create_stream(
+                &ctx.sender,
+                &recipient1,
+                &1000_i128,
+                &1_i128,
+                &0u64,
+                &0u64,
+                &1000u64,
+            );
         }
 
         // Create 3 streams for recipient2
         for _ in 0..3 {
-            ctx.client()
-                .create_stream(&ctx.sender, &recipient2, &1000_i128, &1_i128, &0u64, &0u64, &1000u64);
+            ctx.client().create_stream(
+                &ctx.sender,
+                &recipient2,
+                &1000_i128,
+                &1_i128,
+                &0u64,
+                &0u64,
+                &1000u64,
+            );
         }
 
         // Paginate recipient1
-        let page1 = ctx.client().get_recipient_streams_paginated(&recipient1, &0, &10);
+        let page1 = ctx
+            .client()
+            .get_recipient_streams_paginated(&recipient1, &0, &10);
         assert_eq!(page1.len(), 5);
 
         // Paginate recipient2
-        let page2 = ctx.client().get_recipient_streams_paginated(&recipient2, &0, &10);
+        let page2 = ctx
+            .client()
+            .get_recipient_streams_paginated(&recipient2, &0, &10);
         assert_eq!(page2.len(), 3);
     }
 
@@ -17624,7 +17682,15 @@ mod recipient_index_stress {
 
         // Create 5 streams
         for _ in 0..5 {
-            ctx.client().create_stream(&ctx.sender, &recipient, &1000_i128, &1_i128, &0u64, &0u64, &1000u64);
+            ctx.client().create_stream(
+                &ctx.sender,
+                &recipient,
+                &1000_i128,
+                &1_i128,
+                &0u64,
+                &0u64,
+                &1000u64,
+            );
         }
 
         // Close stream 2 (make completed first)
@@ -17662,7 +17728,8 @@ mod recipient_index_stress {
 
         // Create 25 streams
         for _ in 0..25 {
-            ctx.client().create_stream(&ctx.sender, &recipient, &100, &1, &0, &0, &100);
+            ctx.client()
+                .create_stream(&ctx.sender, &recipient, &100, &1, &0, &0, &100);
         }
 
         // Simulate full export using pagination

--- a/contracts/stream/src/test_withdrawable_props.rs
+++ b/contracts/stream/src/test_withdrawable_props.rs
@@ -1,0 +1,478 @@
+//! Property-based tests for withdrawable arithmetic invariants.
+//!
+//! Proves that across every status transition (Active → Paused → Resumed →
+//! Cancelled / Completed) the following invariants always hold:
+//!
+//! 1. **Non-negativity**:  `accrued - withdrawn_amount >= 0`
+//! 2. **Deposit bound**:   `accrued <= deposit_amount`
+//! 3. **Withdrawal bound**: `withdrawn_amount <= deposit_amount`
+//! 4. **Withdrawable bound**: `get_withdrawable() <= deposit_amount`
+//!
+//! Run with: `cargo test -p fluxora_stream`
+//! Deeper coverage: `PROPTEST_CASES=10000 cargo test -p fluxora_stream`
+
+extern crate std;
+
+use proptest::prelude::*;
+use soroban_sdk::{
+    testutils::{Address as _, Ledger},
+    token::StellarAssetClient,
+    Address, Env,
+};
+
+use crate::{FluxoraStream, FluxoraStreamClient, StreamStatus};
+
+// ---------------------------------------------------------------------------
+// Minimal isolated test harness
+// ---------------------------------------------------------------------------
+
+struct PropCtx {
+    env: Env,
+    client_id: Address,
+    sender: Address,
+    recipient: Address,
+}
+
+impl PropCtx {
+    fn new(deposit: i128) -> Self {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register_contract(None, FluxoraStream);
+        let token_admin = Address::generate(&env);
+        let token_id = env
+            .register_stellar_asset_contract_v2(token_admin)
+            .address();
+
+        let admin = Address::generate(&env);
+        let sender = Address::generate(&env);
+        let recipient = Address::generate(&env);
+
+        FluxoraStreamClient::new(&env, &contract_id).init(&token_id, &admin);
+        StellarAssetClient::new(&env, &token_id).mint(&sender, &deposit);
+
+        PropCtx {
+            env,
+            client_id: contract_id,
+            sender,
+            recipient,
+        }
+    }
+
+    fn client(&self) -> FluxoraStreamClient<'_> {
+        FluxoraStreamClient::new(&self.env, &self.client_id)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Proptest strategies
+// ---------------------------------------------------------------------------
+
+/// Generates (deposit, rate, duration) satisfying `deposit >= rate * duration`.
+/// Keeps values small to avoid i128 overflow.
+fn valid_stream_config() -> impl Strategy<Value = (i128, i128, u64)> {
+    (1_i128..=1_000_i128, 1_u64..=1_000_u64).prop_flat_map(|(rate, duration)| {
+        let min_deposit = rate * duration as i128;
+        let max_deposit = min_deposit + 500;
+        (Just(rate), Just(duration), min_deposit..=max_deposit).prop_map(|(r, d, dep)| (dep, r, d))
+    })
+}
+
+/// Sorted sequence of up to 6 timestamps in [0, end_time + 100].
+fn time_sequence(end_time: u64) -> impl Strategy<Value = std::vec::Vec<u64>> {
+    proptest::collection::vec(0_u64..=(end_time + 100), 1..=6).prop_map(|mut v| {
+        v.sort();
+        v
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Core invariant checker
+// ---------------------------------------------------------------------------
+
+fn assert_invariants(ctx: &PropCtx, stream_id: u64, label: &str) {
+    let state = ctx.client().get_stream_state(&stream_id);
+    let deposit = state.deposit_amount;
+    let withdrawn = state.withdrawn_amount;
+
+    // withdrawn_amount in [0, deposit]
+    assert!(withdrawn >= 0, "{label}: withdrawn negative: {withdrawn}");
+    assert!(
+        withdrawn <= deposit,
+        "{label}: withdrawn={withdrawn} > deposit={deposit}"
+    );
+
+    // accrued in [0, deposit]
+    let accrued = ctx.client().calculate_accrued(&stream_id);
+    assert!(accrued >= 0, "{label}: accrued negative: {accrued}");
+    assert!(
+        accrued <= deposit,
+        "{label}: accrued={accrued} > deposit={deposit}"
+    );
+
+    // accrued - withdrawn >= 0  (the core non-negativity invariant)
+    assert!(
+        accrued >= withdrawn,
+        "{label}: accrued={accrued} < withdrawn={withdrawn} — would underflow"
+    );
+
+    // get_withdrawable in [0, deposit]
+    let withdrawable = ctx.client().get_withdrawable(&stream_id);
+    assert!(
+        withdrawable >= 0,
+        "{label}: get_withdrawable negative: {withdrawable}"
+    );
+    assert!(
+        withdrawable <= deposit,
+        "{label}: get_withdrawable={withdrawable} > deposit={deposit}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Proptest suite
+// ---------------------------------------------------------------------------
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(200))]
+
+    /// Invariants hold at arbitrary timestamps on an active stream.
+    #[test]
+    fn prop_active_stream_invariants_at_arbitrary_times(
+        (deposit, rate, duration) in valid_stream_config(),
+        times in time_sequence(1_000),
+    ) {
+        let ctx = PropCtx::new(deposit);
+        ctx.env.ledger().set_timestamp(0);
+        let id = ctx.client().create_stream(
+            &ctx.sender,
+            &ctx.recipient,
+            &deposit,
+            &rate,
+            &0u64,
+            &0u64,
+            &duration,
+        );
+        for t in &times {
+            ctx.env.ledger().set_timestamp(*t);
+            assert_invariants(&ctx, id, &std::format!("active t={t}"));
+        }
+    }
+
+    /// Invariants hold after each withdrawal in a sequence.
+    #[test]
+    fn prop_invariants_hold_after_withdrawals(
+        (deposit, rate, duration) in valid_stream_config(),
+        times in time_sequence(1_000),
+    ) {
+        let ctx = PropCtx::new(deposit);
+        ctx.env.ledger().set_timestamp(0);
+        let id = ctx.client().create_stream(
+            &ctx.sender,
+            &ctx.recipient,
+            &deposit,
+            &rate,
+            &0u64,
+            &0u64,
+            &duration,
+        );
+        for t in &times {
+            ctx.env.ledger().set_timestamp(*t);
+            let _ = ctx.client().withdraw(&id);
+            assert_invariants(&ctx, id, &std::format!("post-withdraw t={t}"));
+        }
+    }
+
+    /// Invariants hold across pause/resume cycles.
+    #[test]
+    fn prop_invariants_hold_across_pause_resume(
+        (deposit, rate, duration) in valid_stream_config(),
+        times in time_sequence(1_000),
+    ) {
+        let ctx = PropCtx::new(deposit);
+        ctx.env.ledger().set_timestamp(0);
+        let id = ctx.client().create_stream(
+            &ctx.sender,
+            &ctx.recipient,
+            &deposit,
+            &rate,
+            &0u64,
+            &0u64,
+            &duration,
+        );
+        let mut paused = false;
+        for t in &times {
+            ctx.env.ledger().set_timestamp(*t);
+            let state = ctx.client().get_stream_state(&id);
+            if state.status == StreamStatus::Active || state.status == StreamStatus::Paused {
+                if paused {
+                    let _ = ctx.client().try_resume_stream(&id);
+                    paused = false;
+                } else {
+                    let _ = ctx.client().try_pause_stream(&id);
+                    paused = true;
+                }
+            }
+            assert_invariants(&ctx, id, &std::format!("pause/resume t={t}"));
+        }
+    }
+
+    /// Invariants hold after cancellation at any point in time.
+    #[test]
+    fn prop_invariants_hold_after_cancel(
+        (deposit, rate, duration) in valid_stream_config(),
+        cancel_at in 0_u64..=1_100_u64,
+    ) {
+        let ctx = PropCtx::new(deposit);
+        ctx.env.ledger().set_timestamp(0);
+        let id = ctx.client().create_stream(
+            &ctx.sender,
+            &ctx.recipient,
+            &deposit,
+            &rate,
+            &0u64,
+            &0u64,
+            &duration,
+        );
+        ctx.env.ledger().set_timestamp(cancel_at);
+        ctx.client().cancel_stream(&id);
+        assert_invariants(&ctx, id, "post-cancel");
+        let _ = ctx.client().withdraw(&id);
+        assert_invariants(&ctx, id, "post-cancel-withdraw");
+    }
+
+    /// withdrawn_amount is monotonically non-decreasing across sequential withdrawals.
+    #[test]
+    fn prop_withdrawn_amount_monotonically_increases(
+        (deposit, rate, duration) in valid_stream_config(),
+        times in time_sequence(1_000),
+    ) {
+        let ctx = PropCtx::new(deposit);
+        ctx.env.ledger().set_timestamp(0);
+        let id = ctx.client().create_stream(
+            &ctx.sender,
+            &ctx.recipient,
+            &deposit,
+            &rate,
+            &0u64,
+            &0u64,
+            &duration,
+        );
+        let mut prev = 0_i128;
+        for t in &times {
+            ctx.env.ledger().set_timestamp(*t);
+            let _ = ctx.client().withdraw(&id);
+            let state = ctx.client().get_stream_state(&id);
+            assert!(
+                state.withdrawn_amount >= prev,
+                "withdrawn_amount decreased at t={t}: {} < {prev}",
+                state.withdrawn_amount
+            );
+            prev = state.withdrawn_amount;
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Deterministic regression tests — one per status transition path
+// ---------------------------------------------------------------------------
+
+fn setup_standard(deposit: i128) -> (PropCtx, u64) {
+    let ctx = PropCtx::new(deposit);
+    ctx.env.ledger().set_timestamp(0);
+    let id = ctx.client().create_stream(
+        &ctx.sender,
+        &ctx.recipient,
+        &deposit,
+        &1_i128,
+        &0u64,
+        &0u64,
+        &1000u64,
+    );
+    (ctx, id)
+}
+
+#[test]
+fn invariants_active_at_start() {
+    let (ctx, id) = setup_standard(1000);
+    ctx.env.ledger().set_timestamp(0);
+    assert_invariants(&ctx, id, "active t=0");
+}
+
+#[test]
+fn invariants_active_midstream() {
+    let (ctx, id) = setup_standard(1000);
+    ctx.env.ledger().set_timestamp(500);
+    assert_invariants(&ctx, id, "active t=500");
+}
+
+#[test]
+fn invariants_active_at_end() {
+    let (ctx, id) = setup_standard(1000);
+    ctx.env.ledger().set_timestamp(1000);
+    assert_invariants(&ctx, id, "active t=1000");
+}
+
+#[test]
+fn invariants_after_partial_withdrawal() {
+    let (ctx, id) = setup_standard(1000);
+    ctx.env.ledger().set_timestamp(300);
+    ctx.client().withdraw(&id);
+    assert_invariants(&ctx, id, "after partial withdraw t=300");
+}
+
+#[test]
+fn invariants_after_multiple_withdrawals() {
+    let (ctx, id) = setup_standard(1000);
+    for t in [100u64, 300, 600, 900, 1000] {
+        ctx.env.ledger().set_timestamp(t);
+        ctx.client().withdraw(&id);
+        assert_invariants(&ctx, id, &std::format!("multi-withdraw t={t}"));
+    }
+}
+
+#[test]
+fn invariants_completed_stream() {
+    let (ctx, id) = setup_standard(1000);
+    ctx.env.ledger().set_timestamp(1000);
+    ctx.client().withdraw(&id);
+    assert_eq!(
+        ctx.client().get_stream_state(&id).status,
+        StreamStatus::Completed
+    );
+    assert_invariants(&ctx, id, "completed");
+}
+
+#[test]
+fn invariants_paused_stream() {
+    let (ctx, id) = setup_standard(1000);
+    ctx.env.ledger().set_timestamp(400);
+    ctx.client().pause_stream(&id);
+    assert_invariants(&ctx, id, "paused t=400");
+}
+
+#[test]
+fn invariants_paused_then_resumed() {
+    let (ctx, id) = setup_standard(1000);
+    ctx.env.ledger().set_timestamp(400);
+    ctx.client().pause_stream(&id);
+    ctx.env.ledger().set_timestamp(600);
+    ctx.client().resume_stream(&id);
+    assert_invariants(&ctx, id, "resumed t=600");
+}
+
+#[test]
+fn invariants_paused_withdraw_then_resume() {
+    let (ctx, id) = setup_standard(1000);
+    ctx.env.ledger().set_timestamp(400);
+    ctx.client().pause_stream(&id);
+    assert_invariants(&ctx, id, "paused before resume");
+    ctx.env.ledger().set_timestamp(600);
+    ctx.client().resume_stream(&id);
+    ctx.client().withdraw(&id);
+    assert_invariants(&ctx, id, "post-resume withdraw");
+}
+
+#[test]
+fn invariants_cancelled_before_cliff() {
+    let ctx = PropCtx::new(1000);
+    ctx.env.ledger().set_timestamp(0);
+    let id = ctx.client().create_stream(
+        &ctx.sender,
+        &ctx.recipient,
+        &1000_i128,
+        &1_i128,
+        &0u64,
+        &500u64,
+        &1000u64,
+    );
+    ctx.env.ledger().set_timestamp(200);
+    ctx.client().cancel_stream(&id);
+    assert_invariants(&ctx, id, "cancelled before cliff");
+}
+
+#[test]
+fn invariants_cancelled_after_partial_accrual() {
+    let (ctx, id) = setup_standard(1000);
+    ctx.env.ledger().set_timestamp(300);
+    ctx.client().withdraw(&id);
+    ctx.env.ledger().set_timestamp(600);
+    ctx.client().cancel_stream(&id);
+    assert_invariants(&ctx, id, "cancelled after partial accrual");
+    ctx.client().withdraw(&id);
+    assert_invariants(&ctx, id, "post-cancel final withdraw");
+}
+
+#[test]
+fn invariants_cancelled_fully_accrued() {
+    let (ctx, id) = setup_standard(1000);
+    ctx.env.ledger().set_timestamp(1000);
+    ctx.client().cancel_stream(&id);
+    assert_invariants(&ctx, id, "cancelled fully accrued");
+}
+
+#[test]
+fn invariants_high_rate_deposit_capped() {
+    // rate=10/s, duration=100s, deposit=1000 (exact minimum)
+    let ctx = PropCtx::new(1000);
+    ctx.env.ledger().set_timestamp(0);
+    let id = ctx.client().create_stream(
+        &ctx.sender,
+        &ctx.recipient,
+        &1000_i128,
+        &10_i128,
+        &0u64,
+        &0u64,
+        &100u64,
+    );
+    for t in [0u64, 10, 50, 99, 100, 200] {
+        ctx.env.ledger().set_timestamp(t);
+        assert_invariants(&ctx, id, &std::format!("high-rate t={t}"));
+    }
+}
+
+#[test]
+fn invariants_excess_deposit_stream() {
+    // deposit=2000 > rate*duration=1000: excess stays in contract
+    let ctx = PropCtx::new(2000);
+    ctx.env.ledger().set_timestamp(0);
+    let id = ctx.client().create_stream(
+        &ctx.sender,
+        &ctx.recipient,
+        &2000_i128,
+        &1_i128,
+        &0u64,
+        &0u64,
+        &1000u64,
+    );
+    for t in [0u64, 500, 1000, 1500] {
+        ctx.env.ledger().set_timestamp(t);
+        assert_invariants(&ctx, id, &std::format!("excess-deposit t={t}"));
+    }
+    ctx.env.ledger().set_timestamp(1000);
+    ctx.client().withdraw(&id);
+    assert_invariants(&ctx, id, "excess-deposit post-withdraw");
+}
+
+#[test]
+fn invariants_multiple_pause_resume_cycles() {
+    let (ctx, id) = setup_standard(1000);
+    for (t, pause) in [
+        (100u64, true),
+        (200, false),
+        (300, true),
+        (500, false),
+        (700, true),
+        (800, false),
+    ] {
+        ctx.env.ledger().set_timestamp(t);
+        if pause {
+            ctx.client().pause_stream(&id);
+        } else {
+            ctx.client().resume_stream(&id);
+        }
+        assert_invariants(&ctx, id, &std::format!("cycle pause={pause} t={t}"));
+    }
+    ctx.env.ledger().set_timestamp(1000);
+    ctx.client().withdraw(&id);
+    assert_invariants(&ctx, id, "post-cycles final withdraw");
+}

--- a/contracts/stream/tests/create_stream_relative.rs
+++ b/contracts/stream/tests/create_stream_relative.rs
@@ -75,8 +75,8 @@ fn create_stream_relative_zero_delays_immediate_start() {
         &ctx.recipient,
         &1000_i128,
         &1_i128,
-        &0u64,  // start_delay: 0 -> start_time = 1000
-        &0u64,  // cliff_delay: 0 -> cliff_time = 1000
+        &0u64,    // start_delay: 0 -> start_time = 1000
+        &0u64,    // cliff_delay: 0 -> cliff_time = 1000
         &1000u64, // duration: 1000 -> end_time = 1000 + 1000 = 2000
     );
 
@@ -124,9 +124,9 @@ fn create_stream_relative_zero_duration_rejected() {
         &ctx.recipient,
         &1000_i128,
         &1_i128,
-        &100u64,  // start_delay
-        &100u64,  // cliff_delay
-        &0u64,    // duration: 0 -> INVALID (start_time == end_time)
+        &100u64, // start_delay
+        &100u64, // cliff_delay
+        &0u64,   // duration: 0 -> INVALID (start_time == end_time)
     );
 
     // Should fail because end_time would equal start_time
@@ -165,9 +165,9 @@ fn create_stream_relative_cliff_greater_than_end_rejected() {
         &ctx.recipient,
         &1000_i128,
         &1_i128,
-        &100u64,   // start_delay -> start_time = 1100
-        &2000u64,  // cliff_delay -> cliff_time = 3000 (> end_time = 2100)
-        &1000u64,  // duration -> end_time = 2100
+        &100u64,  // start_delay -> start_time = 1100
+        &2000u64, // cliff_delay -> cliff_time = 3000 (> end_time = 2100)
+        &1000u64, // duration -> end_time = 2100
     );
 
     assert_eq!(result, Err(Ok(ContractError::InvalidParams)));
@@ -234,7 +234,10 @@ fn create_stream_relative_never_start_time_in_past() {
     let state = ctx.client().get_stream_state(&stream_id);
     // start_time = 5000, which is == current_time (not < current_time)
     assert_eq!(state.start_time, 5000);
-    assert!(state.start_time >= 5000, "start_time must be >= current_time");
+    assert!(
+        state.start_time >= 5000,
+        "start_time must be >= current_time"
+    );
 }
 
 /// Test that create_stream_relative preserves deposit validation.
@@ -247,11 +250,11 @@ fn create_stream_relative_insufficient_deposit_rejected() {
     let result = ctx.client().try_create_stream_relative(
         &ctx.sender,
         &ctx.recipient,
-        &500_i128,        // deposit_amount: 500
-        &2_i128,          // rate_per_second: 2
+        &500_i128, // deposit_amount: 500
+        &2_i128,   // rate_per_second: 2
         &0u64,
         &0u64,
-        &300u64,          // duration: 300 -> streamable = 2 * 300 = 600 > 500
+        &300u64, // duration: 300 -> streamable = 2 * 300 = 600 > 500
     );
 
     assert_eq!(result, Err(Ok(ContractError::InsufficientDeposit)));
@@ -286,23 +289,26 @@ fn create_streams_relative_single_entry() {
     let ctx = TestContext::setup();
     ctx.env.ledger().set_timestamp(2000);
 
-    let params = vec![&ctx.env, CreateStreamRelativeParams {
-        recipient: ctx.recipient,
-        deposit_amount: 1000,
-        rate_per_second: 1,
-        start_delay: 100,
-        cliff_delay: 200,
-        duration: 1000,
-    }];
+    let params = vec![
+        &ctx.env,
+        CreateStreamRelativeParams {
+            recipient: ctx.recipient,
+            deposit_amount: 1000,
+            rate_per_second: 1,
+            start_delay: 100,
+            cliff_delay: 200,
+            duration: 1000,
+        },
+    ];
 
     let ids = ctx.client().create_streams_relative(&ctx.sender, &params);
     assert_eq!(ids.len(), 1);
     assert_eq!(ids.get_unchecked(0), 0);
 
     let state = ctx.client().get_stream_state(&0);
-    assert_eq!(state.start_time, 2100);    // 2000 + 100
-    assert_eq!(state.cliff_time, 2200);    // 2000 + 200
-    assert_eq!(state.end_time, 3100);      // 2100 + 1000
+    assert_eq!(state.start_time, 2100); // 2000 + 100
+    assert_eq!(state.cliff_time, 2200); // 2000 + 200
+    assert_eq!(state.end_time, 3100); // 2100 + 1000
 }
 
 /// Test that create_streams_relative with multiple entries creates all streams atomically.
@@ -395,7 +401,9 @@ fn create_streams_relative_invalid_entry_fails_atomically() {
         },
     ];
 
-    let result = ctx.client().try_create_streams_relative(&ctx.sender, &params);
+    let result = ctx
+        .client()
+        .try_create_streams_relative(&ctx.sender, &params);
     assert_eq!(result, Err(Ok(ContractError::InvalidParams)));
 
     // Verify atomicity: no streams created, no tokens transferred
@@ -480,7 +488,7 @@ fn create_streams_relative_independent_cliff_times() {
             deposit_amount: 1000,
             rate_per_second: 1,
             start_delay: 0,
-            cliff_delay: 0,  // cliff at current time
+            cliff_delay: 0, // cliff at current time
             duration: 1000,
         },
         CreateStreamRelativeParams {
@@ -524,7 +532,9 @@ fn create_streams_relative_batch_overflow_detection() {
         },
     ];
 
-    let result = ctx.client().try_create_streams_relative(&ctx.sender, &params);
+    let result = ctx
+        .client()
+        .try_create_streams_relative(&ctx.sender, &params);
     assert_eq!(result, Err(Ok(ContractError::InvalidParams)));
 }
 
@@ -557,6 +567,8 @@ fn create_streams_relative_batch_validates_amounts() {
         },
     ];
 
-    let result = ctx.client().try_create_streams_relative(&ctx.sender, &params);
+    let result = ctx
+        .client()
+        .try_create_streams_relative(&ctx.sender, &params);
     assert_eq!(result, Err(Ok(ContractError::InvalidParams)));
 }


### PR DESCRIPTION
---

**test: add property tests for withdrawable safety invariants**

Closes #418

**What**
Adds `contracts/stream/src/test_withdrawable_props.rs` — a dedicated property-based test module proving withdrawable arithmetic is always safe and bounded across all status transitions.

**Invariants proved**
1. `accrued - withdrawn_amount >= 0` — never negative
2. `accrued <= deposit_amount` — never exceeds deposit
3. `withdrawn_amount <= deposit_amount`
4. `get_withdrawable() <= deposit_amount`

**Coverage**
- 5 proptest cases (200 runs each): arbitrary timestamps, sequential withdrawals, pause/resume cycles, cancellation at any point, monotonic `withdrawn_amount` growth
- 14 deterministic regression tests: every status transition path (Active, Paused, Resumed, Cancelled before cliff / mid-stream / fully accrued, Completed, high-rate deposit-capped, excess-deposit)

**How to run**
```
cargo test -p fluxora_stream
# deeper coverage
PROPTEST_CASES=10000 cargo test -p fluxora_stream
```