### PR TITLE
chore: harden reproducible WASM checksum workflow and documentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,46 +107,7 @@ jobs:
           fi
 
       - name: Verify WASM build reproducibility
-        run: |
-          set -euo pipefail
-          REFERENCE_FILE="wasm/checksums.sha256"
-          WASM_FILE="target/wasm32-unknown-unknown/release/fluxora_stream.wasm"
-
-          if [ ! -f "${REFERENCE_FILE}" ]; then
-            echo "::error::Reference checksums file not found at ${REFERENCE_FILE}. Run script/update-wasm-checksums.sh to generate it."
-            exit 1
-          fi
-
-          if [ ! -f "${WASM_FILE}" ]; then
-            echo "::error::WASM artifact not found at ${WASM_FILE}. Build step may have failed."
-            exit 1
-          fi
-
-          # Extract the expected checksum from the reference file (skip comments and blank lines)
-          EXPECTED=$(grep -v '^#' "${REFERENCE_FILE}" | grep -v '^$' | grep 'fluxora_stream.wasm' | awk '{print $1}')
-          if [ -z "${EXPECTED}" ]; then
-            echo "::error::No reference checksum found for fluxora_stream.wasm in ${REFERENCE_FILE}"
-            exit 1
-          fi
-
-          # Compute the actual checksum of the built WASM
-          ACTUAL=$(sha256sum "${WASM_FILE}" | awk '{print $1}')
-
-          echo "Expected SHA256: ${EXPECTED}"
-          echo "Actual   SHA256: ${ACTUAL}"
-
-          if [ "${ACTUAL}" != "${EXPECTED}" ]; then
-            echo "::error::WASM checksum mismatch! Build is not reproducible."
-            echo "  Expected: ${EXPECTED}"
-            echo "  Actual:   ${ACTUAL}"
-            echo ""
-            echo "This means the WASM output differs from the committed reference."
-            echo "If this is an intentional source change, run: bash script/update-wasm-checksums.sh"
-            echo "Then commit the updated wasm/checksums.sha256 file."
-            exit 1
-          fi
-
-          echo "WASM build reproducibility verified: checksum matches reference."
+        run: bash script/verify-wasm-checksum.sh --no-build
 
       - name: Upload WASM hash artifact
         uses: actions/upload-artifact@v4

--- a/README.md
+++ b/README.md
@@ -203,11 +203,24 @@ After each CI build, the pipeline computes a SHA256 hash of the contract WASM ar
 To verify a deployment:
 
 1. Download the hash artifact from the CI run (GitHub Actions → Artifacts → `fluxora_stream-wasm-hash`).
-2. Compute the SHA256 hash of your local WASM file:
+2. Rebuild locally and verify against the committed reference:
    ```bash
-   sha256sum target/wasm32-unknown-unknown/release/fluxora_stream.wasm
+   bash script/verify-wasm-checksum.sh
    ```
-3. Compare the output to the CI hash file. A match confirms your binary is identical to the tested build.
+3. Or verify existing artifacts without rebuilding:
+   ```bash
+   bash script/verify-wasm-checksum.sh --no-build
+   ```
+
+To update checksums after a source change:
+
+```bash
+bash script/update-wasm-checksums.sh
+git add wasm/checksums.sha256
+git commit -m "chore: update wasm checksums"
+```
+
+See [docs/security.md](docs/security.md#reproducible-wasm-builds) for the full reproducibility contract, auditor verification steps, and residual risks.
 
 ## Related repos
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -306,7 +306,7 @@ The CI pipeline verifies that the WASM artifact produced by `cargo build --relea
 
 | Factor                     | How it is pinned                                                |
 |---------------------------|-----------------------------------------------------------------|
-| Rust toolchain            | `rust-toolchain.toml` — `channel = "stable"`, targets pinned    |
+| Rust toolchain            | `rust-toolchain.toml` — channel and targets pinned              |
 | soroban-sdk version       | `contracts/stream/Cargo.toml` — `21.7.7` exact version          |
 | Build profile             | `--release` with `wasm32-unknown-unknown` target                |
 | Feature flags             | Only default features during WASM build (`testutils` is test-only) |
@@ -314,10 +314,22 @@ The CI pipeline verifies that the WASM artifact produced by `cargo build --relea
 
 ### CI verification flow
 
-1. Build WASM with pinned toolchain
-2. Compute `sha256sum` of the artifact
-3. Compare against `wasm/checksums.sha256`
-4. Fail with actionable error if mismatch detected
+1. Build WASM with pinned toolchain (`cargo build --release --target wasm32-unknown-unknown`)
+2. Run `bash script/verify-wasm-checksum.sh --no-build` — compares each artifact against `wasm/checksums.sha256`
+3. Fail with actionable error message if any checksum mismatches
+4. Upload raw and optimized WASM + hash files as CI artifacts (30-day retention)
+
+### Local verification
+
+To verify a build locally before deployment:
+
+```bash
+# Rebuild and verify in one step
+bash script/verify-wasm-checksum.sh
+
+# Verify existing artifacts without rebuilding
+bash script/verify-wasm-checksum.sh --no-build
+```
 
 ### Updating checksums
 
@@ -326,8 +338,21 @@ When the contract source changes intentionally:
 ```bash
 bash script/update-wasm-checksums.sh
 git add wasm/checksums.sha256
-git commit -m "chore: update wasm checksums"
+git commit -m "chore: update wasm checksums after <describe change>"
 ```
+
+The script also accepts `--dry-run` to preview the new hashes without writing:
+
+```bash
+bash script/update-wasm-checksums.sh --dry-run
+```
+
+### Auditor verification steps
+
+1. Clone the repository at the commit tagged for audit.
+2. Confirm `rust-toolchain.toml` channel matches the CI build.
+3. Run `bash script/verify-wasm-checksum.sh` — all entries must print `OK`.
+4. Compare the passing hash against the on-chain contract hash via `stellar contract inspect`.
 
 ### Residual risks
 

--- a/script/update-wasm-checksums.sh
+++ b/script/update-wasm-checksums.sh
@@ -1,54 +1,132 @@
 #!/usr/bin/env bash
 # update-wasm-checksums.sh
 #
-# Rebuilds the WASM artifact and updates wasm/checksums.sha256 with the
-# fresh SHA256. Run this locally whenever contract source changes and
-# commit the updated checksums file alongside your code change.
+# Rebuilds all WASM artifacts and updates wasm/checksums.sha256 with fresh
+# SHA256 hashes. Run this locally whenever contract source changes and commit
+# the updated checksums file alongside your code change.
 #
-# Usage: bash script/update-wasm-checksums.sh
+# Usage: bash script/update-wasm-checksums.sh [--dry-run]
+#
+# Options:
+#   --dry-run   Print what would be written without modifying checksums.sha256
+#
+# Exit codes:
+#   0  Success — checksums file updated (or dry-run printed)
+#   1  Build failed or WASM artifact missing
 
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-WASM_FILE="${REPO_ROOT}/target/wasm32-unknown-unknown/release/fluxora_stream.wasm"
 CHECKSUMS_FILE="${REPO_ROOT}/wasm/checksums.sha256"
+DRY_RUN=false
 
-echo "Building WASM (release)..."
-cargo build --release -p fluxora_stream --target wasm32-unknown-unknown \
-  --manifest-path "${REPO_ROOT}/Cargo.toml"
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN=true ;;
+    *) echo "Unknown argument: $arg" >&2; exit 1 ;;
+  esac
+done
 
-if [ ! -f "${WASM_FILE}" ]; then
-  echo "ERROR: WASM artifact not found at ${WASM_FILE}" >&2
+# ---------------------------------------------------------------------------
+# Contracts to hash: name → relative WASM path from repo root
+# Add new contracts here when they are added to the workspace.
+# ---------------------------------------------------------------------------
+declare -A CONTRACTS
+CONTRACTS["fluxora_stream"]="target/wasm32-unknown-unknown/release/fluxora_stream.wasm"
+
+# ---------------------------------------------------------------------------
+# Verify required tools
+# ---------------------------------------------------------------------------
+for tool in cargo sha256sum awk date; do
+  if ! command -v "$tool" &>/dev/null; then
+    echo "ERROR: required tool '$tool' not found in PATH" >&2
+    exit 1
+  fi
+done
+
+# ---------------------------------------------------------------------------
+# Verify rust-toolchain.toml is present (reproducibility requirement)
+# ---------------------------------------------------------------------------
+if [ ! -f "${REPO_ROOT}/rust-toolchain.toml" ]; then
+  echo "ERROR: rust-toolchain.toml not found — pinned toolchain is required for reproducible builds" >&2
   exit 1
 fi
 
-NEW_HASH=$(sha256sum "${WASM_FILE}" | awk '{print $1}')
-echo "New SHA256: ${NEW_HASH}"
+TOOLCHAIN_CHANNEL=$(grep 'channel' "${REPO_ROOT}/rust-toolchain.toml" | awk -F'"' '{print $2}')
+echo "Rust toolchain: ${TOOLCHAIN_CHANNEL} (from rust-toolchain.toml)"
 
-# Rewrite the checksums file, preserving the header comments
-HEADER=$(grep '^#' "${CHECKSUMS_FILE}")
-TODAY=$(date +%Y-%m-%d)
+# ---------------------------------------------------------------------------
+# Build all contracts
+# ---------------------------------------------------------------------------
+echo "Building WASM artifacts (release, wasm32-unknown-unknown)..."
+cargo build --release --target wasm32-unknown-unknown \
+  --manifest-path "${REPO_ROOT}/Cargo.toml" \
+  $(for name in "${!CONTRACTS[@]}"; do echo "-p $name"; done)
 
-cat > "${CHECKSUMS_FILE}" <<EOF
-# Fluxora Stream WASM Checksums
+# ---------------------------------------------------------------------------
+# Compute hashes
+# ---------------------------------------------------------------------------
+declare -A NEW_HASHES
+for name in "${!CONTRACTS[@]}"; do
+  wasm_path="${REPO_ROOT}/${CONTRACTS[$name]}"
+  if [ ! -f "${wasm_path}" ]; then
+    echo "ERROR: WASM artifact not found: ${wasm_path}" >&2
+    echo "  Build may have failed or the contract name is wrong." >&2
+    exit 1
+  fi
+  hash=$(sha256sum "${wasm_path}" | awk '{print $1}')
+  NEW_HASHES["$name"]="$hash"
+  echo "  ${name}: ${hash}"
+done
+
+# ---------------------------------------------------------------------------
+# Dry-run: print and exit
+# ---------------------------------------------------------------------------
+if [ "$DRY_RUN" = true ]; then
+  echo ""
+  echo "--- DRY RUN: checksums.sha256 would be updated to ---"
+  for name in "${!NEW_HASHES[@]}"; do
+    echo "${NEW_HASHES[$name]}  ${name}.wasm"
+  done
+  echo "--- No files were modified ---"
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Write checksums file
+# ---------------------------------------------------------------------------
+TODAY=$(date -u +%Y-%m-%d)
+
+{
+  cat <<EOF
+# Fluxora Contract WASM Checksums
 #
-# This file contains reference SHA256 checksums for reproducible WASM builds.
+# Reference SHA256 checksums for reproducible WASM builds.
 # CI verifies that a fresh build produces byte-identical artifacts.
 #
 # Format: <sha256>  <filename>
 # Generated by: script/update-wasm-checksums.sh
 # Last updated: ${TODAY}
+# Rust toolchain: ${TOOLCHAIN_CHANNEL}
 #
-# To regenerate, run: bash script/update-wasm-checksums.sh
+# To regenerate: bash script/update-wasm-checksums.sh
+# To verify:     bash script/verify-wasm-checksum.sh
 #
 # Determinism contract:
-#   - Rust toolchain is pinned via rust-toolchain.toml (stable channel)
-#   - soroban-sdk version is pinned in contracts/stream/Cargo.toml
+#   - Rust toolchain pinned via rust-toolchain.toml
+#   - soroban-sdk version pinned in each contract's Cargo.toml
 #   - Build uses --release with wasm32-unknown-unknown target
-#   - No environment-dependent flags or features beyond the pinned toolchain
+#   - No environment-dependent flags beyond the pinned toolchain
 #
-${NEW_HASH}  fluxora_stream.wasm
 EOF
+  for name in "${!NEW_HASHES[@]}"; do
+    echo "${NEW_HASHES[$name]}  ${name}.wasm"
+  done
+} > "${CHECKSUMS_FILE}"
 
+echo ""
 echo "Updated ${CHECKSUMS_FILE}"
 echo "Commit this file alongside your source changes."
+echo ""
+echo "To verify the build is reproducible, run:"
+echo "  bash script/verify-wasm-checksum.sh"

--- a/script/verify-wasm-checksum.sh
+++ b/script/verify-wasm-checksum.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# verify-wasm-checksum.sh
+#
+# Verifies that locally-built WASM artifacts match the reference checksums in
+# wasm/checksums.sha256. Use this to confirm a build is reproducible before
+# deployment, or to audit a downloaded artifact.
+#
+# Usage:
+#   bash script/verify-wasm-checksum.sh              # verify all contracts
+#   bash script/verify-wasm-checksum.sh --no-build   # skip rebuild, check existing artifacts
+#
+# Exit codes:
+#   0  All checksums match
+#   1  One or more checksums mismatch, or a required file is missing
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CHECKSUMS_FILE="${REPO_ROOT}/wasm/checksums.sha256"
+BUILD=true
+
+for arg in "$@"; do
+  case "$arg" in
+    --no-build) BUILD=false ;;
+    *) echo "Unknown argument: $arg" >&2; exit 1 ;;
+  esac
+done
+
+# ---------------------------------------------------------------------------
+# Verify required tools
+# ---------------------------------------------------------------------------
+for tool in sha256sum awk grep; do
+  if ! command -v "$tool" &>/dev/null; then
+    echo "ERROR: required tool '$tool' not found in PATH" >&2
+    exit 1
+  fi
+done
+
+# ---------------------------------------------------------------------------
+# Verify checksums file exists
+# ---------------------------------------------------------------------------
+if [ ! -f "${CHECKSUMS_FILE}" ]; then
+  echo "ERROR: Reference checksums file not found: ${CHECKSUMS_FILE}" >&2
+  echo "  Run: bash script/update-wasm-checksums.sh" >&2
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Optionally rebuild
+# ---------------------------------------------------------------------------
+if [ "$BUILD" = true ]; then
+  if ! command -v cargo &>/dev/null; then
+    echo "ERROR: cargo not found — cannot rebuild. Use --no-build to skip." >&2
+    exit 1
+  fi
+  echo "Building WASM artifacts (release, wasm32-unknown-unknown)..."
+  cargo build --release --target wasm32-unknown-unknown \
+    --manifest-path "${REPO_ROOT}/Cargo.toml" \
+    -p fluxora_stream
+fi
+
+# ---------------------------------------------------------------------------
+# Verify each entry in checksums file
+# ---------------------------------------------------------------------------
+PASS=0
+FAIL=0
+
+while IFS= read -r line; do
+  # Skip comments and blank lines
+  [[ "$line" =~ ^#.*$ || -z "$line" ]] && continue
+
+  EXPECTED_HASH=$(echo "$line" | awk '{print $1}')
+  FILENAME=$(echo "$line" | awk '{print $2}')
+
+  # Map filename to full path
+  WASM_PATH="${REPO_ROOT}/target/wasm32-unknown-unknown/release/${FILENAME}"
+
+  if [ ! -f "${WASM_PATH}" ]; then
+    echo "MISSING  ${FILENAME}"
+    echo "         Expected path: ${WASM_PATH}"
+    FAIL=$((FAIL + 1))
+    continue
+  fi
+
+  ACTUAL_HASH=$(sha256sum "${WASM_PATH}" | awk '{print $1}')
+
+  if [ "${ACTUAL_HASH}" = "${EXPECTED_HASH}" ]; then
+    echo "OK       ${FILENAME}"
+    echo "         ${ACTUAL_HASH}"
+    PASS=$((PASS + 1))
+  else
+    echo "MISMATCH ${FILENAME}"
+    echo "         Expected: ${EXPECTED_HASH}"
+    echo "         Actual:   ${ACTUAL_HASH}"
+    echo ""
+    echo "  The WASM output differs from the committed reference."
+    echo "  If this is an intentional source change, run:"
+    echo "    bash script/update-wasm-checksums.sh"
+    echo "  Then commit the updated wasm/checksums.sha256."
+    FAIL=$((FAIL + 1))
+  fi
+done < "${CHECKSUMS_FILE}"
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "Results: ${PASS} passed, ${FAIL} failed"
+
+if [ "${FAIL}" -gt 0 ]; then
+  echo "FAIL: Build is not reproducible — checksum(s) do not match reference."
+  exit 1
+fi
+
+echo "PASS: All WASM checksums match reference. Build is reproducible."


### PR DESCRIPTION
                                                                                                                                                                                                                                                                                    
  Hardens the deterministic WASM build verification workflow so operators and auditors can reproduce and verify builds reliably.                       
                                                                                                                                                       
  Changes:                                                                                                                                             
                                                                                                                                                       
  - script/update-wasm-checksums.sh — --dry-run flag, required-tool validation, rust-toolchain.toml presence check, multi-contract CONTRACTS map,      
  toolchain channel recorded in header                                                                                                                 
  - script/verify-wasm-checksum.sh — new script; --no-build skips rebuild; clear OK / MISMATCH / MISSING output per artifact; non-zero exit on any     
  failure                                                                                                                                              
  - .github/workflows/ci.yml — verification step now delegates to bash script/verify-wasm-checksum.sh --no-build, removing ~30 lines of duplicated     
  inline shell                                                                                                                                         
  - docs/security.md — expanded reproducible builds section: CI flow, local verification commands, auditor steps, --dry-run usage                      
  - README.md — WASM verification section updated with verify-wasm-checksum.sh commands                                                                
                                                                                                                                                       
  Closes #433                                                                                                                                          
 