### PR TITLE
test: add rate-update boundary tests for forward-only invariant

### DIFF
--- a/contracts/stream/tests/integration_suite.rs
+++ b/contracts/stream/tests/integration_suite.rs
@@ -4,6 +4,7 @@ use fluxora_stream::{
     ContractError, CreateStreamParams, FluxoraStream, FluxoraStreamClient, PauseReason,
     StreamStatus,
 };
+use proptest::prelude::*;
 use soroban_sdk::log;
 use soroban_sdk::{
     testutils::{Address as _, Events, Ledger},
@@ -4329,6 +4330,109 @@ fn snapshot_event_rate_end_topup_recp() {
         soroban_sdk::Symbol::from_val(&ctx.env, &last_event.1.get(0).unwrap()),
         soroban_sdk::symbol_short!("recp_upd")
     );
+}
+
+#[test]
+fn update_rate_rejects_equal_and_zero_rates() {
+    let ctx = TestContext::setup();
+    ctx.env.ledger().set_timestamp(0);
+    let stream_id = ctx.create_default_stream();
+
+    let equal_rate_result = ctx
+        .client()
+        .try_update_rate_per_second(&stream_id, &1_i128);
+    assert_eq!(equal_rate_result, Err(Ok(ContractError::InvalidParams)));
+
+    let zero_rate_result = ctx
+        .client()
+        .try_update_rate_per_second(&stream_id, &0_i128);
+    assert_eq!(zero_rate_result, Err(Ok(ContractError::InvalidParams)));
+}
+
+#[test]
+fn update_rate_accepts_maximum_i128_rate() {
+    let ctx = TestContext::setup();
+    ctx.env.ledger().set_timestamp(0);
+
+    let stream_id = ctx.client().create_stream(
+        &ctx.sender,
+        &ctx.recipient,
+        &i128::MAX,
+        &1_i128,
+        &0u64,
+        &0u64,
+        &1u64,
+        &0,
+        &None,
+    );
+
+    ctx.client().update_rate_per_second(&stream_id, &i128::MAX);
+    let state = ctx.client().get_stream_state(&stream_id);
+    assert_eq!(state.rate_per_second, i128::MAX);
+    assert_eq!(state.status, StreamStatus::Active);
+}
+
+#[test]
+fn update_rate_on_paused_stream_is_allowed() {
+    let ctx = TestContext::setup();
+    ctx.env.ledger().set_timestamp(0);
+    let stream_id = ctx.create_default_stream();
+
+    ctx.client()
+        .pause_stream(&stream_id, &PauseReason::Operational);
+    ctx.client().update_rate_per_second(&stream_id, &2_i128);
+
+    let state = ctx.client().get_stream_state(&stream_id);
+    assert_eq!(state.status, StreamStatus::Paused);
+    assert_eq!(state.rate_per_second, 2_i128);
+}
+
+#[test]
+fn update_rate_rejected_on_cancelled_stream() {
+    let ctx = TestContext::setup();
+    ctx.env.ledger().set_timestamp(0);
+    let stream_id = ctx.create_default_stream();
+
+    ctx.client().cancel_stream(&stream_id);
+    let result = ctx
+        .client()
+        .try_update_rate_per_second(&stream_id, &2_i128);
+    assert_eq!(result, Err(Ok(ContractError::InvalidState)));
+}
+
+proptest::proptest! {
+    #[test]
+    fn update_rate_accepts_monotonic_increase_sequences(
+        mut rates in proptest::collection::vec(1_i128..1000, 2..6)
+    ) {
+        rates.sort();
+        rates.dedup();
+        proptest::prop_assume!(rates.len() >= 2);
+
+        let ctx = TestContext::setup();
+        ctx.env.ledger().set_timestamp(0);
+
+        let duration = 10u64;
+        let deposit = rates.last().unwrap().checked_mul(duration as i128).unwrap();
+        let stream_id = ctx.client().create_stream(
+            &ctx.sender,
+            &ctx.recipient,
+            &deposit,
+            &rates[0],
+            &0u64,
+            &0u64,
+            &duration,
+            &0,
+            &None,
+        );
+
+        for &next_rate in rates.iter().skip(1) {
+            ctx.client().update_rate_per_second(&stream_id, &next_rate);
+            let state = ctx.client().get_stream_state(&stream_id);
+            proptest::prop_assert_eq!(state.rate_per_second, next_rate);
+            proptest::prop_assert!(state.status == StreamStatus::Active || state.status == StreamStatus::Paused);
+        }
+    }
 }
 
 #[test]

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -677,6 +677,7 @@ A naive decrease would retroactively lower the recipient's accrued tokens. To pr
 - **Unauthorized**: Caller is not the stream sender.
 - **InvalidState**: Stream is `Completed` or `Cancelled`.
 - **InvalidParams**: `new_rate_per_second <= 0` or `new_rate_per_second <= old_rate`.
+  - This includes the boundary cases where the proposed rate is equal to the current rate or zero.
 - **InsufficientDeposit**: `deposit_amount < new_rate_per_second * (end_time - start_time)`.
 - **Atomicity**: Any failure reverts the entire transaction with no state changes or events.
 

--- a/docs/test-coverage.md
+++ b/docs/test-coverage.md
@@ -7,6 +7,8 @@ Every pull request and push to `main`/`develop` must meet this threshold or the 
 
 Current baseline: **96.4%** (644/668 lines — see `coverage/cobertura.xml`).
 
+> New stream contract coverage includes boundary tests for `update_rate_per_second`: rejecting equal and zero rates, accepting `i128::MAX` when deposit coverage holds, allowing paused-stream updates, rejecting cancelled streams, and exercising monotonic rate sequences with `proptest`.
+
 ---
 
 ## Running Coverage Locally


### PR DESCRIPTION
Closes #524

---

Adds comprehensive boundary coverage for `update_rate_per_second` in the stream contract.

- Rejects equal-rate and zero-rate updates
- Accepts `i128::MAX` when the deposit coverage allows it
- Allows rate updates on paused streams
- Rejects rate updates on cancelled streams
- Adds property-based `proptest` coverage for monotonic increasing rate sequences

Also updates `docs/streaming.md` and `docs/test-coverage.md` with the new invariant behavior and coverage notes.