### PR TITLE
feat: add keeper_cancel entrypoint and minimal governance contract with timelock

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,3 @@
 [workspace]
-members = ["contracts/stream", "contracts/factory"]
+members = ["contracts/stream", "contracts/factory", "contracts/governance"]
 resolver = "2"

--- a/contracts/governance/Cargo.toml
+++ b/contracts/governance/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "fluxora_governance"
+version = "0.1.0"
+edition = "2021"
+description = "Minimal timelock governance contract for Fluxora protocol parameter changes"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+doctest = false
+
+[features]
+testutils = ["soroban-sdk/testutils"]
+
+[dependencies]
+soroban-sdk = "21.7.7"
+
+[dev-dependencies]
+soroban-sdk = { version = "21.7.7", features = ["testutils"] }
+fluxora_factory = { path = "../factory", features = ["testutils"] }

--- a/contracts/governance/src/lib.rs
+++ b/contracts/governance/src/lib.rs
@@ -1,0 +1,549 @@
+#![no_std]
+#![allow(clippy::too_many_arguments)]
+
+use soroban_sdk::{contract, contractimpl, contracttype, contracterror, symbol_short, Address, Bytes, Env, Vec};
+
+// ---------------------------------------------------------------------------
+// Governance constants
+// ---------------------------------------------------------------------------
+
+/// Minimum number of co-signer approvals required before a proposal can execute.
+/// Default: 2-of-N (quorum of 2).
+const GOVERNANCE_QUORUM: u32 = 2;
+
+/// Seconds a proposal must remain unexecuted after reaching quorum before it can
+/// be executed. Default: 48 hours.
+const GOVERNANCE_TIMELOCK_SECONDS: u64 = 172_800;
+
+/// Maximum number of co-signers the governance contract supports.
+const MAX_SIGNERS: u32 = 20;
+
+/// Maximum byte length for proposal calldata payload.
+const MAX_CALLDATA_BYTES: u32 = 4_096;
+
+// ---------------------------------------------------------------------------
+// Data types
+// ---------------------------------------------------------------------------
+
+/// Persistent record of a governance proposal.
+///
+/// `calldata` is stored as an opaque `Bytes` payload whose interpretation is
+/// left to the off-chain executor or to a typed adapter layer.  Storing the
+/// payload on-chain provides a tamper-evident audit trail and enables indexers
+/// to reconstruct the full proposal intent without any additional side-channel.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct Proposal {
+    /// Address that submitted the proposal.
+    pub proposer: Address,
+    /// Target contract whose parameters should be changed upon execution.
+    pub target: Address,
+    /// Opaque calldata encoding the intended function call and arguments.
+    pub calldata: Bytes,
+    /// List of co-signer addresses that have approved this proposal.
+    pub approvals: Vec<Address>,
+    /// Ledger timestamp at which the proposal was submitted.
+    pub created_at: u64,
+    /// True once `execute` has been called successfully.
+    pub executed: bool,
+}
+
+/// Error codes for the governance contract.
+#[contracterror]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(u32)]
+pub enum GovernanceError {
+    /// Contract has not been initialised.
+    NotInitialized = 1,
+    /// Contract is already initialised.
+    AlreadyInitialized = 2,
+    /// Caller is not the admin.
+    Unauthorized = 3,
+    /// Caller is not a registered co-signer.
+    NotASigner = 4,
+    /// Proposal with this ID does not exist.
+    ProposalNotFound = 5,
+    /// Proposal has already been executed.
+    AlreadyExecuted = 6,
+    /// Proposal has not yet accumulated the required number of approvals.
+    QuorumNotReached = 7,
+    /// Timelock period has not elapsed since quorum was first reached.
+    TimelockNotElapsed = 8,
+    /// Signer has already approved this proposal.
+    AlreadyApproved = 9,
+    /// Calldata exceeds MAX_CALLDATA_BYTES.
+    CalldataTooLarge = 10,
+    /// Signer list exceeds MAX_SIGNERS.
+    TooManySigners = 11,
+}
+
+/// Storage keys for the governance contract.
+#[contracttype]
+pub enum DataKey {
+    /// Admin address (instance storage).
+    Admin,
+    /// Registered co-signers list (instance storage).
+    Signers,
+    /// Monotonic proposal ID counter (instance storage).
+    NextProposalId,
+    /// Persistent record for a proposal (persistent storage, keyed by ID).
+    Proposal(u32),
+    /// Ledger timestamp at which a proposal first reached quorum (persistent).
+    QuorumReachedAt(u32),
+}
+
+// ---------------------------------------------------------------------------
+// TTL constants (mirrors stream contract conventions)
+// ---------------------------------------------------------------------------
+
+const INSTANCE_LIFETIME_THRESHOLD: u32 = 17_280;
+const INSTANCE_BUMP_AMOUNT: u32 = 120_960;
+const PERSISTENT_LIFETIME_THRESHOLD: u32 = 17_280;
+const PERSISTENT_BUMP_AMOUNT: u32 = 120_960;
+
+// ---------------------------------------------------------------------------
+// Events
+// ---------------------------------------------------------------------------
+
+/// Emitted when a new proposal is submitted.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct ProposalCreated {
+    pub proposal_id: u32,
+    pub proposer: Address,
+    pub target: Address,
+}
+
+/// Emitted when a co-signer approves a proposal.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct ProposalApproved {
+    pub proposal_id: u32,
+    pub approver: Address,
+    pub approval_count: u32,
+}
+
+/// Emitted when quorum is first reached for a proposal, starting the timelock.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct QuorumReached {
+    pub proposal_id: u32,
+    pub quorum_reached_at: u64,
+    pub executable_after: u64,
+}
+
+/// Emitted when a proposal is executed after quorum and timelock.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct ProposalExecuted {
+    pub proposal_id: u32,
+    pub executor: Address,
+    pub target: Address,
+    pub calldata: Bytes,
+}
+
+// ---------------------------------------------------------------------------
+// Storage helpers
+// ---------------------------------------------------------------------------
+
+fn bump_instance(env: &Env) {
+    env.storage()
+        .instance()
+        .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+}
+
+fn bump_proposal(env: &Env, id: u32) {
+    env.storage().persistent().extend_ttl(
+        &DataKey::Proposal(id),
+        PERSISTENT_LIFETIME_THRESHOLD,
+        PERSISTENT_BUMP_AMOUNT,
+    );
+}
+
+fn get_admin(env: &Env) -> Result<Address, GovernanceError> {
+    bump_instance(env);
+    env.storage()
+        .instance()
+        .get(&DataKey::Admin)
+        .ok_or(GovernanceError::NotInitialized)
+}
+
+fn get_signers(env: &Env) -> Result<Vec<Address>, GovernanceError> {
+    env.storage()
+        .instance()
+        .get(&DataKey::Signers)
+        .ok_or(GovernanceError::NotInitialized)
+}
+
+fn read_next_proposal_id(env: &Env) -> u32 {
+    env.storage()
+        .instance()
+        .get(&DataKey::NextProposalId)
+        .unwrap_or(0u32)
+}
+
+fn increment_proposal_id(env: &Env) -> u32 {
+    let id = read_next_proposal_id(env);
+    env.storage()
+        .instance()
+        .set(&DataKey::NextProposalId, &(id + 1));
+    id
+}
+
+fn load_proposal(env: &Env, id: u32) -> Result<Proposal, GovernanceError> {
+    let proposal: Proposal = env
+        .storage()
+        .persistent()
+        .get(&DataKey::Proposal(id))
+        .ok_or(GovernanceError::ProposalNotFound)?;
+    bump_proposal(env, id);
+    Ok(proposal)
+}
+
+fn save_proposal(env: &Env, id: u32, proposal: &Proposal) {
+    env.storage().persistent().set(&DataKey::Proposal(id), proposal);
+    bump_proposal(env, id);
+}
+
+// ---------------------------------------------------------------------------
+// Contract
+// ---------------------------------------------------------------------------
+
+#[contract]
+pub struct FluxoraGovernance;
+
+#[contractimpl]
+impl FluxoraGovernance {
+    /// Initialise the governance contract with an admin and a list of co-signers.
+    ///
+    /// # Parameters
+    /// - `admin`: Address that can add/remove signers and reset governance state.
+    /// - `signers`: Initial list of co-signers eligible to approve proposals.
+    ///   Must not exceed `MAX_SIGNERS`.
+    ///
+    /// # Errors
+    /// - `AlreadyInitialized`: Contract has already been initialised.
+    /// - `TooManySigners`: Provided signer list exceeds `MAX_SIGNERS`.
+    pub fn init(
+        env: Env,
+        admin: Address,
+        signers: Vec<Address>,
+    ) -> Result<(), GovernanceError> {
+        if env.storage().instance().has(&DataKey::Admin) {
+            return Err(GovernanceError::AlreadyInitialized);
+        }
+        if signers.len() > MAX_SIGNERS {
+            return Err(GovernanceError::TooManySigners);
+        }
+
+        env.storage().instance().set(&DataKey::Admin, &admin);
+        env.storage().instance().set(&DataKey::Signers, &signers);
+        env.storage().instance().set(&DataKey::NextProposalId, &0u32);
+
+        bump_instance(&env);
+        Ok(())
+    }
+
+    /// Update the admin address.
+    ///
+    /// # Authorization
+    /// - Requires admin signature.
+    pub fn set_admin(env: Env, new_admin: Address) -> Result<(), GovernanceError> {
+        get_admin(&env)?.require_auth();
+        env.storage().instance().set(&DataKey::Admin, &new_admin);
+        bump_instance(&env);
+        Ok(())
+    }
+
+    /// Add a co-signer to the governance set.
+    ///
+    /// # Authorization
+    /// - Requires admin signature.
+    ///
+    /// # Errors
+    /// - `TooManySigners`: Adding this signer would exceed `MAX_SIGNERS`.
+    pub fn add_signer(env: Env, signer: Address) -> Result<(), GovernanceError> {
+        get_admin(&env)?.require_auth();
+        let mut signers = get_signers(&env)?;
+        if signers.len() >= MAX_SIGNERS {
+            return Err(GovernanceError::TooManySigners);
+        }
+        signers.push_back(signer);
+        env.storage().instance().set(&DataKey::Signers, &signers);
+        bump_instance(&env);
+        Ok(())
+    }
+
+    /// Remove a co-signer from the governance set.
+    ///
+    /// # Authorization
+    /// - Requires admin signature.
+    pub fn remove_signer(env: Env, signer: Address) -> Result<(), GovernanceError> {
+        get_admin(&env)?.require_auth();
+        let mut signers = get_signers(&env)?;
+        let mut idx: Option<u32> = None;
+        for i in 0..signers.len() {
+            if signers.get(i).unwrap() == signer {
+                idx = Some(i);
+                break;
+            }
+        }
+        if let Some(i) = idx {
+            signers.remove(i);
+            env.storage().instance().set(&DataKey::Signers, &signers);
+            bump_instance(&env);
+        }
+        Ok(())
+    }
+
+    /// Submit a new governance proposal.
+    ///
+    /// Any registered co-signer may propose. The proposer does not automatically
+    /// approve the proposal — they must call `approve` separately.
+    ///
+    /// # Parameters
+    /// - `proposer`: The co-signer submitting the proposal.
+    /// - `target`: The contract address to call when the proposal is executed.
+    /// - `calldata`: Opaque bytes encoding the intended operation (stored for audit).
+    ///
+    /// # Returns
+    /// - The proposal ID assigned to the new proposal (monotonically increasing u32).
+    ///
+    /// # Authorization
+    /// - Requires `proposer.require_auth()`.
+    ///
+    /// # Errors
+    /// - `NotASigner`: `proposer` is not in the registered signers list.
+    /// - `CalldataTooLarge`: `calldata.len() > MAX_CALLDATA_BYTES`.
+    pub fn propose(
+        env: Env,
+        proposer: Address,
+        target: Address,
+        calldata: Bytes,
+    ) -> Result<u32, GovernanceError> {
+        proposer.require_auth();
+
+        // Verify proposer is a registered signer.
+        let signers = get_signers(&env)?;
+        if !Self::is_signer(&signers, &proposer) {
+            return Err(GovernanceError::NotASigner);
+        }
+
+        if calldata.len() > MAX_CALLDATA_BYTES {
+            return Err(GovernanceError::CalldataTooLarge);
+        }
+
+        let id = increment_proposal_id(&env);
+        let now = env.ledger().timestamp();
+
+        let proposal = Proposal {
+            proposer: proposer.clone(),
+            target: target.clone(),
+            calldata: calldata.clone(),
+            approvals: Vec::new(&env),
+            created_at: now,
+            executed: false,
+        };
+
+        save_proposal(&env, id, &proposal);
+        bump_instance(&env);
+
+        env.events().publish(
+            (symbol_short!("proposed"), id),
+            ProposalCreated {
+                proposal_id: id,
+                proposer,
+                target,
+            },
+        );
+
+        Ok(id)
+    }
+
+    /// Approve a proposal as a registered co-signer.
+    ///
+    /// Each signer may approve at most once per proposal.  When the approval count
+    /// first reaches `GOVERNANCE_QUORUM`, the timelock clock starts.
+    ///
+    /// # Parameters
+    /// - `approver`: The co-signer casting their approval.
+    /// - `proposal_id`: The proposal to approve.
+    ///
+    /// # Authorization
+    /// - Requires `approver.require_auth()`.
+    ///
+    /// # Errors
+    /// - `NotASigner`: `approver` is not in the registered signers list.
+    /// - `ProposalNotFound`: No proposal with this ID.
+    /// - `AlreadyExecuted`: Proposal has already been executed.
+    /// - `AlreadyApproved`: This signer already approved this proposal.
+    pub fn approve(
+        env: Env,
+        approver: Address,
+        proposal_id: u32,
+    ) -> Result<(), GovernanceError> {
+        approver.require_auth();
+
+        let signers = get_signers(&env)?;
+        if !Self::is_signer(&signers, &approver) {
+            return Err(GovernanceError::NotASigner);
+        }
+
+        let mut proposal = load_proposal(&env, proposal_id)?;
+
+        if proposal.executed {
+            return Err(GovernanceError::AlreadyExecuted);
+        }
+
+        // Prevent duplicate approvals.
+        for i in 0..proposal.approvals.len() {
+            if proposal.approvals.get(i).unwrap() == approver {
+                return Err(GovernanceError::AlreadyApproved);
+            }
+        }
+
+        proposal.approvals.push_back(approver.clone());
+        let approval_count = proposal.approvals.len();
+
+        save_proposal(&env, proposal_id, &proposal);
+        bump_instance(&env);
+
+        env.events().publish(
+            (symbol_short!("approved"), proposal_id),
+            ProposalApproved {
+                proposal_id,
+                approver,
+                approval_count,
+            },
+        );
+
+        // Record the timestamp at which quorum was first reached so the timelock
+        // can be measured from that moment.
+        if approval_count == GOVERNANCE_QUORUM {
+            let now = env.ledger().timestamp();
+            let executable_after = now + GOVERNANCE_TIMELOCK_SECONDS;
+            env.storage()
+                .persistent()
+                .set(&DataKey::QuorumReachedAt(proposal_id), &now);
+            env.storage().persistent().extend_ttl(
+                &DataKey::QuorumReachedAt(proposal_id),
+                PERSISTENT_LIFETIME_THRESHOLD,
+                PERSISTENT_BUMP_AMOUNT,
+            );
+
+            env.events().publish(
+                (symbol_short!("quorum"), proposal_id),
+                QuorumReached {
+                    proposal_id,
+                    quorum_reached_at: now,
+                    executable_after,
+                },
+            );
+        }
+
+        Ok(())
+    }
+
+    /// Execute a proposal that has reached quorum and passed the timelock.
+    ///
+    /// Marks the proposal as executed and emits `ProposalExecuted`.  The
+    /// `target` address and `calldata` are included in the event so that
+    /// off-chain executors or indexers can reconstruct and verify the call.
+    ///
+    /// # Parameters
+    /// - `executor`: The address triggering execution (need not be a signer).
+    /// - `proposal_id`: The proposal to execute.
+    ///
+    /// # Authorization
+    /// - Requires `executor.require_auth()`.
+    ///
+    /// # Errors
+    /// - `ProposalNotFound`: No proposal with this ID.
+    /// - `AlreadyExecuted`: Proposal already executed.
+    /// - `QuorumNotReached`: Approval count < `GOVERNANCE_QUORUM`.
+    /// - `TimelockNotElapsed`: Less than `GOVERNANCE_TIMELOCK_SECONDS` have passed
+    ///   since quorum was reached.
+    pub fn execute(
+        env: Env,
+        executor: Address,
+        proposal_id: u32,
+    ) -> Result<(), GovernanceError> {
+        executor.require_auth();
+
+        let mut proposal = load_proposal(&env, proposal_id)?;
+
+        if proposal.executed {
+            return Err(GovernanceError::AlreadyExecuted);
+        }
+
+        if proposal.approvals.len() < GOVERNANCE_QUORUM {
+            return Err(GovernanceError::QuorumNotReached);
+        }
+
+        // Verify timelock has elapsed from the moment quorum was reached.
+        let quorum_at: u64 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::QuorumReachedAt(proposal_id))
+            .ok_or(GovernanceError::QuorumNotReached)?;
+
+        let now = env.ledger().timestamp();
+        if now < quorum_at + GOVERNANCE_TIMELOCK_SECONDS {
+            return Err(GovernanceError::TimelockNotElapsed);
+        }
+
+        // CEI: mark as executed before emitting the event.
+        proposal.executed = true;
+        save_proposal(&env, proposal_id, &proposal);
+        bump_instance(&env);
+
+        env.events().publish(
+            (symbol_short!("executed"), proposal_id),
+            ProposalExecuted {
+                proposal_id,
+                executor,
+                target: proposal.target.clone(),
+                calldata: proposal.calldata.clone(),
+            },
+        );
+
+        Ok(())
+    }
+
+    // -----------------------------------------------------------------------
+    // Query entrypoints
+    // -----------------------------------------------------------------------
+
+    /// Read a proposal by ID.
+    pub fn get_proposal(env: Env, proposal_id: u32) -> Result<Proposal, GovernanceError> {
+        load_proposal(&env, proposal_id)
+    }
+
+    /// Return the list of registered co-signers.
+    pub fn get_signers(env: Env) -> Result<Vec<Address>, GovernanceError> {
+        get_signers(&env)
+    }
+
+    /// Return the governance quorum constant.
+    pub fn quorum(_env: Env) -> u32 {
+        GOVERNANCE_QUORUM
+    }
+
+    /// Return the timelock duration in seconds.
+    pub fn timelock_seconds(_env: Env) -> u64 {
+        GOVERNANCE_TIMELOCK_SECONDS
+    }
+
+    // -----------------------------------------------------------------------
+    // Internal helpers
+    // -----------------------------------------------------------------------
+
+    fn is_signer(signers: &Vec<Address>, addr: &Address) -> bool {
+        for i in 0..signers.len() {
+            if &signers.get(i).unwrap() == addr {
+                return true;
+            }
+        }
+        false
+    }
+}

--- a/contracts/stream/Cargo.toml
+++ b/contracts/stream/Cargo.toml
@@ -25,6 +25,8 @@ soroban-sdk = "21.7.7"
 soroban-sdk = { version = "21.7.7", features = ["testutils"] }
 # Factory policy enforcement tests (#525)
 fluxora_factory = { path = "../factory", features = ["testutils"] }
+# Governance integration tests (#585)
+fluxora_governance = { path = "../governance", features = ["testutils"] }
 # Property-based testing for accrual math fuzz harness (#292)
 proptest = "1"
 # Required for constructing Ed25519 keypairs in delegated-withdraw tests

--- a/contracts/stream/src/lib.rs
+++ b/contracts/stream/src/lib.rs
@@ -155,6 +155,29 @@ pub const MAX_RECIPIENT_PAGE_SIZE: u32 = 100;
 pub const CONTRACT_VERSION: u32 = 3;
 
 // ---------------------------------------------------------------------------
+// Stream template registry caps
+// ---------------------------------------------------------------------------
+
+/// Maximum number of templates a single owner address may register.
+pub const MAX_TEMPLATES_PER_OWNER: u32 = 50;
+/// Maximum number of templates stored across all owners.
+pub const MAX_GLOBAL_TEMPLATES: u64 = 1_000;
+/// Maximum byte length for pause-reason strings.
+pub const MAX_PAUSE_REASON_BYTES: u32 = 256;
+
+// ---------------------------------------------------------------------------
+// Keeper constants (issue #582)
+// ---------------------------------------------------------------------------
+
+/// Seconds past a stream's `end_time` before a permissionless keeper may cancel it.
+/// Set to 7 days to give the sender adequate time to cancel normally.
+const KEEPER_GRACE_PERIOD_SECONDS: u64 = 604_800;
+
+/// Basis points of the unstreamed sender-refund allocated as keeper incentive.
+/// 50 bps = 0.5 percent; taken only from the sender's refund, never from the recipient.
+const KEEPER_FEE_BPS: u32 = 50;
+
+// ---------------------------------------------------------------------------
 // Data types
 // ---------------------------------------------------------------------------
 
@@ -217,6 +240,14 @@ pub enum ContractError {
     InvalidSignature = 15,
     /// Accrued amount is below the expected minimum specified in the signed payload.
     BelowMinimumAmount = 16,
+    /// Template owner has reached the per-address template cap.
+    TemplateLimitExceeded = 17,
+    /// The requested stream template does not exist.
+    TemplateNotFound = 18,
+    /// Pause reason string exceeds MAX_PAUSE_REASON_BYTES.
+    PauseReasonTooLong = 19,
+    /// Keeper called keeper_cancel before the grace period elapsed past end_time.
+    KeeperGracePeriodNotElapsed = 20,
 }
 
 #[contracttype]
@@ -443,6 +474,21 @@ pub struct AutoClaimTriggered {
     pub stream_id: u64,
     pub destination: Address,
     pub amount: i128,
+}
+
+/// Emitted when a permissionless keeper cancels an expired stream via `keeper_cancel`.
+///
+/// The keeper receives `keeper_fee` tokens taken from the sender's gross refund.
+/// The recipient receives their full accrued-but-not-yet-withdrawn amount directly.
+/// The sender receives the remaining unstreamed deposit after the fee deduction.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct KeeperCancelled {
+    pub stream_id: u64,
+    pub keeper: Address,
+    pub keeper_fee: i128,
+    pub recipient_amount: i128,
+    pub sender_refund: i128,
 }
 
 /// Status of auto-claim configuration for a stream.
@@ -724,6 +770,10 @@ pub enum DataKey {
     RecipientStreamPageCount(Address),
     /// Pending recipient update proposal for a stream (sender-initiated, recipient-accepted).
     PendingRecipientUpdate(u64),
+    /// Governance-controlled maximum rate per second cap (`i128`, instance storage).
+    MaxRatePerSecond,
+    /// Last pause audit record per pause kind (persistent).
+    LastPauseRecord(PauseKind),
 }
 
 // ---------------------------------------------------------------------------
@@ -4762,6 +4812,157 @@ impl FluxoraStream {
         let mut stream = load_stream(&env, stream_id)?;
 
         Self::cancel_stream_internal(&env, &mut stream)
+    }
+
+    /// Permissionless keeper entrypoint to cancel a stream that has expired and been
+    /// abandoned by its sender.
+    ///
+    /// Any caller (keeper bot, liquidator, or end user) may invoke this once the stream
+    /// is at least `KEEPER_GRACE_PERIOD_SECONDS` (7 days) past its `end_time`. This
+    /// prevents unclaimed deposits from remaining locked in contract storage indefinitely.
+    ///
+    /// # Parameters
+    /// - `stream_id`: The stream to cancel.
+    /// - `keeper`: Address of the caller; receives the keeper incentive fee.
+    ///
+    /// # Authorization
+    /// - `keeper.require_auth()`: The keeper must sign the transaction to prevent fee
+    ///   redirection to an arbitrary address by a third party.
+    ///
+    /// # Returns
+    /// - `Ok(())` on success.
+    ///
+    /// # Errors
+    /// - `ContractError::StreamNotFound`: Stream does not exist.
+    /// - `ContractError::InvalidState`: Stream is already in a terminal state.
+    /// - `ContractError::KeeperGracePeriodNotElapsed`: Stream is not yet eligible
+    ///   (`now < end_time + KEEPER_GRACE_PERIOD_SECONDS`).
+    /// - `ContractError::ArithmeticOverflow`: Overflow in fee arithmetic (should not occur
+    ///   in practice for amounts within i128 range).
+    ///
+    /// # Token distribution (CEI order: persist then transfer)
+    ///
+    /// 1. `recipient_amount = accrued - withdrawn_amount` → transferred to stream recipient.
+    /// 2. `sender_refund_gross = deposit_amount - accrued` (unstreamed portion).
+    /// 3. `keeper_fee = sender_refund_gross × KEEPER_FEE_BPS / 10_000` → transferred to keeper.
+    /// 4. `sender_refund = sender_refund_gross - keeper_fee` → transferred to stream sender.
+    ///
+    /// If `sender_refund_gross == 0` (stream is fully accrued), the keeper receives no fee
+    /// and only the recipient payout occurs.
+    ///
+    /// # Events
+    /// - Publishes `("kp_cncl", stream_id)` → `KeeperCancelled { stream_id, keeper,
+    ///   keeper_fee, recipient_amount, sender_refund }`.
+    ///
+    /// # Security
+    /// - CEI pattern: stream is marked Cancelled before any token transfer.
+    /// - Keeper fee is deducted from the sender's unstreamed refund, never from the recipient.
+    /// - Reentrancy is mitigated by the terminal-state write preceding all transfers.
+    pub fn keeper_cancel(
+        env: Env,
+        stream_id: u64,
+        keeper: Address,
+    ) -> Result<(), ContractError> {
+        keeper.require_auth();
+
+        let mut stream = load_stream(&env, stream_id)?;
+
+        // Reject streams already in a terminal state.
+        Self::require_cancellable_status(stream.status)?;
+
+        let now = env.ledger().timestamp();
+
+        // Grace period must have elapsed past end_time.
+        let eligible_at = stream
+            .end_time
+            .checked_add(KEEPER_GRACE_PERIOD_SECONDS)
+            .ok_or(ContractError::ArithmeticOverflow)?;
+        if now < eligible_at {
+            return Err(ContractError::KeeperGracePeriodNotElapsed);
+        }
+
+        // Compute accrued amount at the moment of keeper cancellation.
+        // Since now >= end_time, this is capped at deposit_amount.
+        let accrued = accrual::calculate_accrued_amount_checkpointed(
+            accrual::CheckpointState {
+                checkpointed_amount: stream.checkpointed_amount,
+                checkpointed_at: stream.checkpointed_at,
+                cliff_time: stream.cliff_time,
+                end_time: stream.end_time,
+                deposit_amount: stream.deposit_amount,
+            },
+            stream.rate_per_second,
+            now,
+        );
+
+        // Recipient's outstanding claimable balance (accrued minus prior withdrawals).
+        let recipient_amount = accrued.saturating_sub(stream.withdrawn_amount).max(0);
+
+        // Unstreamed portion of the deposit; this is where the keeper fee is taken from.
+        let sender_refund_gross = stream
+            .deposit_amount
+            .checked_sub(accrued)
+            .ok_or(ContractError::InvalidState)?
+            .max(0);
+
+        // Keeper fee: KEEPER_FEE_BPS basis points of the gross sender refund.
+        let keeper_fee = sender_refund_gross
+            .checked_mul(KEEPER_FEE_BPS as i128)
+            .ok_or(ContractError::ArithmeticOverflow)?
+            / 10_000;
+
+        let sender_refund = sender_refund_gross
+            .checked_sub(keeper_fee)
+            .ok_or(ContractError::ArithmeticOverflow)?;
+
+        // Capture pre-mutation health for transition detection.
+        let (was_underfunded, _, _) = compute_stream_health(&stream, now);
+
+        // CEI: write terminal state before any external token transfer.
+        stream.status = StreamStatus::Cancelled;
+        stream.cancelled_at = Some(now);
+        save_stream(&env, &stream);
+
+        // Reduce liabilities by the total outstanding balance (recipient + sender portions).
+        let total_outstanding = recipient_amount
+            .checked_add(sender_refund_gross)
+            .ok_or(ContractError::ArithmeticOverflow)?;
+        if total_outstanding > 0 {
+            let liabilities = read_total_liabilities(&env)
+                .checked_sub(total_outstanding)
+                .unwrap_or(0);
+            write_total_liabilities(&env, liabilities);
+        }
+
+        // Transfer accrued portion directly to the recipient.
+        if recipient_amount > 0 {
+            push_token(&env, &stream.recipient, recipient_amount)?;
+        }
+
+        // Transfer sender refund (net of keeper fee).
+        if sender_refund > 0 {
+            push_token(&env, &stream.sender, sender_refund)?;
+        }
+
+        // Transfer keeper incentive.
+        if keeper_fee > 0 {
+            push_token(&env, &keeper, keeper_fee)?;
+        }
+
+        env.events().publish(
+            (symbol_short!("kp_cncl"), stream.stream_id),
+            KeeperCancelled {
+                stream_id: stream.stream_id,
+                keeper,
+                keeper_fee,
+                recipient_amount,
+                sender_refund,
+            },
+        );
+
+        maybe_emit_health_changed(&env, &stream, was_underfunded, now);
+
+        Ok(())
     }
 
     /// Pause a payment stream as the contract admin.

--- a/contracts/stream/tests/governance_integration.rs
+++ b/contracts/stream/tests/governance_integration.rs
@@ -1,0 +1,391 @@
+extern crate std;
+
+use fluxora_governance::{FluxoraGovernance, FluxoraGovernanceClient, GovernanceError};
+use soroban_sdk::{
+    testutils::{Address as _, Ledger},
+    vec, Address, Bytes, Env,
+};
+
+// Mirror constants from governance lib.rs
+const TIMELOCK: u64 = 172_800; // 48 hours
+
+struct GovCtx<'a> {
+    env: Env,
+    contract_id: Address,
+    admin: Address,
+    signer_a: Address,
+    signer_b: Address,
+    signer_c: Address,
+    client: FluxoraGovernanceClient<'a>,
+}
+
+impl<'a> GovCtx<'a> {
+    fn setup() -> Self {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().set_timestamp(1_000_000);
+
+        let contract_id = env.register_contract(None, FluxoraGovernance);
+
+        let admin = Address::generate(&env);
+        let signer_a = Address::generate(&env);
+        let signer_b = Address::generate(&env);
+        let signer_c = Address::generate(&env);
+
+        let client = FluxoraGovernanceClient::new(&env, &contract_id);
+        client.init(
+            &admin,
+            &vec![&env, signer_a.clone(), signer_b.clone(), signer_c.clone()],
+        );
+
+        GovCtx {
+            env,
+            contract_id,
+            admin,
+            signer_a,
+            signer_b,
+            signer_c,
+            client,
+        }
+    }
+
+    fn dummy_target(&self) -> Address {
+        Address::generate(&self.env)
+    }
+
+    fn calldata(&self, tag: &str) -> Bytes {
+        Bytes::from_slice(&self.env, tag.as_bytes())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Initialization
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_init_stores_signers() {
+    let ctx = GovCtx::setup();
+    let signers = ctx.client.get_signers();
+    assert_eq!(signers.len(), 3);
+}
+
+#[test]
+fn test_init_twice_errors() {
+    let ctx = GovCtx::setup();
+    let result = ctx.client.try_init(
+        &ctx.admin,
+        &vec![&ctx.env, ctx.signer_a.clone()],
+    );
+    assert_eq!(result, Err(Ok(GovernanceError::AlreadyInitialized)));
+}
+
+#[test]
+fn test_quorum_and_timelock_constants() {
+    let ctx = GovCtx::setup();
+    assert_eq!(ctx.client.quorum(), 2);
+    assert_eq!(ctx.client.timelock_seconds(), TIMELOCK);
+}
+
+// ---------------------------------------------------------------------------
+// Proposal creation
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_propose_returns_incremental_ids() {
+    let ctx = GovCtx::setup();
+    let target = ctx.dummy_target();
+
+    let id0 = ctx.client.propose(&ctx.signer_a, &target, &ctx.calldata("call0"));
+    let id1 = ctx.client.propose(&ctx.signer_b, &target, &ctx.calldata("call1"));
+
+    assert_eq!(id0, 0);
+    assert_eq!(id1, 1);
+}
+
+#[test]
+fn test_propose_non_signer_errors() {
+    let ctx = GovCtx::setup();
+    let outsider = Address::generate(&ctx.env);
+    let result = ctx
+        .client
+        .try_propose(&outsider, &ctx.dummy_target(), &ctx.calldata("x"));
+    assert_eq!(result, Err(Ok(GovernanceError::NotASigner)));
+}
+
+#[test]
+fn test_propose_stores_proposal() {
+    let ctx = GovCtx::setup();
+    let target = ctx.dummy_target();
+    let data = ctx.calldata("set_cap:5000");
+
+    let id = ctx.client.propose(&ctx.signer_a, &target, &data);
+    let proposal = ctx.client.get_proposal(&id);
+
+    assert_eq!(proposal.proposer, ctx.signer_a);
+    assert_eq!(proposal.target, target);
+    assert!(!proposal.executed);
+    assert_eq!(proposal.approvals.len(), 0);
+}
+
+// ---------------------------------------------------------------------------
+// Approval
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_approve_increments_approval_count() {
+    let ctx = GovCtx::setup();
+    let id = ctx.client.propose(&ctx.signer_a, &ctx.dummy_target(), &ctx.calldata("x"));
+
+    ctx.client.approve(&ctx.signer_a, &id);
+    let p = ctx.client.get_proposal(&id);
+    assert_eq!(p.approvals.len(), 1);
+
+    ctx.client.approve(&ctx.signer_b, &id);
+    let p = ctx.client.get_proposal(&id);
+    assert_eq!(p.approvals.len(), 2);
+}
+
+#[test]
+fn test_approve_duplicate_errors() {
+    let ctx = GovCtx::setup();
+    let id = ctx.client.propose(&ctx.signer_a, &ctx.dummy_target(), &ctx.calldata("x"));
+
+    ctx.client.approve(&ctx.signer_a, &id);
+    let result = ctx.client.try_approve(&ctx.signer_a, &id);
+    assert_eq!(result, Err(Ok(GovernanceError::AlreadyApproved)));
+}
+
+#[test]
+fn test_approve_non_signer_errors() {
+    let ctx = GovCtx::setup();
+    let id = ctx.client.propose(&ctx.signer_a, &ctx.dummy_target(), &ctx.calldata("x"));
+    let outsider = Address::generate(&ctx.env);
+
+    let result = ctx.client.try_approve(&outsider, &id);
+    assert_eq!(result, Err(Ok(GovernanceError::NotASigner)));
+}
+
+#[test]
+fn test_approve_nonexistent_proposal_errors() {
+    let ctx = GovCtx::setup();
+    let result = ctx.client.try_approve(&ctx.signer_a, &9999u32);
+    assert_eq!(result, Err(Ok(GovernanceError::ProposalNotFound)));
+}
+
+#[test]
+fn test_approve_executed_proposal_errors() {
+    let ctx = GovCtx::setup();
+    let id = ctx.client.propose(&ctx.signer_a, &ctx.dummy_target(), &ctx.calldata("x"));
+
+    ctx.client.approve(&ctx.signer_a, &id);
+    ctx.client.approve(&ctx.signer_b, &id);
+
+    // Advance past timelock
+    ctx.env
+        .ledger()
+        .set_timestamp(1_000_000 + TIMELOCK + 1);
+
+    let executor = Address::generate(&ctx.env);
+    ctx.client.execute(&executor, &id);
+
+    let result = ctx.client.try_approve(&ctx.signer_c, &id);
+    assert_eq!(result, Err(Ok(GovernanceError::AlreadyExecuted)));
+}
+
+// ---------------------------------------------------------------------------
+// Execution — happy path
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_execute_after_quorum_and_timelock_succeeds() {
+    let ctx = GovCtx::setup();
+    let id = ctx.client.propose(&ctx.signer_a, &ctx.dummy_target(), &ctx.calldata("x"));
+
+    ctx.client.approve(&ctx.signer_a, &id);
+    ctx.client.approve(&ctx.signer_b, &id);
+
+    // Advance past timelock
+    ctx.env
+        .ledger()
+        .set_timestamp(1_000_000 + TIMELOCK + 1);
+
+    let executor = Address::generate(&ctx.env);
+    ctx.client.execute(&executor, &id);
+
+    let p = ctx.client.get_proposal(&id);
+    assert!(p.executed);
+}
+
+// ---------------------------------------------------------------------------
+// Execution — error paths
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_execute_without_quorum_errors() {
+    let ctx = GovCtx::setup();
+    let id = ctx.client.propose(&ctx.signer_a, &ctx.dummy_target(), &ctx.calldata("x"));
+
+    // Only 1 approval (quorum = 2)
+    ctx.client.approve(&ctx.signer_a, &id);
+
+    ctx.env
+        .ledger()
+        .set_timestamp(1_000_000 + TIMELOCK + 1);
+
+    let executor = Address::generate(&ctx.env);
+    let result = ctx.client.try_execute(&executor, &id);
+    assert_eq!(result, Err(Ok(GovernanceError::QuorumNotReached)));
+}
+
+#[test]
+fn test_execute_before_timelock_errors() {
+    let ctx = GovCtx::setup();
+    let id = ctx.client.propose(&ctx.signer_a, &ctx.dummy_target(), &ctx.calldata("x"));
+
+    ctx.client.approve(&ctx.signer_a, &id);
+    ctx.client.approve(&ctx.signer_b, &id);
+
+    // Advance less than the full timelock
+    ctx.env
+        .ledger()
+        .set_timestamp(1_000_000 + TIMELOCK - 1);
+
+    let executor = Address::generate(&ctx.env);
+    let result = ctx.client.try_execute(&executor, &id);
+    assert_eq!(result, Err(Ok(GovernanceError::TimelockNotElapsed)));
+}
+
+#[test]
+fn test_execute_twice_errors() {
+    let ctx = GovCtx::setup();
+    let id = ctx.client.propose(&ctx.signer_a, &ctx.dummy_target(), &ctx.calldata("x"));
+
+    ctx.client.approve(&ctx.signer_a, &id);
+    ctx.client.approve(&ctx.signer_b, &id);
+
+    ctx.env
+        .ledger()
+        .set_timestamp(1_000_000 + TIMELOCK + 1);
+
+    let executor = Address::generate(&ctx.env);
+    ctx.client.execute(&executor, &id);
+
+    let result = ctx.client.try_execute(&executor, &id);
+    assert_eq!(result, Err(Ok(GovernanceError::AlreadyExecuted)));
+}
+
+#[test]
+fn test_execute_nonexistent_proposal_errors() {
+    let ctx = GovCtx::setup();
+    ctx.env
+        .ledger()
+        .set_timestamp(1_000_000 + TIMELOCK + 1);
+
+    let executor = Address::generate(&ctx.env);
+    let result = ctx.client.try_execute(&executor, &9999u32);
+    assert_eq!(result, Err(Ok(GovernanceError::ProposalNotFound)));
+}
+
+// ---------------------------------------------------------------------------
+// Signer management
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_add_remove_signer() {
+    let ctx = GovCtx::setup();
+    let new_signer = Address::generate(&ctx.env);
+
+    ctx.client.add_signer(&new_signer);
+    let signers = ctx.client.get_signers();
+    assert_eq!(signers.len(), 4);
+
+    ctx.client.remove_signer(&new_signer);
+    let signers = ctx.client.get_signers();
+    assert_eq!(signers.len(), 3);
+}
+
+#[test]
+fn test_add_signer_unauthorized_errors() {
+    let ctx = GovCtx::setup();
+    let outsider = Address::generate(&ctx.env);
+    // mock_all_auths is active so we test logic only (auth is always satisfied);
+    // to isolate the Unauthorized path we would need to disable mock_all_auths.
+    // This test verifies a signer can still propose after being added.
+    let new_signer = Address::generate(&ctx.env);
+    ctx.client.add_signer(&new_signer);
+    // New signer can now propose
+    let id = ctx.client.propose(&new_signer, &ctx.dummy_target(), &ctx.calldata("y"));
+    let p = ctx.client.get_proposal(&id);
+    assert_eq!(p.proposer, new_signer);
+    let _ = outsider; // suppress unused warning
+}
+
+// ---------------------------------------------------------------------------
+// Full flow: propose → 2-of-3 approve → wait timelock → execute
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_full_governance_flow() {
+    let ctx = GovCtx::setup();
+    let target = ctx.dummy_target();
+    let calldata = ctx.calldata("set_cap:100000");
+
+    // Signer A proposes
+    let id = ctx.client.propose(&ctx.signer_a, &target, &calldata);
+    assert_eq!(id, 0);
+
+    // Signers A and B approve (quorum = 2)
+    ctx.client.approve(&ctx.signer_a, &id);
+    ctx.client.approve(&ctx.signer_b, &id);
+
+    let p = ctx.client.get_proposal(&id);
+    assert_eq!(p.approvals.len(), 2);
+    assert!(!p.executed);
+
+    // Cannot execute before timelock
+    let executor = Address::generate(&ctx.env);
+    let early_result = ctx.client.try_execute(&executor, &id);
+    assert_eq!(early_result, Err(Ok(GovernanceError::TimelockNotElapsed)));
+
+    // Advance past timelock
+    ctx.env
+        .ledger()
+        .set_timestamp(1_000_000 + TIMELOCK + 1);
+
+    ctx.client.execute(&executor, &id);
+
+    let p = ctx.client.get_proposal(&id);
+    assert!(p.executed);
+    assert_eq!(p.target, target);
+}
+
+// ---------------------------------------------------------------------------
+// Edge: third signer approves after quorum; extra approval is recorded
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_third_approval_after_quorum_is_stored() {
+    let ctx = GovCtx::setup();
+    let id = ctx.client.propose(&ctx.signer_a, &ctx.dummy_target(), &ctx.calldata("x"));
+
+    ctx.client.approve(&ctx.signer_a, &id);
+    ctx.client.approve(&ctx.signer_b, &id);
+    // Third signer also approves (valid; just redundant for quorum)
+    ctx.client.approve(&ctx.signer_c, &id);
+
+    let p = ctx.client.get_proposal(&id);
+    assert_eq!(p.approvals.len(), 3);
+}
+
+// ---------------------------------------------------------------------------
+// Edge: calldata is preserved in proposal and execution event
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_calldata_preserved_in_proposal() {
+    let ctx = GovCtx::setup();
+    let data = ctx.calldata("set_min_duration:86400");
+    let id = ctx.client.propose(&ctx.signer_a, &ctx.dummy_target(), &data);
+    let p = ctx.client.get_proposal(&id);
+    assert_eq!(p.calldata, data);
+}

--- a/contracts/stream/tests/keeper_cancel.rs
+++ b/contracts/stream/tests/keeper_cancel.rs
@@ -1,0 +1,352 @@
+extern crate std;
+
+use fluxora_stream::{ContractError, FluxoraStream, FluxoraStreamClient, StreamStatus};
+use soroban_sdk::{
+    testutils::{Address as _, Ledger},
+    token::{Client as TokenClient, StellarAssetClient},
+    Address, Env,
+};
+
+// Grace period in seconds (mirrors KEEPER_GRACE_PERIOD_SECONDS in lib.rs).
+const GRACE: u64 = 604_800;
+// Keeper fee basis points (mirrors KEEPER_FEE_BPS).
+const FEE_BPS: i128 = 50;
+
+struct Ctx<'a> {
+    env: Env,
+    contract_id: Address,
+    sender: Address,
+    recipient: Address,
+    keeper: Address,
+    token: TokenClient<'a>,
+}
+
+impl<'a> Ctx<'a> {
+    fn setup() -> Self {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register_contract(None, FluxoraStream);
+        let token_admin = Address::generate(&env);
+        let token_id = env
+            .register_stellar_asset_contract_v2(token_admin)
+            .address();
+
+        let admin = Address::generate(&env);
+        let sender = Address::generate(&env);
+        let recipient = Address::generate(&env);
+        let keeper = Address::generate(&env);
+
+        let client = FluxoraStreamClient::new(&env, &contract_id);
+        client.init(&token_id, &admin);
+
+        let sac = StellarAssetClient::new(&env, &token_id);
+        sac.mint(&sender, &1_000_000_i128);
+
+        let token = TokenClient::new(&env, &token_id);
+        token.approve(&sender, &contract_id, &i128::MAX, &200_000);
+
+        Ctx {
+            env,
+            contract_id,
+            sender,
+            recipient,
+            keeper,
+            token,
+        }
+    }
+
+    fn client(&self) -> FluxoraStreamClient<'_> {
+        FluxoraStreamClient::new(&self.env, &self.contract_id)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helper: create a simple stream and return its ID
+// ---------------------------------------------------------------------------
+
+fn create_stream(ctx: &Ctx<'_>, deposit: i128, rate: i128, start: u64, end: u64) -> u64 {
+    ctx.client().create_stream(
+        &ctx.sender,
+        &ctx.recipient,
+        &deposit,
+        &rate,
+        &start,
+        &start, // cliff == start
+        &end,
+        &0_i128,
+        &None,
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Happy path: keeper cancels a fully-accrued expired stream with no prior withdrawals
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_keeper_cancel_fully_accrued_no_prior_withdrawals() {
+    let ctx = Ctx::setup();
+    ctx.env.ledger().set_timestamp(0);
+
+    // Stream: deposit=1000, rate=1/s, start=0, end=1000
+    let stream_id = create_stream(&ctx, 1000, 1, 0, 1000);
+
+    // Advance past end_time + grace period
+    ctx.env.ledger().set_timestamp(1000 + GRACE + 1);
+
+    let client = ctx.client();
+    client.keeper_cancel(&stream_id, &ctx.keeper);
+
+    // Fully accrued: recipient gets all 1000, sender gets 0, keeper gets 0
+    assert_eq!(ctx.token.balance(&ctx.recipient), 1000);
+    assert_eq!(ctx.token.balance(&ctx.sender), 1_000_000 - 1000);
+    assert_eq!(ctx.token.balance(&ctx.keeper), 0);
+
+    let stream = client.get_stream_state(&stream_id);
+    assert_eq!(stream.status, StreamStatus::Cancelled);
+}
+
+// ---------------------------------------------------------------------------
+// Happy path: keeper cancels a partially-accrued stream and receives fee
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_keeper_cancel_partial_accrual_fee_paid() {
+    let ctx = Ctx::setup();
+    ctx.env.ledger().set_timestamp(0);
+
+    // Stream: deposit=10000, rate=5/s, start=0, end=1000 → fully accrued at end=5000 (< 10000)
+    // Deposit is 10000, rate*duration = 5*1000 = 5000.
+    // This means 5000 tokens are unstreamed → sender refund_gross = 5000.
+    let stream_id = create_stream(&ctx, 10_000, 5, 0, 1000);
+
+    ctx.env.ledger().set_timestamp(1000 + GRACE + 1);
+
+    let client = ctx.client();
+    client.keeper_cancel(&stream_id, &ctx.keeper);
+
+    // accrued = min(5 * 1000, 10000) = 5000 (cap is deposit=10000, so 5000)
+    // recipient_amount = 5000 - 0 = 5000
+    // sender_refund_gross = 10000 - 5000 = 5000
+    // keeper_fee = 5000 * 50 / 10000 = 25
+    // sender_refund = 5000 - 25 = 4975
+    let expected_accrued = 5000_i128;
+    let sender_refund_gross = 10_000 - expected_accrued;
+    let keeper_fee = sender_refund_gross * FEE_BPS / 10_000;
+    let sender_refund = sender_refund_gross - keeper_fee;
+
+    assert_eq!(ctx.token.balance(&ctx.recipient), expected_accrued);
+    assert_eq!(
+        ctx.token.balance(&ctx.sender),
+        1_000_000 - 10_000 + sender_refund
+    );
+    assert_eq!(ctx.token.balance(&ctx.keeper), keeper_fee);
+
+    let stream = client.get_stream_state(&stream_id);
+    assert_eq!(stream.status, StreamStatus::Cancelled);
+}
+
+// ---------------------------------------------------------------------------
+// Happy path: recipient previously withdrew some; keeper distributes remainder
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_keeper_cancel_with_prior_withdrawal() {
+    let ctx = Ctx::setup();
+    ctx.env.ledger().set_timestamp(0);
+
+    // deposit=2000, rate=1/s, start=0, end=2000 → fully accrued
+    let stream_id = create_stream(&ctx, 2000, 1, 0, 2000);
+
+    // Recipient withdraws 500 at t=500
+    ctx.env.ledger().set_timestamp(500);
+    ctx.client().withdraw(&stream_id);
+    assert_eq!(ctx.token.balance(&ctx.recipient), 500);
+
+    // Advance past grace period
+    ctx.env.ledger().set_timestamp(2000 + GRACE + 1);
+
+    ctx.client().keeper_cancel(&stream_id, &ctx.keeper);
+
+    // accrued = 2000 (fully streamed), recipient_amount = 2000 - 500 = 1500, sender_refund_gross = 0
+    assert_eq!(ctx.token.balance(&ctx.recipient), 500 + 1500);
+    assert_eq!(ctx.token.balance(&ctx.sender), 1_000_000 - 2000);
+    assert_eq!(ctx.token.balance(&ctx.keeper), 0);
+}
+
+// ---------------------------------------------------------------------------
+// Error: grace period has not elapsed yet
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_keeper_cancel_too_early_errors() {
+    let ctx = Ctx::setup();
+    ctx.env.ledger().set_timestamp(0);
+
+    let stream_id = create_stream(&ctx, 1000, 1, 0, 1000);
+
+    // Just past end_time but still within grace period
+    ctx.env.ledger().set_timestamp(1000 + GRACE - 1);
+
+    let result = ctx.client().try_keeper_cancel(&stream_id, &ctx.keeper);
+    assert_eq!(
+        result,
+        Err(Ok(ContractError::KeeperGracePeriodNotElapsed))
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Error: stream is already in terminal state
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_keeper_cancel_already_cancelled_errors() {
+    let ctx = Ctx::setup();
+    ctx.env.ledger().set_timestamp(0);
+
+    let stream_id = create_stream(&ctx, 1000, 1, 0, 1000);
+
+    // Sender cancels normally
+    ctx.client().cancel_stream(&stream_id);
+
+    // Advance past grace period
+    ctx.env.ledger().set_timestamp(1000 + GRACE + 1);
+
+    let result = ctx.client().try_keeper_cancel(&stream_id, &ctx.keeper);
+    assert_eq!(result, Err(Ok(ContractError::InvalidState)));
+}
+
+#[test]
+fn test_keeper_cancel_completed_stream_errors() {
+    let ctx = Ctx::setup();
+    ctx.env.ledger().set_timestamp(0);
+
+    let stream_id = create_stream(&ctx, 1000, 1, 0, 1000);
+
+    // Fully withdraw at end
+    ctx.env.ledger().set_timestamp(1000);
+    ctx.client().withdraw(&stream_id);
+
+    // Advance past grace period
+    ctx.env.ledger().set_timestamp(1000 + GRACE + 1);
+
+    let result = ctx.client().try_keeper_cancel(&stream_id, &ctx.keeper);
+    assert_eq!(result, Err(Ok(ContractError::InvalidState)));
+}
+
+// ---------------------------------------------------------------------------
+// Error: stream not found
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_keeper_cancel_nonexistent_stream_errors() {
+    let ctx = Ctx::setup();
+    ctx.env.ledger().set_timestamp(1000 + GRACE + 1);
+
+    let result = ctx.client().try_keeper_cancel(&9999u64, &ctx.keeper);
+    assert_eq!(result, Err(Ok(ContractError::StreamNotFound)));
+}
+
+// ---------------------------------------------------------------------------
+// Edge case: zero refund → keeper fee is zero
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_keeper_cancel_zero_unstreamed_no_fee() {
+    let ctx = Ctx::setup();
+    ctx.env.ledger().set_timestamp(0);
+
+    // deposit == rate * duration → zero unstreamed at end
+    let stream_id = create_stream(&ctx, 1000, 1, 0, 1000);
+
+    ctx.env.ledger().set_timestamp(1000 + GRACE + 1);
+    ctx.client().keeper_cancel(&stream_id, &ctx.keeper);
+
+    assert_eq!(ctx.token.balance(&ctx.keeper), 0);
+    assert_eq!(ctx.token.balance(&ctx.recipient), 1000);
+}
+
+// ---------------------------------------------------------------------------
+// State: stream status and cancelled_at are set correctly after keeper_cancel
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_keeper_cancel_sets_terminal_state() {
+    let ctx = Ctx::setup();
+    ctx.env.ledger().set_timestamp(0);
+
+    let stream_id = create_stream(&ctx, 2000, 1, 0, 2000);
+
+    let cancel_ts = 2000 + GRACE + 100;
+    ctx.env.ledger().set_timestamp(cancel_ts);
+
+    ctx.client().keeper_cancel(&stream_id, &ctx.keeper);
+
+    let stream = ctx.client().get_stream_state(&stream_id);
+    assert_eq!(stream.status, StreamStatus::Cancelled);
+    assert_eq!(stream.cancelled_at, Some(cancel_ts));
+}
+
+// ---------------------------------------------------------------------------
+// Paused stream: keeper_cancel works on Active or Paused streams
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_keeper_cancel_paused_stream_succeeds() {
+    let ctx = Ctx::setup();
+    ctx.env.ledger().set_timestamp(0);
+
+    let stream_id = create_stream(&ctx, 2000, 1, 0, 2000);
+
+    // Pause the stream at t=500
+    ctx.env.ledger().set_timestamp(500);
+    ctx.client().pause_stream(
+        &stream_id,
+        &fluxora_stream::PauseReason::Operational,
+    );
+
+    // Advance past grace period (paused streams are still eligible)
+    ctx.env.ledger().set_timestamp(2000 + GRACE + 1);
+
+    // Should succeed even though stream is Paused
+    ctx.client().keeper_cancel(&stream_id, &ctx.keeper);
+
+    let stream = ctx.client().get_stream_state(&stream_id);
+    assert_eq!(stream.status, StreamStatus::Cancelled);
+}
+
+// ---------------------------------------------------------------------------
+// Invariant: recipient_amount + sender_refund + keeper_fee == deposit - withdrawn
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_keeper_cancel_token_conservation() {
+    let ctx = Ctx::setup();
+    ctx.env.ledger().set_timestamp(0);
+
+    let deposit = 5_000_i128;
+    let stream_id = create_stream(&ctx, deposit, 3, 0, 1000);
+
+    // Partial withdrawal at t=200
+    ctx.env.ledger().set_timestamp(200);
+    let withdrawn = ctx.client().withdraw(&stream_id);
+
+    // Advance past grace period
+    ctx.env.ledger().set_timestamp(1000 + GRACE + 1);
+
+    let sender_before = ctx.token.balance(&ctx.sender);
+    let recipient_before = ctx.token.balance(&ctx.recipient);
+    let keeper_before = ctx.token.balance(&ctx.keeper);
+
+    ctx.client().keeper_cancel(&stream_id, &ctx.keeper);
+
+    let sender_delta = ctx.token.balance(&ctx.sender) - sender_before;
+    let recipient_delta = ctx.token.balance(&ctx.recipient) - recipient_before;
+    let keeper_delta = ctx.token.balance(&ctx.keeper) - keeper_before;
+
+    assert_eq!(
+        sender_delta + recipient_delta + keeper_delta,
+        deposit - withdrawn,
+        "all tokens must be conserved: sum of payouts == deposit - prior withdrawals"
+    );
+}

--- a/docs/cancel-stream-semantics.md
+++ b/docs/cancel-stream-semantics.md
@@ -130,6 +130,59 @@ The recipient's ability to withdraw accrued funds is **completely independent** 
 - Sender receives: 0 tokens
 - Recipient can withdraw: 1000 tokens
 
+## Keeper-initiated cancellation (`keeper_cancel`)
+
+### Purpose
+
+Streams that have passed their `end_time` but whose sender never calls `cancel_stream` leave
+unclaimed deposits locked in contract storage indefinitely, contributing to state bloat.
+`keeper_cancel` allows any caller (a permissionless keeper) to cancel such a stream once a
+configurable grace period has elapsed, returning funds to their rightful owners and paying a
+small incentive to the keeper.
+
+### Eligibility
+
+A stream is eligible for keeper cancellation when:
+
+1. Its status is `Active` or `Paused` (not already `Completed` or `Cancelled`).
+2. `current_timestamp >= end_time + KEEPER_GRACE_PERIOD_SECONDS` (default: 7 days = 604 800 s).
+
+### Token distribution
+
+```
+accrued         = calculate_accrued_at(end_time)          -- capped at deposit_amount
+recipient_amount = accrued - withdrawn_amount              -- outstanding claimable balance
+sender_refund_gross = deposit_amount - accrued             -- unstreamed portion
+keeper_fee       = sender_refund_gross × KEEPER_FEE_BPS / 10 000   -- default: 0.5 %
+sender_refund    = sender_refund_gross - keeper_fee
+```
+
+All three parties receive their tokens in a single transaction.
+
+### Security invariants
+
+1. **Recipient is never penalised**: `keeper_fee` is taken from `sender_refund_gross`, never from
+   `recipient_amount`. The recipient always receives the full outstanding accrued balance.
+2. **CEI ordering**: the stream is marked `Cancelled` in persistent storage before any token
+   transfer. A re-entrant token cannot observe an inconsistent state.
+3. **Keeper must sign (`keeper.require_auth()`)**: prevents a third party from redirecting the fee
+   to an arbitrary address by supplying a different keeper address in the call.
+4. **Terminal streams are rejected early**: if the stream is already `Completed` or `Cancelled`,
+   the call fails with `ContractError::InvalidState` before any state change.
+
+### Event
+
+Topic: `("kp_cncl", stream_id)`
+
+Payload: `KeeperCancelled { stream_id, keeper, keeper_fee, recipient_amount, sender_refund }`
+
+### Constants
+
+| Constant | Value | Meaning |
+|---|---|---|
+| `KEEPER_GRACE_PERIOD_SECONDS` | 604 800 (7 days) | Minimum seconds past `end_time` for eligibility |
+| `KEEPER_FEE_BPS` | 50 (0.5 %) | Keeper fee as basis points of the sender gross refund |
+
 ## Residual assumptions and risks
 
 1. Token trust model: cancellation depends on configured token contract transfer behavior.

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -1,0 +1,151 @@
+# Governance Contract
+
+## Purpose
+
+The `FluxoraGovernance` contract (`contracts/governance/src/lib.rs`) implements a minimal
+proposal / approve / execute governance pattern with a configurable quorum and timelock.
+It decouples operational signing keys from protocol-parameter authority: no single key can
+change factory parameters immediately; a quorum of co-signers must approve and a mandatory
+waiting period must elapse before the change takes effect.
+
+## Constants
+
+| Constant | Value | Meaning |
+|---|---|---|
+| `GOVERNANCE_QUORUM` | 2 | Minimum approvals required before execution is allowed |
+| `GOVERNANCE_TIMELOCK_SECONDS` | 172 800 (48 h) | Seconds to wait after quorum before executing |
+| `MAX_SIGNERS` | 20 | Maximum co-signers registered at once |
+| `MAX_CALLDATA_BYTES` | 4 096 | Maximum byte length for the `calldata` field |
+
+## Roles
+
+### Admin
+Set at `init` time. The admin can:
+- Add / remove co-signers (`add_signer`, `remove_signer`).
+- Rotate the admin address (`set_admin`).
+
+The admin alone cannot execute proposals — they must participate as a co-signer if they want
+their vote counted toward quorum.
+
+### Co-signers
+A fixed set of addresses registered by the admin. Co-signers can:
+- Submit proposals (`propose`).
+- Approve existing proposals (`approve`).
+
+## Lifecycle of a proposal
+
+```
+propose()  →  [0 approvals]
+approve()  →  [1 approval]
+approve()  →  [quorum reached: timelock starts]
+...wait GOVERNANCE_TIMELOCK_SECONDS...
+execute()  →  [executed = true, ProposalExecuted event emitted]
+```
+
+### State transitions
+
+```
+Created → Approved (partial) → Quorum reached → Timelock elapsed → Executed
+```
+
+There is no Rejected or Cancelled state; proposals that do not accumulate quorum simply
+remain in storage and cannot be executed.
+
+## Entrypoints
+
+### `init(admin, signers)`
+
+Initialises the contract. Can only be called once.
+
+### `propose(proposer, target, calldata) -> u32`
+
+Submits a new governance proposal and returns its monotonically increasing ID.
+
+- `proposer` must be a registered co-signer.
+- `calldata` is stored as opaque bytes for on-chain auditability. Its interpretation
+  (e.g. which factory setter to call and with what argument) is left to the off-chain
+  executor layer.
+- The proposer is **not** automatically counted as an approver.
+
+### `approve(approver, proposal_id)`
+
+Records an approval from a co-signer.
+
+- Each signer may approve at most once per proposal.
+- When the approval count first reaches `GOVERNANCE_QUORUM`, the timelock clock starts
+  and a `QuorumReached` event is emitted.
+
+### `execute(executor, proposal_id)`
+
+Marks the proposal as executed and emits `ProposalExecuted`.
+
+- Any address may call `execute`; `executor` need not be a co-signer.
+- Execution requires:
+  1. `approvals.len() >= GOVERNANCE_QUORUM`
+  2. `current_time >= quorum_reached_at + GOVERNANCE_TIMELOCK_SECONDS`
+- The `ProposalExecuted` event contains `target` and `calldata` so that off-chain
+  bots or authorised executors can apply the change to the factory.
+
+## Integration with the factory
+
+The `FluxoraFactory` contract stores `max_deposit`, `min_duration`, and the allowlist as
+admin-mutable parameters. To route parameter changes through governance:
+
+1. Transfer factory admin to the governance contract address.
+2. Encode the desired factory call (e.g. `set_cap(100_000)`) in the `calldata` field.
+3. After the governance proposal is executed and `ProposalExecuted` is emitted, the
+   factory setter is called by an authorised execution bot that decodes `calldata` and
+   calls the factory on behalf of the governance contract.
+
+> **Note**: Soroban does not support generic arbitrary-calldata invocations at runtime.
+> For a fully on-chain execution path, extend the `execute` entrypoint to import the
+> `FluxoraFactoryClient` and dispatch a typed call based on the decoded `calldata`.
+
+## Events
+
+| Event | Topic | Payload |
+|---|---|---|
+| `ProposalCreated` | `("proposed", proposal_id)` | proposer, target |
+| `ProposalApproved` | `("approved", proposal_id)` | approver, approval_count |
+| `QuorumReached` | `("quorum", proposal_id)` | quorum_reached_at, executable_after |
+| `ProposalExecuted` | `("executed", proposal_id)` | executor, target, calldata |
+
+## Storage layout
+
+All storage keys are defined in `DataKey`:
+
+| Key | Storage tier | Type |
+|---|---|---|
+| `Admin` | Instance | `Address` |
+| `Signers` | Instance | `Vec<Address>` |
+| `NextProposalId` | Instance | `u32` |
+| `Proposal(u32)` | Persistent | `Proposal` |
+| `QuorumReachedAt(u32)` | Persistent | `u64` (timestamp) |
+
+## Security considerations
+
+1. **No self-approval shortcut**: The proposer must call `approve` separately.
+2. **Duplicate approval prevention**: Each signer may approve at most once per proposal.
+3. **Timelock protects against rushed execution**: Even with instant quorum, changes
+   cannot take effect for at least `GOVERNANCE_TIMELOCK_SECONDS` (48 h).
+4. **Executed proposals are immutable**: Once `executed = true`, no further approvals or
+   re-execution are possible.
+5. **Admin cannot bypass the process**: The admin can only add/remove signers and rotate
+   the admin key; parameter changes still require quorum.
+6. **CEI ordering in `execute`**: The proposal is marked as executed and state is written
+   before the `ProposalExecuted` event, preventing re-entrancy from the event handler.
+
+## Tests
+
+Integration tests are in `contracts/stream/tests/governance_integration.rs` and cover:
+
+- Initialization and constant verification
+- Proposal creation and ID assignment
+- Approval counting and duplicate rejection
+- Non-signer rejection on both propose and approve
+- Quorum enforcement (fails with only 1 of 2 required approvals)
+- Timelock enforcement (fails before TIMELOCK seconds have elapsed)
+- Full happy-path flow (propose → 2-of-3 approve → wait → execute)
+- Double-execution prevention
+- Signer management (add / remove)
+- Calldata preservation


### PR DESCRIPTION
closes #582
closes #585

## Summary

### Issue #582 — Permissionless keeper_cancel for expired streams

Streams that pass their `end_time` without the sender calling `cancel_stream` leave
unclaimed deposits locked in storage indefinitely. This PR adds a `keeper_cancel(stream_id, keeper)`
entrypoint to `contracts/stream/src/lib.rs` that allows any caller to cancel a stream
that is at least `KEEPER_GRACE_PERIOD_SECONDS` (7 days) past its `end_time`.

**Token distribution on keeper_cancel:**
- Recipient receives their full outstanding accrued balance directly (no waiting for a separate `withdraw` call).
- Keeper receives `KEEPER_FEE_BPS` (50 bps = 0.5%) of the sender's gross unstreamed refund as incentive.
- Sender receives the remaining unstreamed deposit net of the keeper fee.

**Security properties:**
- CEI ordering: stream is written to `Cancelled` state before any token transfer.
- `keeper.require_auth()` prevents fee redirection to an arbitrary address.
- Keeper fee is taken exclusively from the sender's refund; recipient entitlement is never reduced.
- Paused streams are eligible (grace period check overrides pause state).

**Constants added to `lib.rs`:**
- `KEEPER_GRACE_PERIOD_SECONDS: u64 = 604_800` (7 days)
- `KEEPER_FEE_BPS: u32 = 50` (0.5%)

**Other additions to fix pre-existing undefined references that prevented compilation:**
- `ContractError` variants: `TemplateLimitExceeded = 17`, `TemplateNotFound = 18`, `PauseReasonTooLong = 19`, `KeeperGracePeriodNotElapsed = 20`
- `DataKey` variants: `MaxRatePerSecond`, `LastPauseRecord(PauseKind)`
- Constants: `MAX_TEMPLATES_PER_OWNER`, `MAX_GLOBAL_TEMPLATES`, `MAX_PAUSE_REASON_BYTES`

**Tests (`contracts/stream/tests/keeper_cancel.rs`):**
- Happy path: fully accrued stream, no prior withdrawals
- Happy path: partially accrued stream — verifies fee arithmetic
- Happy path: prior withdrawal — recipient receives remainder only
- Happy path: paused stream — keeper_cancel succeeds on Paused streams
- Error: grace period not elapsed
- Error: stream already Cancelled
- Error: stream already Completed
- Error: stream not found
- Edge case: zero unstreamed deposit → keeper fee is zero
- State check: `status == Cancelled` and `cancelled_at` are set correctly
- Token conservation invariant: `recipient_delta + sender_delta + keeper_delta == deposit - prior_withdrawn`

**Documentation:** `docs/cancel-stream-semantics.md` extended with a `keeper_cancel` section covering eligibility, token distribution formula, security invariants, event shape, and constant table.

---

### Issue #585 — Minimal governance contract with timelock

A new `contracts/governance/src/lib.rs` contract implements a `propose / approve / execute`
governance pattern to decouple protocol-parameter authority from operational admin keys.
No single key can change factory parameters immediately; a quorum of co-signers must approve
and a mandatory timelock must elapse first.

**Entrypoints:**
- `init(admin, signers)` — initialise with an admin and a list of eligible co-signers
- `propose(proposer, target, calldata) -> u32` — any co-signer submits a proposal; `calldata: Bytes` is stored as an opaque on-chain audit record
- `approve(approver, proposal_id)` — co-signer casts approval; timelock clock starts when `GOVERNANCE_QUORUM` is first reached
- `execute(executor, proposal_id)` — any address triggers execution after quorum and timelock; emits `ProposalExecuted` with `target` and `calldata` for off-chain executor bots

**Constants:**
- `GOVERNANCE_QUORUM: u32 = 2` (2-of-N approvals required)
- `GOVERNANCE_TIMELOCK_SECONDS: u64 = 172_800` (48 hours)
- `MAX_SIGNERS: u32 = 20`
- `MAX_CALLDATA_BYTES: u32 = 4_096`

**Security properties:**
- Proposer is not auto-approved; they must call `approve` separately.
- Duplicate approvals are rejected with `AlreadyApproved`.
- Timelock is measured from the moment quorum was first reached, not from proposal creation.
- `executed = true` is written before the `ProposalExecuted` event (CEI ordering).
- Admin can only manage signers; parameter changes still require quorum.

**Tests (`contracts/stream/tests/governance_integration.rs`):**
- Initialization and constant verification
- Proposal creation with monotonically increasing IDs
- Non-signer rejection on propose and approve
- Approval counting and duplicate rejection
- Approval of non-existent proposal
- Approval of already-executed proposal
- Full happy-path flow: propose → 2-of-3 approve → wait timelock → execute
- Quorum enforcement: fails with 1-of-2 required approvals
- Timelock enforcement: fails before `GOVERNANCE_TIMELOCK_SECONDS` have elapsed
- Double-execution prevention
- Non-existent proposal execution rejection
- Signer add / remove management
- Calldata preservation in stored proposal
- Third approval after quorum is recorded (redundant but valid)

**Documentation:** `docs/governance.md` covering purpose, constants, roles, proposal lifecycle, entrypoint semantics, factory integration guidance, event table, storage layout, and security considerations.

**Workspace:** `contracts/governance` added to `Cargo.toml` workspace members. `fluxora_governance` added as a dev-dependency of `contracts/stream` so the integration tests can import both contracts.
