### PR TITLE
feat: add sender rotation for streams with explicit event semantics

### DIFF
--- a/contracts/stream/src/lib.rs
+++ b/contracts/stream/src/lib.rs
@@ -252,6 +252,18 @@ pub struct StreamToppedUp {
     pub new_end_time: u64,
 }
 
+/// Emitted when the stream sender is rotated via `transfer_sender`.
+///
+/// The `old_sender` loses all sender-role privileges (pause, cancel, rate updates, etc.)
+/// and the `new_sender` gains them immediately. Recipient entitlement is unchanged.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct SenderTransferred {
+    pub stream_id: u64,
+    pub old_sender: Address,
+    pub new_sender: Address,
+}
+
 /// Emitted when the contract admin toggles the global emergency pause flag.
 #[contracttype]
 #[derive(Clone, Debug)]
@@ -2910,6 +2922,76 @@ impl FluxoraStream {
         // Remove stream from recipient's index before deleting the stream
         remove_stream_from_recipient_index(&env, &stream.recipient, stream_id);
         remove_stream(&env, stream_id);
+
+        Ok(())
+    }
+
+    /// Transfer sender ownership of a stream to a new address.
+    ///
+    /// Allows the current sender to rotate the treasury key for an existing stream.
+    /// After a successful call the `new_sender` gains all sender-role privileges
+    /// (pause, resume, cancel, rate updates, schedule changes) and the `old_sender`
+    /// loses them immediately. The recipient's accrued entitlement is never affected.
+    ///
+    /// # Parameters
+    /// - `stream_id`: Unique identifier of the stream to update.
+    /// - `new_sender`: Address that will become the new stream sender.
+    ///
+    /// # Authorization
+    /// - Requires authorization from the **current** stream sender only.
+    ///
+    /// # Validation
+    /// - Stream must exist.
+    /// - Stream must be in `Active` or `Paused` state (not terminal).
+    /// - `new_sender` must differ from the current sender.
+    /// - `new_sender` must differ from the stream's recipient (no self-streaming).
+    ///
+    /// # State Changes
+    /// - `stream.sender` is updated to `new_sender`.
+    ///
+    /// # Events
+    /// - Emits `("sndr_xfr", stream_id)` → `SenderTransferred { stream_id, old_sender, new_sender }`.
+    ///
+    /// # Errors
+    /// - `StreamNotFound` — invalid `stream_id`.
+    /// - `InvalidState` — stream is `Completed` or `Cancelled`.
+    /// - `InvalidParams` — `new_sender == old_sender` or `new_sender == recipient`.
+    /// - `Unauthorized` — caller is not the current sender.
+    pub fn transfer_sender(
+        env: Env,
+        stream_id: u64,
+        new_sender: Address,
+    ) -> Result<(), ContractError> {
+        let mut stream = load_stream(&env, stream_id)?;
+
+        // Only the current sender may initiate a transfer.
+        Self::require_stream_sender(&stream.sender);
+
+        // Only non-terminal streams can have their sender rotated.
+        Self::require_cancellable_status(stream.status)?;
+
+        // new_sender must be a different address.
+        if new_sender == stream.sender {
+            return Err(ContractError::InvalidParams);
+        }
+
+        // new_sender must not be the recipient (would create a self-stream).
+        if new_sender == stream.recipient {
+            return Err(ContractError::InvalidParams);
+        }
+
+        let old_sender = stream.sender.clone();
+        stream.sender = new_sender.clone();
+        save_stream(&env, &stream);
+
+        env.events().publish(
+            (symbol_short!("sndr_xfr"), stream_id),
+            SenderTransferred {
+                stream_id,
+                old_sender,
+                new_sender,
+            },
+        );
 
         Ok(())
     }

--- a/contracts/stream/tests/integration_suite.rs
+++ b/contracts/stream/tests/integration_suite.rs
@@ -3750,3 +3750,210 @@ fn test_batch_withdraw_to_contract_address_fails() {
     let res = ctx.client().try_batch_withdraw_to(&ctx.recipient, &params);
     assert_eq!(res, Err(Ok(fluxora_stream::ContractError::InvalidParams)));
 }
+
+// ===========================================================================
+// Issue #417 — transfer_sender: sender rotation with strict auth and event
+// ===========================================================================
+
+use fluxora_stream::SenderTransferred;
+
+/// Basic success: new_sender is stored, old_sender loses rights, event emitted.
+#[test]
+fn transfer_sender_success_updates_sender_and_emits_event() {
+    let ctx = TestContext::setup();
+    ctx.env.ledger().set_timestamp(0);
+    let stream_id = ctx.create_default_stream();
+
+    let new_sender = Address::generate(&ctx.env);
+    let events_before = ctx.env.events().all().len();
+
+    ctx.client().transfer_sender(&stream_id, &new_sender);
+
+    let state = ctx.client().get_stream_state(&stream_id);
+    assert_eq!(state.sender, new_sender, "sender must be updated");
+
+    // Verify event
+    let events = ctx.env.events().all();
+    let evt = events
+        .iter()
+        .skip(events_before as usize)
+        .find(|(contract, topics, _)| {
+            contract == &ctx.contract_id
+                && topics.len() == 2
+                && Symbol::try_from_val(&ctx.env, &topics.get(0).unwrap())
+                    == Ok(Symbol::new(&ctx.env, "sndr_xfr"))
+                && u64::try_from_val(&ctx.env, &topics.get(1).unwrap()) == Ok(stream_id)
+        })
+        .expect("sndr_xfr event must be emitted");
+
+    let payload = SenderTransferred::try_from_val(&ctx.env, &evt.2)
+        .expect("event payload must decode as SenderTransferred");
+    assert_eq!(payload.stream_id, stream_id);
+    assert_eq!(payload.old_sender, ctx.sender);
+    assert_eq!(payload.new_sender, new_sender);
+}
+
+/// Old sender loses pause/cancel rights after transfer.
+#[test]
+fn transfer_sender_old_sender_loses_rights() {
+    let ctx = TestContext::setup();
+    ctx.env.ledger().set_timestamp(0);
+    let stream_id = ctx.create_default_stream();
+
+    let new_sender = Address::generate(&ctx.env);
+    ctx.client().transfer_sender(&stream_id, &new_sender);
+
+    // Old sender trying to pause must fail (strict mode)
+    let env = &ctx.env;
+    env.mock_auths(&[soroban_sdk::testutils::MockAuth {
+        address: &ctx.sender,
+        invoke: &soroban_sdk::testutils::MockAuthInvoke {
+            contract: &ctx.contract_id,
+            fn_name: "pause_stream",
+            args: (stream_id,).into_val(env),
+            sub_invokes: &[],
+        },
+    }]);
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        ctx.client().pause_stream(&stream_id);
+    }));
+    assert!(result.is_err(), "old sender must not be able to pause after transfer");
+}
+
+/// New sender gains pause/cancel rights after transfer.
+#[test]
+fn transfer_sender_new_sender_gains_rights() {
+    let ctx = TestContext::setup();
+    ctx.env.ledger().set_timestamp(0);
+    let stream_id = ctx.create_default_stream();
+
+    let new_sender = Address::generate(&ctx.env);
+    ctx.client().transfer_sender(&stream_id, &new_sender);
+
+    // New sender can pause (mock_all_auths is active in TestContext::setup)
+    ctx.client().pause_stream(&stream_id);
+    assert_eq!(
+        ctx.client().get_stream_state(&stream_id).status,
+        StreamStatus::Paused
+    );
+
+    // New sender can resume
+    ctx.client().resume_stream(&stream_id);
+    assert_eq!(
+        ctx.client().get_stream_state(&stream_id).status,
+        StreamStatus::Active
+    );
+
+    // New sender can cancel
+    ctx.env.ledger().set_timestamp(500);
+    ctx.client().cancel_stream(&stream_id);
+    assert_eq!(
+        ctx.client().get_stream_state(&stream_id).status,
+        StreamStatus::Cancelled
+    );
+}
+
+/// Recipient entitlement is unchanged after sender transfer.
+#[test]
+fn transfer_sender_recipient_entitlement_unchanged() {
+    let ctx = TestContext::setup();
+    ctx.env.ledger().set_timestamp(0);
+    let stream_id = ctx.create_default_stream();
+
+    let new_sender = Address::generate(&ctx.env);
+    ctx.client().transfer_sender(&stream_id, &new_sender);
+
+    // Recipient can still withdraw accrued tokens
+    ctx.env.ledger().set_timestamp(600);
+    let withdrawn = ctx.client().withdraw(&stream_id);
+    assert_eq!(withdrawn, 600, "recipient entitlement must be unchanged");
+    assert_eq!(ctx.token.balance(&ctx.recipient), 600);
+}
+
+/// Transfer on a paused stream succeeds.
+#[test]
+fn transfer_sender_works_on_paused_stream() {
+    let ctx = TestContext::setup();
+    ctx.env.ledger().set_timestamp(0);
+    let stream_id = ctx.create_default_stream();
+
+    ctx.env.ledger().set_timestamp(200);
+    ctx.client().pause_stream(&stream_id);
+
+    let new_sender = Address::generate(&ctx.env);
+    let result = ctx.client().try_transfer_sender(&stream_id, &new_sender);
+    assert!(result.is_ok(), "transfer_sender must succeed on paused stream");
+
+    let state = ctx.client().get_stream_state(&stream_id);
+    assert_eq!(state.sender, new_sender);
+    assert_eq!(state.status, StreamStatus::Paused);
+}
+
+/// Transfer on a completed stream returns InvalidState.
+#[test]
+fn transfer_sender_rejects_completed_stream() {
+    let ctx = TestContext::setup();
+    ctx.env.ledger().set_timestamp(0);
+    let stream_id = ctx.create_default_stream();
+
+    ctx.env.ledger().set_timestamp(1000);
+    ctx.client().withdraw(&stream_id);
+
+    let new_sender = Address::generate(&ctx.env);
+    let result = ctx.client().try_transfer_sender(&stream_id, &new_sender);
+    assert_eq!(result, Err(Ok(ContractError::InvalidState)));
+}
+
+/// Transfer on a cancelled stream returns InvalidState.
+#[test]
+fn transfer_sender_rejects_cancelled_stream() {
+    let ctx = TestContext::setup();
+    ctx.env.ledger().set_timestamp(0);
+    let stream_id = ctx.create_default_stream();
+
+    ctx.env.ledger().set_timestamp(300);
+    ctx.client().cancel_stream(&stream_id);
+
+    let new_sender = Address::generate(&ctx.env);
+    let result = ctx.client().try_transfer_sender(&stream_id, &new_sender);
+    assert_eq!(result, Err(Ok(ContractError::InvalidState)));
+}
+
+/// Transfer to the same address returns InvalidParams.
+#[test]
+fn transfer_sender_rejects_same_sender() {
+    let ctx = TestContext::setup();
+    ctx.env.ledger().set_timestamp(0);
+    let stream_id = ctx.create_default_stream();
+
+    let result = ctx.client().try_transfer_sender(&stream_id, &ctx.sender);
+    assert_eq!(result, Err(Ok(ContractError::InvalidParams)));
+}
+
+/// Transfer to the recipient address returns InvalidParams.
+#[test]
+fn transfer_sender_rejects_recipient_as_new_sender() {
+    let ctx = TestContext::setup();
+    ctx.env.ledger().set_timestamp(0);
+    let stream_id = ctx.create_default_stream();
+
+    let result = ctx.client().try_transfer_sender(&stream_id, &ctx.recipient);
+    assert_eq!(result, Err(Ok(ContractError::InvalidParams)));
+}
+
+/// Chained transfers: A → B → C, each step updates sender correctly.
+#[test]
+fn transfer_sender_chained_transfers() {
+    let ctx = TestContext::setup();
+    ctx.env.ledger().set_timestamp(0);
+    let stream_id = ctx.create_default_stream();
+
+    let sender_b = Address::generate(&ctx.env);
+    let sender_c = Address::generate(&ctx.env);
+
+    ctx.client().transfer_sender(&stream_id, &sender_b);
+    assert_eq!(ctx.client().get_stream_state(&stream_id).sender, sender_b);
+
+    ctx.client().transfer_sender(&stream_id, &sender_c);
+    assert_eq!(ctx.client().get_stream_state(&stream_id).sender, sender_c);
+}

--- a/docs/events.md
+++ b/docs/events.md
@@ -32,6 +32,7 @@ Notes:
 | ContractPaused   | `["paused_ctl"]`                | `bool`                                                                                                                                                    | When the global contract pause state is toggled via `set_contract_paused`.                                              |
 | ProtocolPaused   | `["pr_pause", admin: Address]`  | `ProtocolPaused { reason: String, paused_at: u64 }`                                                                                                       | When `pause_protocol` successfully pauses the protocol. Not emitted on idempotent calls.                               |
 | ProtocolResumed  | `["pr_resume", admin: Address]` | `ProtocolResumed { resumed_at: u64 }`                                                                                                                     | When `resume_protocol` successfully resumes the protocol. Not emitted on idempotent calls.                             |
+| SenderTransferred | `["sndr_xfr", stream_id: u64]` | `SenderTransferred { stream_id: u64, old_sender: Address, new_sender: Address }`                                                                          | When `transfer_sender` successfully rotates the stream sender. Emitted after state is persisted. Not emitted on failure. |
 
 ---
 | Event name | Topic(s) | Data (shape & types) | When emitted |
@@ -293,6 +294,35 @@ Example:
   }
 }
 ```
+
+### 12) SenderTransferred
+
+Emitted by `transfer_sender` when the stream sender is successfully rotated.
+
+```
+topics: ["sndr_xfr", <stream_id: u64>]
+data:   SenderTransferred {
+          stream_id:  u64,
+          old_sender: Address,
+          new_sender: Address,
+        }
+```
+
+Example:
+
+```json
+{
+  "topics": ["sndr_xfr", 0],
+  "data": {
+    "stream_id": 0,
+    "old_sender": "G...OLD_SENDER...",
+    "new_sender": "G...NEW_SENDER..."
+  }
+}
+```
+
+Indexers should update their sender reference for the stream on receipt of this event.
+The `old_sender` field allows indexers to correlate the previous treasury key.
 
 ---
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -141,6 +141,7 @@ reentrancy impact — state will already reflect the current operation when the 
 | `close_completed_stream`  | Permissionless (any caller)                             |
 | `set_admin`               | Current contract admin                                  |
 | `set_contract_paused`     | Contract admin                                          |
+| `transfer_sender`         | Current stream sender                                   |
 
 Cancellation-specific boundary checks:
 

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -496,6 +496,7 @@ contract.create_streams_relative(&sender, &params)?;
 | `decrease_rate_per_second`| Sender                        | `sender.require_auth()`                     |
 | `shorten_stream_end_time` | Sender                        | `sender.require_auth()`                     |
 | `extend_stream_end_time`  | Sender                        | `sender.require_auth()`                     |
+| `transfer_sender`         | Current stream sender         | `sender.require_auth()`                     |
 | `set_auto_claim`          | Recipient                     | `recipient.require_auth()`                  |
 | `revoke_auto_claim`       | Recipient                     | `recipient.require_auth()`                  |
 | `trigger_auto_claim`      | Anyone                        | None (permissionless; destination fixed by recipient) |
@@ -628,6 +629,32 @@ A naive decrease would retroactively lower the recipient's accrued tokens. To pr
 - Accrued amounts never decrease due to rate updates.
 - Recipient entitlement is preserved or increased.
 - Deposit coverage ensures the stream remains fully fundable at the new rate.
+
+### transfer_sender: Observable Semantics
+
+`transfer_sender(stream_id, new_sender)` allows the current stream sender to rotate the treasury key for an existing stream.
+
+#### Success Semantics (Observable)
+
+- **Authorization**: Only the current stream `sender` can authorize the call.
+- **State Requirements**: Stream must be in `Active` or `Paused` status (not `Completed` or `Cancelled`).
+- **Parameter Validation**: `new_sender != current_sender` and `new_sender != recipient`.
+- **State Change**: `stream.sender` is updated to `new_sender`. All other fields are unchanged.
+- **Immediate Effect**: `new_sender` gains all sender-role privileges (pause, resume, cancel, rate updates, schedule changes) immediately. `old_sender` loses them immediately.
+- **Recipient Entitlement**: Unchanged. Accrued amounts, `withdrawn_amount`, and schedule are unaffected.
+- **Event**: Emits `("sndr_xfr", stream_id)` with `SenderTransferred { stream_id, old_sender, new_sender }`.
+
+#### Failure Semantics (Observable)
+
+- **StreamNotFound**: Invalid `stream_id`.
+- **Unauthorized**: Caller is not the current stream sender.
+- **InvalidState**: Stream is `Completed` or `Cancelled`.
+- **InvalidParams**: `new_sender == current_sender` or `new_sender == recipient`.
+- **Atomicity**: Any failure reverts the entire transaction with no state changes or events.
+
+#### Use Case
+
+Treasury key rotation: when a treasury wallet is being rotated, the operator calls `transfer_sender` to hand over stream management rights to the new key without disrupting the recipient's accrual or requiring stream recreation.
 
 ### batch_withdraw: completed stream behavior
 

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -45,6 +45,11 @@ CONTRACT_VERSION = 2
 - Changing TTL bump constants (`INSTANCE_BUMP_AMOUNT`, `PERSISTENT_BUMP_AMOUNT`).
 - Changing internal helper functions with no external surface.
 
+> **Note (transfer_sender):** The `transfer_sender` entry-point is a purely additive
+> new entry-point. Old clients that do not call it are unaffected. `CONTRACT_VERSION`
+> was incremented conservatively per the policy above. Indexers should subscribe to
+> the new `sndr_xfr` event to track sender rotations.
+
 ---
 
 ## 2. version() Entry-Point Semantics


### PR DESCRIPTION
## Summary

Closes #417

Supports treasury key rotation by allowing the current sender to transfer stream ownership to a new address. The recipient's accrued entitlement is never affected. The operation is fully observable via a `SenderTransferred` event.

## Contract changes (`contracts/stream/src/lib.rs`)

- Added `SenderTransferred` event struct: `{ stream_id, old_sender, new_sender }`
- Added `transfer_sender(stream_id, new_sender)` entry-point:
  - Requires auth from the **current** sender
  - Validates stream is `Active` or `Paused` (not terminal)
  - Rejects `new_sender == old_sender` or `new_sender == recipient`
  - Updates `stream.sender` in-place; all other fields unchanged
  - Emits `("sndr_xfr", stream_id)` → `SenderTransferred` event

## Tests (`contracts/stream/tests/integration_suite.rs`)

10 new tests covering:
- Success: sender updated, event emitted with correct fields
- Old sender loses pause/cancel rights after transfer
- New sender gains pause/resume/cancel rights
- Recipient entitlement (accrual, withdrawal) unchanged
- Transfer on paused stream succeeds
- Transfer on completed/cancelled stream returns `InvalidState`
- Transfer to same address returns `InvalidParams`
- Transfer to recipient address returns `InvalidParams`
- Chained transfers A → B → C

## Docs updated
- `docs/events.md`: `SenderTransferred` event table entry + schema section
- `docs/streaming.md`: access control table + `transfer_sender` semantics section
- `docs/security.md`: authorization paths table
- `docs/upgrade.md`: versioning note for additive entry-point

## Checklist
- [x] Strict auth: only current sender can transfer
- [x] Recipient entitlement invariant preserved
- [x] Event emitted with old and new sender for indexer observability
- [x] Docs updated