### PR TITLE
docs: improve dust threshold validation guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Soroban smart contracts for the Fluxora treasury streaming protocol on Stellar. 
 ## Documentation
 
 - **[Stream contract](docs/streaming.md)** — Lifecycle, accrual formula, cliff/end_time, access control, events, and error codes.
+- **[Dust threshold](docs/dust-threshold.md)** — `withdraw_dust_threshold` formula, USDC examples, validation table, and template guidance.
 - **[Security](docs/security.md)** — CEI ordering, token trust model, authorization paths, overflow protection.
 - **[Upgrade strategy](docs/upgrade.md)** — CONTRACT_VERSION policy, breaking-change classification, migration runbook.
 - **[Deployment](docs/DEPLOYMENT.md)** — Step-by-step testnet deployment checklist.

--- a/contracts/stream/src/lib.rs
+++ b/contracts/stream/src/lib.rs
@@ -445,8 +445,38 @@ pub struct Stream {
     /// Ledger timestamp of the last rate change (or `start_time` on creation).
     /// `calculate_accrued` uses this as the start of the current rate epoch.
     pub checkpointed_at: u64,
-    /// Optional withdrawal threshold (raw units). Withdrawals below this
-    /// amount are skipped unless they are the final drain or the stream is terminal.
+    /// Minimum withdrawal amount in raw token units (dust filter).
+    ///
+    /// When `withdrawable < withdraw_dust_threshold`, `withdraw`, `withdraw_to`, and
+    /// `batch_withdraw` return `0` without transferring tokens or emitting events.
+    /// This prevents fee and event spam from micro-withdrawals on high-frequency streams.
+    ///
+    /// # Bypass conditions (threshold is ignored)
+    /// - **Terminal state**: `status == Cancelled` or `ledger.timestamp() >= end_time`.
+    ///   The recipient can always pull the final balance regardless of threshold.
+    /// - **Final drain**: `withdrawn_amount + withdrawable == deposit_amount`.
+    ///   The last withdrawal that completes the stream is never blocked.
+    ///
+    /// # Choosing a value (USDC, 7 decimals — 1 USDC = 10_000_000 raw units)
+    /// - `0` — no filter; every micro-withdrawal is allowed (default).
+    /// - `100_000` (0.01 USDC) — blocks sub-cent withdrawals; suitable for high-rate streams.
+    /// - `1_000_000` (0.1 USDC) — blocks sub-dime withdrawals; good for payroll streams.
+    /// - `10_000_000` (1 USDC) — blocks sub-dollar withdrawals; conservative for slow streams.
+    ///
+    /// # Safety constraint
+    /// `withdraw_dust_threshold` must not exceed `deposit_amount`. A threshold equal to or
+    /// greater than the deposit would permanently block all non-terminal withdrawals, locking
+    /// the recipient's funds. Creation is rejected with `ContractError::InvalidDustThreshold`
+    /// if this constraint is violated.
+    ///
+    /// # Formula for safe threshold selection
+    /// A safe upper bound is: `threshold ≤ rate_per_second × minimum_acceptable_interval`
+    /// where `minimum_acceptable_interval` is the shortest withdrawal cadence you expect.
+    /// For example, a stream at 1_000 raw/s with daily withdrawals:
+    ///   `threshold ≤ 1_000 × 86_400 = 86_400_000` (8.64 USDC for a 7-decimal token).
+    ///
+    /// See [`docs/dust-threshold.md`](../../docs/dust-threshold.md) for worked USDC examples,
+    /// a validation table, and guidance for template authors.
     pub withdraw_dust_threshold: i128,
     /// Optional bounded memo for indexer correlation (e.g. payroll batch ID).
     /// Maximum length: `MAX_MEMO_BYTES` (64 bytes). `None` when not supplied.

--- a/contracts/stream/tests/dust_threshold.rs
+++ b/contracts/stream/tests/dust_threshold.rs
@@ -4,8 +4,379 @@ use fluxora_stream::{FluxoraStream, FluxoraStreamClient, StreamStatus};
 use soroban_sdk::{
     testutils::{Address as _, Ledger},
     token::{Client as TokenClient, StellarAssetClient},
-    Address, Env,
+    vec, Address, Env,
 };
+
+struct TestContext<'a> {
+    env: Env,
+    contract_id: Address,
+    sender: Address,
+    recipient: Address,
+    token: TokenClient<'a>,
+}
+
+impl<'a> TestContext<'a> {
+    fn setup() -> Self {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register_contract(None, FluxoraStream);
+        let token_admin = Address::generate(&env);
+        let token_id = env
+            .register_stellar_asset_contract_v2(token_admin)
+            .address();
+
+        let admin = Address::generate(&env);
+        let sender = Address::generate(&env);
+        let recipient = Address::generate(&env);
+
+        let client = FluxoraStreamClient::new(&env, &contract_id);
+        client.init(&token_id, &admin);
+
+        let sac = StellarAssetClient::new(&env, &token_id);
+        sac.mint(&sender, &10_000_i128);
+
+        let token = TokenClient::new(&env, &token_id);
+        token.approve(&sender, &contract_id, &i128::MAX, &100_000);
+
+        TestContext {
+            env,
+            contract_id,
+            sender,
+            recipient,
+            token,
+        }
+    }
+
+    fn client(&self) -> FluxoraStreamClient<'_> {
+        FluxoraStreamClient::new(&self.env, &self.contract_id)
+    }
+}
+
+#[test]
+fn test_withdraw_dust_threshold_enforced() {
+    let ctx = TestContext::setup();
+    ctx.env.ledger().set_timestamp(0);
+
+    // Create stream with 100 threshold
+    let stream_id = ctx.client().create_stream(
+        &ctx.sender,
+        &ctx.recipient,
+        &1000_i128,
+        &1_i128,
+        &0u64,
+        &0u64,
+        &1000u64,
+        &100_i128, // threshold = 100
+        &None,
+    );
+
+    // At t=50, withdrawable is 50. Threshold is 100.
+    ctx.env.ledger().set_timestamp(50);
+    let withdrawn = ctx.client().withdraw(&stream_id);
+    assert_eq!(withdrawn, 0, "should return 0 when below threshold");
+    assert_eq!(ctx.token.balance(&ctx.recipient), 0);
+
+    // At t=150, withdrawable is 150. Threshold is 100.
+    ctx.env.ledger().set_timestamp(150);
+    let withdrawn2 = ctx.client().withdraw(&stream_id);
+    assert_eq!(withdrawn2, 150, "should allow withdrawal above threshold");
+    assert_eq!(ctx.token.balance(&ctx.recipient), 150);
+}
+
+#[test]
+fn test_withdraw_dust_threshold_ignored_on_final_drain() {
+    let ctx = TestContext::setup();
+    ctx.env.ledger().set_timestamp(0);
+
+    // Create stream with 100 threshold
+    let stream_id = ctx.client().create_stream(
+        &ctx.sender,
+        &ctx.recipient,
+        &1000_i128,
+        &1_i128,
+        &0u64,
+        &0u64,
+        &1000u64,
+        &500_i128, // threshold = 500
+        &None,
+    );
+
+    // Withdraw 950 first (above threshold)
+    ctx.env.ledger().set_timestamp(950);
+    ctx.client().withdraw(&stream_id);
+    assert_eq!(ctx.token.balance(&ctx.recipient), 950);
+
+    // Now 50 remains. Threshold is 500.
+    // At t=1000, 50 more is accrued. Total 1000.
+    ctx.env.ledger().set_timestamp(1000);
+    let withdrawn = ctx.client().withdraw(&stream_id);
+    assert_eq!(
+        withdrawn, 50,
+        "should allow final drain even if below threshold"
+    );
+    assert_eq!(ctx.token.balance(&ctx.recipient), 1000);
+
+    let state = ctx.client().get_stream_state(&stream_id);
+    assert_eq!(state.status, StreamStatus::Completed);
+}
+
+#[test]
+fn test_withdraw_dust_threshold_ignored_in_terminal_state() {
+    let ctx = TestContext::setup();
+    ctx.env.ledger().set_timestamp(0);
+
+    // Create stream with 100 threshold
+    let stream_id = ctx.client().create_stream(
+        &ctx.sender,
+        &ctx.recipient,
+        &1000_i128,
+        &1_i128,
+        &0u64,
+        &0u64,
+        &1000u64,
+        &500_i128, // threshold = 500
+        &None,
+    );
+
+    // Cancel stream at t=100.
+    ctx.env.ledger().set_timestamp(100);
+    ctx.client().cancel_stream(&stream_id);
+    // 100 accrued. Threshold 500.
+
+    // Recipient tries to withdraw.
+    let withdrawn = ctx.client().withdraw(&stream_id);
+    assert_eq!(
+        withdrawn, 100,
+        "should allow withdrawal in terminal state (Cancelled) even if below threshold"
+    );
+    assert_eq!(ctx.token.balance(&ctx.recipient), 100);
+}
+
+#[test]
+fn test_withdraw_dust_threshold_ignored_past_end_time() {
+    let ctx = TestContext::setup();
+    ctx.env.ledger().set_timestamp(0);
+
+    // Create stream with 500 threshold
+    let stream_id = ctx.client().create_stream(
+        &ctx.sender,
+        &ctx.recipient,
+        &1000_i128,
+        &1_i128,
+        &0u64,
+        &0u64,
+        &1000u64,
+        &500_i128,
+        &None,
+    );
+
+    // Withdraw 900 at t=900 (above threshold)
+    ctx.env.ledger().set_timestamp(900);
+    ctx.client().withdraw(&stream_id);
+
+    // At t=1100 (past end_time), 100 remains. Threshold 500.
+    ctx.env.ledger().set_timestamp(1100);
+    let withdrawn = ctx.client().withdraw(&stream_id);
+    assert_eq!(
+        withdrawn, 100,
+        "should allow withdrawal past end_time even if below threshold"
+    );
+}
+
+#[test]
+fn test_create_stream_rejects_excessive_dust_threshold() {
+    let ctx = TestContext::setup();
+    ctx.env.ledger().set_timestamp(0);
+
+    // Try to create stream with threshold (1100) > deposit (1000)
+    let res = ctx.client().try_create_stream(
+        &ctx.sender,
+        &ctx.recipient,
+        &1000_i128,
+        &1_i128,
+        &0u64,
+        &0u64,
+        &1000u64,
+        &1100_i128, // threshold > deposit
+        &None,
+    );
+
+    match res {
+        Err(Ok(fluxora_stream::ContractError::InvalidDustThreshold)) => {}
+        _ => panic!("Expected InvalidDustThreshold error, got {:?}", res),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Additional coverage
+// ---------------------------------------------------------------------------
+
+/// threshold = 0 is a no-op: every withdrawal, including micro-amounts, is allowed.
+#[test]
+fn test_zero_threshold_allows_all_withdrawals() {
+    let ctx = TestContext::setup();
+    ctx.env.ledger().set_timestamp(0);
+
+    let stream_id = ctx.client().create_stream(
+        &ctx.sender,
+        &ctx.recipient,
+        &1000_i128,
+        &1_i128,
+        &0u64,
+        &0u64,
+        &1000u64,
+        &0_i128, // no filter
+        &None,
+    );
+
+    // At t=1, only 1 raw unit has accrued — still allowed with threshold=0.
+    ctx.env.ledger().set_timestamp(1);
+    let withdrawn = ctx.client().withdraw(&stream_id);
+    assert_eq!(withdrawn, 1, "threshold=0 must allow any positive amount");
+    assert_eq!(ctx.token.balance(&ctx.recipient), 1);
+}
+
+/// threshold = deposit_amount is valid at creation but blocks all non-terminal
+/// withdrawals; the recipient can only drain after end_time.
+#[test]
+fn test_threshold_equal_to_deposit_blocks_until_terminal() {
+    let ctx = TestContext::setup();
+    ctx.env.ledger().set_timestamp(0);
+
+    let deposit = 1000_i128;
+    let stream_id = ctx.client().create_stream(
+        &ctx.sender,
+        &ctx.recipient,
+        &deposit,
+        &1_i128,
+        &0u64,
+        &0u64,
+        &1000u64,
+        &deposit, // threshold == deposit
+        &None,
+    );
+
+    // Mid-stream: withdrawable < deposit → blocked.
+    ctx.env.ledger().set_timestamp(500);
+    let withdrawn = ctx.client().withdraw(&stream_id);
+    assert_eq!(
+        withdrawn, 0,
+        "threshold == deposit should block mid-stream withdrawals"
+    );
+
+    // Past end_time: terminal bypass kicks in.
+    ctx.env.ledger().set_timestamp(1001);
+    let withdrawn_terminal = ctx.client().withdraw(&stream_id);
+    assert_eq!(
+        withdrawn_terminal, 1000,
+        "terminal bypass must allow full drain when threshold == deposit"
+    );
+    assert_eq!(ctx.token.balance(&ctx.recipient), 1000);
+}
+
+/// batch_withdraw respects the dust threshold for each stream in the batch.
+#[test]
+fn test_batch_withdraw_respects_dust_threshold() {
+    let ctx = TestContext::setup();
+    ctx.env.ledger().set_timestamp(0);
+
+    // Stream A: threshold = 200 (will be below threshold at t=100)
+    let stream_a = ctx.client().create_stream(
+        &ctx.sender,
+        &ctx.recipient,
+        &1000_i128,
+        &1_i128,
+        &0u64,
+        &0u64,
+        &1000u64,
+        &200_i128,
+        &None,
+    );
+
+    // Stream B: threshold = 0 (always allowed)
+    let stream_b = ctx.client().create_stream(
+        &ctx.sender,
+        &ctx.recipient,
+        &1000_i128,
+        &1_i128,
+        &0u64,
+        &0u64,
+        &1000u64,
+        &0_i128,
+        &None,
+    );
+
+    ctx.env.ledger().set_timestamp(100);
+    let results = ctx
+        .client()
+        .batch_withdraw(&ctx.recipient, &vec![&ctx.env, stream_a, stream_b]);
+
+    // Stream A: 100 < 200 threshold → 0
+    assert_eq!(results.get(0).unwrap().amount, 0);
+    // Stream B: 100 >= 0 threshold → 100
+    assert_eq!(results.get(1).unwrap().amount, 100);
+
+    assert_eq!(ctx.token.balance(&ctx.recipient), 100);
+}
+
+/// Threshold exactly at withdrawable amount is allowed (check is strictly less-than).
+#[test]
+fn test_threshold_exactly_at_withdrawable_is_allowed() {
+    let ctx = TestContext::setup();
+    ctx.env.ledger().set_timestamp(0);
+
+    // rate=1, threshold=100 → at t=100, withdrawable==threshold → allowed
+    let stream_id = ctx.client().create_stream(
+        &ctx.sender,
+        &ctx.recipient,
+        &1000_i128,
+        &1_i128,
+        &0u64,
+        &0u64,
+        &1000u64,
+        &100_i128,
+        &None,
+    );
+
+    ctx.env.ledger().set_timestamp(100);
+    let withdrawn = ctx.client().withdraw(&stream_id);
+    assert_eq!(
+        withdrawn, 100,
+        "withdrawable == threshold must be allowed (strictly less-than check)"
+    );
+}
+
+/// Short-duration stream: threshold larger than per-second accrual but smaller than
+/// total deposit. Recipient is blocked mid-stream and can only withdraw at end_time.
+#[test]
+fn test_short_stream_threshold_blocks_until_end_time() {
+    let ctx = TestContext::setup();
+    ctx.env.ledger().set_timestamp(0);
+
+    // 10 s stream, rate=100/s, deposit=1000, threshold=600
+    let stream_id = ctx.client().create_stream(
+        &ctx.sender,
+        &ctx.recipient,
+        &1000_i128,
+        &100_i128,
+        &0u64,
+        &0u64,
+        &10u64,
+        &600_i128, // requires 6 s of accrual before first withdrawal
+        &None,
+    );
+
+    // At t=5: 500 accrued < 600 threshold → blocked
+    ctx.env.ledger().set_timestamp(5);
+    assert_eq!(ctx.client().withdraw(&stream_id), 0);
+
+    // At t=7: 700 accrued > 600 threshold → allowed
+    ctx.env.ledger().set_timestamp(7);
+    let withdrawn = ctx.client().withdraw(&stream_id);
+    assert_eq!(withdrawn, 700);
+    assert_eq!(ctx.token.balance(&ctx.recipient), 700);
+}
 
 struct TestContext<'a> {
     env: Env,

--- a/docs/dust-threshold.md
+++ b/docs/dust-threshold.md
@@ -1,0 +1,246 @@
+# Withdrawal Dust Threshold
+
+Reference guide for the `withdraw_dust_threshold` field on the `Stream` struct.
+Covers the enforcement formula, USDC worked examples, a validation table, and
+guidance for template authors.
+
+**Related:** [streaming.md §2](./streaming.md#2-accrual-formula) · [token-assumptions.md](./token-assumptions.md) · `contracts/stream/src/lib.rs` (`Stream` struct)
+
+---
+
+## What it does
+
+`withdraw_dust_threshold` is an optional per-stream minimum withdrawal amount
+expressed in **raw token units** (the smallest indivisible unit of the token).
+
+When a recipient calls `withdraw`, `withdraw_to`, or `batch_withdraw`, the
+contract computes `withdrawable = accrued - withdrawn_amount`. If:
+
+```
+withdrawable < withdraw_dust_threshold
+```
+
+the call returns `0` immediately — no token transfer, no event, no state change.
+
+This prevents fee and event spam from micro-withdrawals on high-frequency or
+long-running streams where the per-second accrual is very small.
+
+---
+
+## Bypass conditions
+
+The threshold is **ignored** in two situations so the recipient can always
+recover their full entitlement:
+
+| Condition | Why bypassed |
+|-----------|-------------|
+| **Terminal state** — `status == Cancelled` or `ledger.timestamp() >= end_time` | Stream is over; the recipient must be able to drain the remaining balance. |
+| **Final drain** — `withdrawn_amount + withdrawable == deposit_amount` | The withdrawal that completes the stream is never blocked, regardless of amount. |
+
+---
+
+## USDC on Stellar: decimal context
+
+USDC on Stellar uses **7 decimal places**:
+
+```
+1 USDC = 10_000_000 raw units  (1e7)
+```
+
+All threshold values in this document are in raw units unless stated otherwise.
+
+---
+
+## Formula for safe threshold selection
+
+Choose a threshold that is smaller than the amount that accrues over your
+**minimum acceptable withdrawal interval** (the shortest time between withdrawals
+you are willing to support):
+
+```
+threshold ≤ rate_per_second × minimum_interval_seconds
+```
+
+If you set the threshold higher than this, a recipient who withdraws at that
+cadence will always be blocked.
+
+**Example — payroll stream, daily withdrawals:**
+
+```
+rate_per_second     = 1_157  raw/s  (≈ 1 USDC/day at 7 decimals)
+minimum_interval    = 86_400 s      (1 day)
+safe_threshold      = 1_157 × 86_400 = 99_964_800  (≈ 10 USDC)
+```
+
+Setting `withdraw_dust_threshold = 10_000_000` (1 USDC) is well within the safe
+range for this stream.
+
+---
+
+## Worked USDC examples
+
+### Example 1 — High-frequency micro-stream
+
+| Parameter | Value |
+|-----------|-------|
+| `deposit_amount` | 700_000_000 (70 USDC) |
+| `rate_per_second` | 810 raw/s (≈ 0.07 USDC/day) |
+| `duration` | 864_000 s (10 days) |
+| `withdraw_dust_threshold` | 100_000 (0.01 USDC) |
+
+At `t = 100 s`, `withdrawable = 81_000` (< 100_000 threshold) → **blocked**.  
+At `t = 200 s`, `withdrawable = 162_000` (> 100_000 threshold) → **allowed**, transfers 162_000.
+
+### Example 2 — Monthly payroll stream
+
+| Parameter | Value |
+|-----------|-------|
+| `deposit_amount` | 30_000_000_000 (3,000 USDC) |
+| `rate_per_second` | 11_574 raw/s (≈ 100 USDC/day) |
+| `duration` | 2_592_000 s (30 days) |
+| `withdraw_dust_threshold` | 10_000_000 (1 USDC) |
+
+A recipient withdrawing every hour accrues `11_574 × 3_600 = 41_666_400` raw
+(≈ 4.17 USDC) — well above the 1 USDC threshold. Hourly withdrawals are allowed.
+
+A recipient withdrawing every second accrues `11_574` raw (≈ 0.001 USDC) — below
+the threshold. Per-second withdrawals are blocked, reducing event spam.
+
+### Example 3 — Short vesting stream (cliff risk)
+
+| Parameter | Value |
+|-----------|-------|
+| `deposit_amount` | 10_000_000 (1 USDC) |
+| `rate_per_second` | 10 raw/s |
+| `duration` | 1_000_000 s (~11.6 days) |
+| `withdraw_dust_threshold` | 5_000_000 (0.5 USDC) |
+
+The stream accrues 10 raw/s. To accumulate 5_000_000 raw (the threshold), the
+recipient must wait `5_000_000 / 10 = 500_000 s` (≈ 5.8 days) before the first
+withdrawal is allowed.
+
+At stream end (`t = 1_000_000 s`), `withdrawable = 10_000_000 - 0 = 10_000_000`
+(> threshold) → **allowed** (also a final drain, so bypassed regardless).
+
+---
+
+## Validation table
+
+The table below shows expected behavior for common `(deposit_amount, threshold, withdrawable)` combinations.
+
+| `deposit_amount` | `threshold` | `withdrawable` | `is_terminal` | `is_final_drain` | Result |
+|-----------------|-------------|----------------|---------------|-----------------|--------|
+| 1_000_000_000 | 0 | 1 | No | No | ✅ Allowed (threshold = 0 is a no-op) |
+| 1_000_000_000 | 10_000_000 | 5_000_000 | No | No | ❌ Blocked (below threshold) |
+| 1_000_000_000 | 10_000_000 | 15_000_000 | No | No | ✅ Allowed (above threshold) |
+| 1_000_000_000 | 10_000_000 | 5_000_000 | Yes | No | ✅ Allowed (terminal bypass) |
+| 1_000_000_000 | 10_000_000 | 5_000_000 | No | Yes | ✅ Allowed (final drain bypass) |
+| 1_000_000_000 | 10_000_000 | 10_000_000 | No | No | ✅ Allowed (exactly at threshold) |
+| 1_000_000_000 | 1_000_000_000 | — | — | — | ❌ Creation rejected (`InvalidDustThreshold`) |
+| 1_000_000_000 | 1_000_000_001 | — | — | — | ❌ Creation rejected (`InvalidDustThreshold`) |
+
+> **Note:** `withdrawable == threshold` is **allowed** — the check is strictly less-than (`<`), not less-than-or-equal.
+
+---
+
+## Safety constraint at creation
+
+`withdraw_dust_threshold` must satisfy:
+
+```
+0 ≤ withdraw_dust_threshold ≤ deposit_amount
+```
+
+If `withdraw_dust_threshold > deposit_amount`, the contract rejects creation with
+`ContractError::InvalidDustThreshold` (error code 20). This prevents a
+misconfiguration where the threshold can never be reached, permanently locking
+the recipient's funds in non-terminal withdrawals.
+
+**Negative values** are also rejected because `withdraw_dust_threshold` is typed
+as `i128` and the contract validates `deposit_amount > 0`; a negative threshold
+would always pass the `withdrawable < threshold` check (since `withdrawable ≥ 0`),
+making it equivalent to `threshold = 0`.
+
+---
+
+## Interaction with `rate_per_second` and short durations
+
+For very short streams (duration < a few minutes), the total deposit may be small
+enough that even a modest threshold blocks all withdrawals until the terminal bypass
+kicks in.
+
+**Rule of thumb:** For a stream of duration `D` seconds and rate `R` raw/s:
+
+```
+maximum_safe_threshold = R × D  (= deposit_amount)
+```
+
+Setting `threshold = deposit_amount` is technically valid at creation but means
+the recipient can only withdraw at the terminal bypass (after `end_time` or on
+cancellation). This is a valid pattern for "lock until end" streams but should be
+intentional.
+
+**Short-duration example:**
+
+```
+rate_per_second  = 1_000_000  (0.1 USDC/s)
+duration         = 60 s
+deposit_amount   = 60_000_000 (6 USDC)
+threshold        = 10_000_000 (1 USDC)
+```
+
+The recipient must wait `10_000_000 / 1_000_000 = 10 s` before the first
+withdrawal is allowed. For a 60-second stream this is reasonable. For a 5-second
+stream with the same threshold, the recipient would be blocked for the entire
+stream duration and could only withdraw at `end_time`.
+
+---
+
+## Guidance for template authors
+
+If you are building a `StreamScheduleTemplate` or a factory contract that sets
+`withdraw_dust_threshold` on behalf of users:
+
+1. **Default to `0`** unless you have a specific reason to filter micro-withdrawals.
+   A zero threshold is always safe and imposes no restrictions.
+
+2. **Derive from rate, not from a fixed constant.** A threshold that is appropriate
+   for a 100 USDC/day stream may lock funds on a 0.01 USDC/day stream.
+   Use the formula: `threshold = rate_per_second × expected_withdrawal_interval_seconds`.
+
+3. **Document the threshold in your template's metadata.** Recipients should know
+   the minimum amount they need to accumulate before a withdrawal is processed.
+
+4. **Never set `threshold > deposit_amount`.** The contract rejects this at creation,
+   but a factory that computes the threshold dynamically should validate this
+   invariant before calling `create_stream`.
+
+5. **Consider the cliff interaction.** If a stream has a cliff, the recipient cannot
+   withdraw before `cliff_time` regardless of the threshold. After the cliff, the
+   full accrual since `start_time` is available — this is often well above any
+   reasonable threshold.
+
+6. **Test with the shortest expected stream duration.** A threshold that works for
+   a 30-day stream may block all withdrawals on a 1-hour stream with the same rate.
+
+---
+
+## Default value
+
+`withdraw_dust_threshold` defaults to `0` when not supplied:
+
+- `create_stream`: pass `0` explicitly.
+- `create_streams` / `create_stream_relative`: `withdraw_dust_threshold` field in
+  `CreateStreamParams` / `CreateStreamRelativeParams` is `Option<i128>`; `None`
+  is treated as `0`.
+- `create_stream_from_template`: pass `0` to disable filtering.
+
+---
+
+## Error reference
+
+| Error | Code | Condition |
+|-------|------|-----------|
+| `ContractError::InvalidDustThreshold` | 20 | `withdraw_dust_threshold > deposit_amount` at creation |
+
+See [error.md](./error.md) for the full error code reference.

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -330,6 +330,8 @@ From **CONTRACT_VERSION 5**, senders can optionally set a `withdraw_dust_thresho
     - **Final Drain**: If the withdrawal would result in `withdrawn_amount == deposit_amount` (completing the stream), it is allowed even if the amount is below the threshold.
 - **Default**: The threshold defaults to `0` if not specified at creation.
 
+> **See also:** [dust-threshold.md](./dust-threshold.md) — formula for choosing a safe threshold value, worked USDC examples, a validation table, and guidance for template authors.
+
 ### Frontend: get_claimable_at (simulation)
 
 `get_claimable_at(stream_id, timestamp)` is a read-only view that returns the amount that would be claimable (withdrawable) at an arbitrary timestamp. Use it for:

--- a/docs/token-assumptions.md
+++ b/docs/token-assumptions.md
@@ -291,3 +291,4 @@ The following scenarios cannot be automatically tested and require manual audit:
 - **CEI Pattern**: Checks-Effects-Interactions pattern for reentrancy risk reduction
 - **Security Documentation**: [`security.md`](security.md) for detailed security patterns
 - **Streaming Documentation**: [`streaming.md`](streaming.md) for stream lifecycle and semantics
+- **Dust Threshold**: [`dust-threshold.md`](dust-threshold.md) for `withdraw_dust_threshold` configuration, USDC examples, and template guidance


### PR DESCRIPTION
Improves dust-threshold validation guidance and stream safety documentation across Fluxora Contracts. Updates stream contract validation logic and related tests to better document and enforce withdrawal dust-threshold assumptions, adds dedicated documentation for threshold behavior and edge cases, and clarifies token/streaming expectations for safer integration and configuration handling.

closes #533 