### PR TITLE
feat: enable safe closure of cancelled streams after recipient settle…

### DIFF
--- a/contracts/stream/src/lib.rs
+++ b/contracts/stream/src/lib.rs
@@ -2897,9 +2897,29 @@ impl FluxoraStream {
         let stream = load_stream(&env, stream_id)?;
 
         // Only explicitly terminal streams (Completed or Cancelled) can be closed.
-        // Completed: fully withdrawn. Cancelled: refunded and terminated.
         if stream.status != StreamStatus::Completed && stream.status != StreamStatus::Cancelled {
             return Err(ContractError::InvalidState);
+        }
+
+        // For Cancelled streams, prove no claimable balance remains before removing.
+        // Accrual is frozen at cancelled_at; the recipient may still withdraw the frozen amount.
+        // Closing before full settlement would destroy recipient funds.
+        if stream.status == StreamStatus::Cancelled {
+            let cancelled_at = stream.cancelled_at.ok_or(ContractError::InvalidState)?;
+            let accrued = accrual::calculate_accrued_amount_checkpointed(
+                stream.start_time,
+                stream.checkpointed_amount,
+                stream.checkpointed_at,
+                stream.cliff_time,
+                stream.end_time,
+                stream.rate_per_second,
+                stream.deposit_amount,
+                cancelled_at,
+            );
+            let claimable = accrued.saturating_sub(stream.withdrawn_amount).max(0);
+            if claimable > 0 {
+                return Err(ContractError::InvalidState);
+            }
         }
 
         env.events().publish(

--- a/contracts/stream/tests/integration_suite.rs
+++ b/contracts/stream/tests/integration_suite.rs
@@ -3750,3 +3750,168 @@ fn test_batch_withdraw_to_contract_address_fails() {
     let res = ctx.client().try_batch_withdraw_to(&ctx.recipient, &params);
     assert_eq!(res, Err(Ok(fluxora_stream::ContractError::InvalidParams)));
 }
+
+// ---------------------------------------------------------------------------
+// close_completed_stream — cancelled stream settlement tests (issue #439)
+// ---------------------------------------------------------------------------
+
+/// Closing a cancelled stream with remaining claimable balance must fail.
+#[test]
+fn close_cancelled_stream_with_remaining_claim_fails() {
+    let ctx = TestContext::setup();
+    let stream_id = ctx.create_default_stream(); // 1000 tokens, rate=1, end=1000
+
+    // Cancel at t=500 — recipient has 500 tokens to claim
+    ctx.env.ledger().set_timestamp(500);
+    ctx.client().cancel_stream(&stream_id);
+
+    // Attempt to close before recipient withdraws — must fail
+    let result = ctx.client().try_close_completed_stream(&stream_id);
+    assert_eq!(result, Err(Ok(ContractError::InvalidState)));
+
+    // Stream must still exist
+    let stream = ctx.client().get_stream_state(&stream_id);
+    assert_eq!(stream.status, StreamStatus::Cancelled);
+}
+
+/// Closing a cancelled stream after the recipient fully withdraws must succeed.
+#[test]
+fn close_cancelled_stream_after_full_withdrawal_succeeds() {
+    let ctx = TestContext::setup();
+    let stream_id = ctx.create_default_stream();
+
+    ctx.env.ledger().set_timestamp(500);
+    ctx.client().cancel_stream(&stream_id);
+
+    // Recipient withdraws the frozen 500 tokens
+    ctx.client().withdraw(&stream_id);
+    assert_eq!(ctx.token.balance(&ctx.recipient), 500);
+
+    // Now close is allowed
+    ctx.client().close_completed_stream(&stream_id);
+
+    // Stream must be gone
+    let result = ctx.client().try_get_stream_state(&stream_id);
+    assert_eq!(result, Err(Ok(ContractError::StreamNotFound)));
+}
+
+/// Closing a cancelled stream with zero accrual (cancelled before cliff) succeeds immediately.
+#[test]
+fn close_cancelled_stream_before_cliff_no_claim_needed() {
+    let ctx = TestContext::setup();
+
+    // Stream with cliff at t=500
+    ctx.env.ledger().set_timestamp(0);
+    let stream_id = ctx.client().create_stream(
+        &ctx.sender,
+        &ctx.recipient,
+        &1000_i128,
+        &1_i128,
+        &0u64,
+        &500u64, // cliff
+        &1000u64,
+    );
+
+    // Cancel at t=100 — before cliff, so accrued=0, claimable=0
+    ctx.env.ledger().set_timestamp(100);
+    ctx.client().cancel_stream(&stream_id);
+
+    // Close immediately — no withdrawal needed
+    ctx.client().close_completed_stream(&stream_id);
+
+    let result = ctx.client().try_get_stream_state(&stream_id);
+    assert_eq!(result, Err(Ok(ContractError::StreamNotFound)));
+}
+
+/// Closing a cancelled stream after partial withdrawal fails if balance remains.
+#[test]
+fn close_cancelled_stream_partial_withdrawal_fails() {
+    let ctx = TestContext::setup();
+    let stream_id = ctx.create_default_stream();
+
+    ctx.env.ledger().set_timestamp(600);
+    ctx.client().cancel_stream(&stream_id);
+
+    // Recipient withdraws only 300 of the 600 frozen tokens
+    // (simulate by advancing time to 300 and withdrawing, then cancelling at 600)
+    // Re-create scenario: cancel at 600, withdraw at 600 gets 600 tokens
+    // For partial: we need a stream where recipient withdraws before cancel
+    // Use a fresh stream: withdraw 200 at t=200, cancel at t=600 → claimable=400
+    let ctx2 = TestContext::setup();
+    let sid2 = ctx2.create_default_stream();
+
+    ctx2.env.ledger().set_timestamp(200);
+    ctx2.client().withdraw(&sid2); // withdraw 200
+
+    ctx2.env.ledger().set_timestamp(600);
+    ctx2.client().cancel_stream(&sid2); // accrued=600, withdrawn=200, claimable=400
+
+    // Close must fail — 400 tokens still claimable
+    let result = ctx2.client().try_close_completed_stream(&sid2);
+    assert_eq!(result, Err(Ok(ContractError::InvalidState)));
+}
+
+/// Closing a cancelled stream after full withdrawal removes recipient index entry.
+#[test]
+fn close_cancelled_stream_removes_recipient_index() {
+    let ctx = TestContext::setup();
+    let stream_id = ctx.create_default_stream();
+
+    ctx.env.ledger().set_timestamp(500);
+    ctx.client().cancel_stream(&stream_id);
+    ctx.client().withdraw(&stream_id);
+
+    // Confirm stream is in recipient index before close
+    let streams_before = ctx.client().get_recipient_streams(&ctx.recipient);
+    assert!(streams_before.contains(stream_id));
+
+    ctx.client().close_completed_stream(&stream_id);
+
+    // Confirm stream removed from recipient index
+    let streams_after = ctx.client().get_recipient_streams(&ctx.recipient);
+    assert!(!streams_after.contains(stream_id));
+}
+
+/// Closing a completed (not cancelled) stream is unaffected by the new guard.
+#[test]
+fn close_completed_stream_still_works() {
+    let ctx = TestContext::setup();
+    let stream_id = ctx.create_default_stream();
+
+    ctx.env.ledger().set_timestamp(1000);
+    ctx.client().withdraw(&stream_id); // fully drains → Completed
+
+    let stream = ctx.client().get_stream_state(&stream_id);
+    assert_eq!(stream.status, StreamStatus::Completed);
+
+    ctx.client().close_completed_stream(&stream_id);
+
+    let result = ctx.client().try_get_stream_state(&stream_id);
+    assert_eq!(result, Err(Ok(ContractError::StreamNotFound)));
+}
+
+/// Closing an active stream still fails.
+#[test]
+fn close_active_stream_still_fails() {
+    let ctx = TestContext::setup();
+    let stream_id = ctx.create_default_stream();
+
+    let result = ctx.client().try_close_completed_stream(&stream_id);
+    assert_eq!(result, Err(Ok(ContractError::InvalidState)));
+}
+
+/// Idempotency: closing an already-closed cancelled stream returns StreamNotFound.
+#[test]
+fn close_cancelled_stream_double_close_returns_not_found() {
+    let ctx = TestContext::setup();
+    let stream_id = ctx.create_default_stream();
+
+    ctx.env.ledger().set_timestamp(500);
+    ctx.client().cancel_stream(&stream_id);
+    ctx.client().withdraw(&stream_id);
+    ctx.client().close_completed_stream(&stream_id);
+
+    // Second close: stream is gone
+    let result = ctx.client().try_close_completed_stream(&stream_id);
+    assert_eq!(result, Err(Ok(ContractError::StreamNotFound)));
+}

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -123,6 +123,7 @@ Extended on every `load_stream()` (read) and `save_stream()` (write), and on eve
 ### TTL implications for operators
 
 - **Active streams**: TTL refreshed on any interaction.
+- **Cancelled streams**: Remain in persistent storage until the recipient withdraws the frozen accrued amount. `close_completed_stream` is blocked while any claimable balance remains. Operators must ensure recipients are notified to withdraw before TTL expiry.
 - **Inactive streams**: May expire after ~7 days with zero interaction. Operators must ensure recipients are notified before TTL expiry.
 - **Expired entries**: Cannot be recovered. Data is permanently lost.
 - **Contract liveness**: Instance storage stays alive as long as any function is called at least once per 7 days.

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -52,6 +52,8 @@ No hidden rules or implementation details are required to understand protocol be
 Terminal states: `Completed`, `Cancelled`. Both may be closed via `close_completed_stream` to reclaim storage and index space. A stream is also considered technically terminal if `ledger.timestamp() >= end_time`.
 In this "time-terminal" state, pause/resume is blocked, but withdrawal is always allowed regardless of previous pause status.
 
+**Cancelled stream closure rule**: A `Cancelled` stream may only be closed after the recipient has fully withdrawn the frozen accrued amount. Attempting to close a `Cancelled` stream with remaining claimable balance returns `ContractError::InvalidState`. This prevents storage cleanup from destroying recipient funds.
+
 ### Cancellation Semantics (Issue Scope)
 
 This section is the protocol-level contract for `cancel_stream` and `cancel_stream_as_admin`.
@@ -882,6 +884,7 @@ errors relevant to stream creation and timing.
 | `ContractError::InvalidState` (2)                                       | `withdraw`                         | Withdraw from non-terminal paused             |
 | `ContractError::InvalidState` (2)                                       | `cancel_stream`                    | Cancel completed/cancelled                    |
 | `"invalid state for stream closure"`                                    | `close_completed_stream`           | Close non-terminal (Active/Paused) stream    |
+| `ContractError::InvalidState` (2)                                       | `close_completed_stream`           | Close Cancelled stream with remaining claimable balance |
 | `"contract not initialised: missing config"`                            | Functions requiring config         | Config missing                                |
 
 ## Error Reference


### PR DESCRIPTION
                                                               
                                                                                                                                                       
                                                                                                                                                                                                                                                                                        
  Prevents close_completed_stream from removing a Cancelled stream while the recipient still has a claimable balance, eliminating the risk of          
  destroying recipient funds during storage cleanup.                                                                                                   
                                                                                                                                                       
  Contract change (contracts/stream/src/lib.rs):                                                                                                       
                                                                                                                                                       
  For Cancelled streams, close_completed_stream now computes:                                                                                          
                                                                                                                                                       
  accrued = calculate_accrued_amount_checkpointed(..., cancelled_at)                                                                                   
  claimable = accrued − withdrawn_amount                                                                                                               
                                                                                                                                                       
  Returns ContractError::InvalidState if claimable > 0. Completed streams are unaffected.                                                              
                                                                                                                                                       
  Tests (contracts/stream/tests/integration_suite.rs):                                                                                                 
                                                                                                                                                       
  - Cancelled with remaining claim → InvalidState                                                                                                      
  - Cancelled, fully withdrawn → close succeeds, storage removed                                                                                       
  - Cancelled before cliff (zero accrual) → close succeeds immediately                                                                                 
  - Cancelled after partial withdrawal → InvalidState                                                                                                  
  - Close removes recipient index entry                                                                                                                
  - Completed stream close unaffected                                                                                                                  
  - Active stream close still fails                                                                                                                    
  - Double-close returns StreamNotFound                                                                                                                
                                                                                                                                                       
  Docs:                                                                                                                                                
                                                                                                                                                       
  - docs/streaming.md — terminal states section documents the settlement requirement; error table updated                                              
  - docs/storage.md — TTL implications note that cancelled streams stay in storage until recipient withdraws                                           
                                                                                                                                                       
  Closes #439  