### PR TITLE
docs(readme): align entry-point tables and add factory/governance sec…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
         run: pip install pytest pytest-cov
 
       - name: Run test suite with coverage
-        run: pytest tests/ --cov=script/validate-doc-alignment.py --cov-fail-under=95 -v --tb=short
+        run: pytest tests/ --cov=script/ --cov-fail-under=95 -v --tb=short
 
       - name: Validate doc alignment
         run: python3 script/validate-doc-alignment.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
         run: pip install pytest pytest-cov
 
       - name: Run test suite with coverage
-        run: pytest tests/ --cov=script/ --cov-fail-under=95 -v --tb=short
+        run: pytest tests/ --cov=script/validate-doc-alignment.py --cov-fail-under=95 -v --tb=short
 
       - name: Validate doc alignment
         run: python3 script/validate-doc-alignment.py

--- a/README.md
+++ b/README.md
@@ -20,40 +20,22 @@ Soroban smart contracts for the Fluxora treasury streaming protocol on Stellar. 
 - **Data model** — `Stream` (sender, recipient, deposit_amount, rate_per_second, start/cliff/end time, withdrawn_amount, status, cancelled_at).
 - **Status** — `Active`, `Paused`, `Completed`, `Cancelled`.
 
-### Implemented entry-points
+### Core Stream Entry Points
 
-| Entry-point | Caller | Description |
-|---|---|---|
-| `init` | Bootstrap admin | One-shot initialisation: set token and admin |
-| `create_stream` | Sender | Create a single stream and pull deposit |
-| `create_streams` | Sender | Batch-create streams in one atomic transaction |
-| `pause_stream` | Sender | Halt withdrawals (accrual continues) |
-| `resume_stream` | Sender | Re-enable withdrawals |
-| `cancel_stream` | Sender | Terminate stream; refund unstreamed tokens to sender |
-| `withdraw` | Recipient | Pull accrued tokens to recipient address |
-| `withdraw_to` | Recipient | Pull accrued tokens to a specified destination |
-| `batch_withdraw` | Recipient | Withdraw from multiple streams in one call |
-| `top_up_stream` | Any funder | Add tokens to an existing stream's deposit |
-| `update_rate_per_second` | Sender | Change the streaming rate |
-| `shorten_stream_end_time` | Sender | Move end_time earlier; refunds excess deposit |
-| `extend_stream_end_time` | Sender | Move end_time later |
-| `close_completed_stream` | Anyone | Remove a completed stream from storage (cleanup) |
-| `pause_stream_as_admin` | Admin | Administrative pause override |
-| `resume_stream_as_admin` | Admin | Administrative resume override |
-| `cancel_stream_as_admin` | Admin | Administrative cancel override |
-| `set_admin` | Admin | Rotate the admin key |
-| `set_contract_paused` | Admin | Global emergency pause (blocks new stream creation) |
-| `calculate_accrued` | Anyone | View: accrued amount at current ledger time |
-| `get_withdrawable` | Anyone | View: withdrawable amount at current ledger time |
-| `get_claimable_at` | Anyone | View: simulated claimable amount at an arbitrary timestamp |
-| `get_stream_state` | Anyone | View: full stream struct |
-| `get_stream_count` | Anyone | View: total number of streams created |
-| `get_recipient_streams` | Anyone | View: all stream IDs for a recipient (sorted) |
-| `get_recipient_stream_count` | Anyone | View: number of streams for a recipient |
-| `get_config` | Anyone | View: token address and admin address |
-| `version` | Anyone | View: CONTRACT_VERSION constant (pre-flight check) |
+| Entry Point | Caller / Auth Rules | Description |
+| :--- | :--- | :--- |
+| `delegated_withdraw` | `relayer.require_auth()` | Executes an off-chain signed withdrawal payload using an authorized relayer to pay for network gas. |
+| `clone_stream` | `source.sender.require_auth()` | Duplicates an active source stream's configuration vectors to launch an identical parallel stream allocation. |
+| `reserve_stream_ids` | `caller.require_auth()` | Pre-allocates and locks down sequential identifier spaces for multi-step automated initialization streams. |
+| `bulk_cancel_streams` | `sender.require_auth()` | Cancels a collection of stream keys in a single batch, reclaiming remaining un-allocated collateral. |
+| `keeper_cancel` | `keeper.require_auth()` | Allows designated keeper bots to force-terminate insolvent or expired stream states based on parameter gates. |
+| `trigger_auto_claim` | Public / None | Standard unauthenticated entry point to trigger an automated payout slice to a recipient via incentivized relays. |
+| `register_stream_template`| `owner.require_auth()` | Adds a new pre-validated WASM bytecode hash template matrix into global storage. |
+| `sweep_excess` | `admin.require_auth()` & `recipient.require_auth()` | Cleans up stray/native fee balances out of contract spaces directly into a specified target. |
+| `get_stream_health` | Public / None (View) | Read-only analysis interface detailing stream insolvency metrics and structural drift thresholds. |
+| `get_recipient_streams_paginated` | Public / None (View) | Read-only paginated array fetch targeting memory safety across deep address historical records. |
 
-### Cancel semantics
+> For extended configuration properties, edge-case conditions, and execution schemas, check out the complete [Streaming Documentation](docs/streaming.md).
 
 `cancel_stream` and `cancel_stream_as_admin` are valid only when status is `Active` or `Paused`. Streams in `Completed` or `Cancelled` state return `ContractError::InvalidState`. After cancellation, accrual is frozen at `cancelled_at`; the recipient may still withdraw the frozen accrued amount.
 
@@ -229,7 +211,35 @@ See [docs/security.md](docs/security.md#reproducible-wasm-builds) for the full r
 - **fluxora-frontend** — Dashboard and recipient UI
 
 Each is a separate Git repository.
+---
 
+## 🏭 Factory Contract
+The Factory contract anchors the workspace deployment ecosystem by supervising global templates, managing operational scopes, and generating token-bound stream addresses.
+
+* **Initialization (`init`):** Seals factory state parameters, configuring fundamental baseline settings and mapping the primary admin profile.
+* **Policy Setters:** Secure administration entry-points governing structural template overrides, fee parameters, and network ownership allocations.
+* **Stream Creation (`create_stream`):** Instantiates an isolated stream proxy sequence matched precisely against the active, verified template hash register.
+
+> For deployment parameter schemas, factory variables, and initialization matrices, see [docs/factory.md](docs/factory.md).
+
+---
+
+## ⚖️ Governance Contract
+The Governance module coordinates community actions, parameter threshold overrides, and critical upgrade vectors via verifiable checkpoint logic.
+
+* **Proposal Lifecycles (`propose` / `approve` / `execute`):** Standard multi-signature/voting pipeline driving states from conception through validation rounds directly into on-chain enforcement.
+* **Signer Management:** Updates administrative sign-off lists, multisig weights, and required confirmation consensus thresholds.
+
+> For technical consensus models, voter profiles, and cryptographic execution matrices, see [docs/governance.md](docs/governance.md).
+
+---
+
+## 🛠️ Compilation and Local Development
+
+All three workspace contract modules are structured to build simultaneously under standard WebAssembly environments. To compile `stream`, `factory`, and `governance` uniformly in a single action, run:
+
+```bash
+cargo build --target wasm32-unknown-unknown --workspace
 ## Contributing
 
 Please read [CONTRIBUTING.md](CONTRIBUTING.md) for details on the development workflow, branch naming, and testing requirements (including the 95% test coverage standard).

--- a/contracts/governance/src/lib.rs
+++ b/contracts/governance/src/lib.rs
@@ -1,7 +1,9 @@
 #![no_std]
 #![allow(clippy::too_many_arguments)]
 
-use soroban_sdk::{contract, contractimpl, contracttype, contracterror, symbol_short, Address, Bytes, Env, Vec};
+use soroban_sdk::{
+    contract, contracterror, contractimpl, contracttype, symbol_short, Address, Bytes, Env, Vec,
+};
 
 // ---------------------------------------------------------------------------
 // Governance constants
@@ -201,7 +203,9 @@ fn load_proposal(env: &Env, id: u32) -> Result<Proposal, GovernanceError> {
 }
 
 fn save_proposal(env: &Env, id: u32, proposal: &Proposal) {
-    env.storage().persistent().set(&DataKey::Proposal(id), proposal);
+    env.storage()
+        .persistent()
+        .set(&DataKey::Proposal(id), proposal);
     bump_proposal(env, id);
 }
 
@@ -224,11 +228,7 @@ impl FluxoraGovernance {
     /// # Errors
     /// - `AlreadyInitialized`: Contract has already been initialised.
     /// - `TooManySigners`: Provided signer list exceeds `MAX_SIGNERS`.
-    pub fn init(
-        env: Env,
-        admin: Address,
-        signers: Vec<Address>,
-    ) -> Result<(), GovernanceError> {
+    pub fn init(env: Env, admin: Address, signers: Vec<Address>) -> Result<(), GovernanceError> {
         if env.storage().instance().has(&DataKey::Admin) {
             return Err(GovernanceError::AlreadyInitialized);
         }
@@ -238,7 +238,9 @@ impl FluxoraGovernance {
 
         env.storage().instance().set(&DataKey::Admin, &admin);
         env.storage().instance().set(&DataKey::Signers, &signers);
-        env.storage().instance().set(&DataKey::NextProposalId, &0u32);
+        env.storage()
+            .instance()
+            .set(&DataKey::NextProposalId, &0u32);
 
         bump_instance(&env);
         Ok(())
@@ -377,11 +379,7 @@ impl FluxoraGovernance {
     /// - `ProposalNotFound`: No proposal with this ID.
     /// - `AlreadyExecuted`: Proposal has already been executed.
     /// - `AlreadyApproved`: This signer already approved this proposal.
-    pub fn approve(
-        env: Env,
-        approver: Address,
-        proposal_id: u32,
-    ) -> Result<(), GovernanceError> {
+    pub fn approve(env: Env, approver: Address, proposal_id: u32) -> Result<(), GovernanceError> {
         approver.require_auth();
 
         let signers = get_signers(&env)?;
@@ -463,11 +461,7 @@ impl FluxoraGovernance {
     /// - `QuorumNotReached`: Approval count < `GOVERNANCE_QUORUM`.
     /// - `TimelockNotElapsed`: Less than `GOVERNANCE_TIMELOCK_SECONDS` have passed
     ///   since quorum was reached.
-    pub fn execute(
-        env: Env,
-        executor: Address,
-        proposal_id: u32,
-    ) -> Result<(), GovernanceError> {
+    pub fn execute(env: Env, executor: Address, proposal_id: u32) -> Result<(), GovernanceError> {
         executor.require_auth();
 
         let mut proposal = load_proposal(&env, proposal_id)?;

--- a/contracts/stream/src/accrual.rs
+++ b/contracts/stream/src/accrual.rs
@@ -264,7 +264,8 @@ mod kani_proofs {
         };
 
         // Call the function under test. Kani will flag panics or UB.
-        let out = calculate_accrued_amount_checkpointed(state, rate_per_second, deposit_amount, now);
+        let out =
+            calculate_accrued_amount_checkpointed(state, rate_per_second, deposit_amount, now);
 
         // Assert bounds: non-negative and <= deposit_amount
         kani::assert!(out >= 0);
@@ -339,12 +340,22 @@ mod kani_proofs {
             deposit_amount,
         };
 
-        let out_before = calculate_accrued_amount_checkpointed(state, rate_per_second, deposit_amount, now_before);
+        let out_before = calculate_accrued_amount_checkpointed(
+            state,
+            rate_per_second,
+            deposit_amount,
+            now_before,
+        );
         kani::assert!(out_before == 0);
 
         // at or after end
         kani::assume(now_after >= end_time);
-        let out_after = calculate_accrued_amount_checkpointed(state, rate_per_second, deposit_amount, now_after);
+        let out_after = calculate_accrued_amount_checkpointed(
+            state,
+            rate_per_second,
+            deposit_amount,
+            now_after,
+        );
         kani::assert!(out_after >= 0);
         kani::assert!(out_after <= deposit_amount);
     }
@@ -494,9 +505,7 @@ mod invariants {
 mod accrued_after_end_time {
     use crate::accrual::calculate_accrued_amount;
 
-    
     // Helpers
-    
 
     /// A standard stream used across tests:
     ///   start=1000, cliff=1000, end=2000, rate=1/s, deposit=1000

--- a/contracts/stream/src/checksum.rs
+++ b/contracts/stream/src/checksum.rs
@@ -233,14 +233,27 @@ mod tests {
 
         // Verify positions are contiguous and complete
         let positions = [
-            STREAM_ID_POS, SENDER_POS, RECIPIENT_POS, DEPOSIT_AMOUNT_POS,
-            RATE_PER_SECOND_POS, START_TIME_POS, CLIFF_TIME_POS, END_TIME_POS,
-            WITHDRAWN_AMOUNT_POS, STATUS_POS, CANCELLED_AT_POS,
-            CHECKPOINTED_AMOUNT_POS, CHECKPOINTED_AT_POS, WITHDRAW_DUST_THRESHOLD_POS,
+            STREAM_ID_POS,
+            SENDER_POS,
+            RECIPIENT_POS,
+            DEPOSIT_AMOUNT_POS,
+            RATE_PER_SECOND_POS,
+            START_TIME_POS,
+            CLIFF_TIME_POS,
+            END_TIME_POS,
+            WITHDRAWN_AMOUNT_POS,
+            STATUS_POS,
+            CANCELLED_AT_POS,
+            CHECKPOINTED_AMOUNT_POS,
+            CHECKPOINTED_AT_POS,
+            WITHDRAW_DUST_THRESHOLD_POS,
         ];
         assert_eq!(positions.len(), 14);
         for (i, &pos) in positions.iter().enumerate() {
-            assert_eq!(pos, i, "V5 Stream field at index {i} has wrong position {pos}");
+            assert_eq!(
+                pos, i,
+                "V5 Stream field at index {i} has wrong position {pos}"
+            );
         }
     }
 

--- a/contracts/stream/src/lib.rs
+++ b/contracts/stream/src/lib.rs
@@ -2,12 +2,12 @@
 #![allow(clippy::too_many_arguments)]
 
 mod accrual;
-mod token_check;
 #[cfg(test)]
 mod checksum;
+mod token_check;
 
-use token_check::verify_token_behavior;
 use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, token, Address, Env};
+use token_check::verify_token_behavior;
 
 // ---------------------------------------------------------------------------
 // TTL constants
@@ -1456,11 +1456,7 @@ fn save_rotation_history(env: &Env, stream_id: u64, history: &soroban_sdk::Vec<R
     );
 }
 
-fn append_rotation_entry(
-    env: &Env,
-    stream_id: u64,
-    entry: RotationEntry,
-) {
+fn append_rotation_entry(env: &Env, stream_id: u64, entry: RotationEntry) {
     let mut history = load_rotation_history(env, stream_id);
     if history.len() as u32 >= MAX_ROTATION_HISTORY {
         history.remove(0);
@@ -2621,7 +2617,8 @@ impl FluxoraStream {
 
         // Check pause/resume cooldown to prevent rapid-toggle DoS
         let current_ledger = env.ledger().sequence();
-        let ledgers_since_last_toggle = current_ledger.saturating_sub(stream.last_pause_toggle_ledger);
+        let ledgers_since_last_toggle =
+            current_ledger.saturating_sub(stream.last_pause_toggle_ledger);
         if ledgers_since_last_toggle < MIN_PAUSE_INTERVAL_LEDGERS {
             return Err(ContractError::PauseCooldownActive);
         }
@@ -2636,7 +2633,10 @@ impl FluxoraStream {
         };
         env.events().publish(
             (symbol_short!("paused"), stream_id),
-            StreamPaused { stream_id, reason: reason_str },
+            StreamPaused {
+                stream_id,
+                reason: reason_str,
+            },
         );
         Ok(())
     }
@@ -2684,7 +2684,8 @@ impl FluxoraStream {
 
         // Check pause/resume cooldown to prevent rapid-toggle DoS
         let current_ledger = env.ledger().sequence();
-        let ledgers_since_last_toggle = current_ledger.saturating_sub(stream.last_pause_toggle_ledger);
+        let ledgers_since_last_toggle =
+            current_ledger.saturating_sub(stream.last_pause_toggle_ledger);
         if ledgers_since_last_toggle < MIN_PAUSE_INTERVAL_LEDGERS {
             return Err(ContractError::PauseCooldownActive);
         }
@@ -4910,37 +4911,40 @@ impl FluxoraStream {
     ) -> Page {
         let streams = load_recipient_streams(&env, &recipient);
         let total = streams.len();
-        
+
         // Apply limit cap
         let effective_limit = limit.min(RECIPIENT_STREAMS_PAGE_LIMIT);
-        
+
         // Find starting position
         let start_idx = if cursor == 0 {
             0
         } else {
             match streams.binary_search(&cursor) {
-                Ok(pos) => pos + 1,  // Start after the cursor
-                Err(pos) => pos,     // Insert position if not found
+                Ok(pos) => pos + 1, // Start after the cursor
+                Err(pos) => pos,    // Insert position if not found
             }
         };
-        
+
         // Calculate end position
         let end_idx = (start_idx as u32 + effective_limit).min(total as u32);
-        
+
         let mut next_cursor = 0u64;
         if (end_idx as usize) < total as usize {
             next_cursor = streams.get(end_idx).unwrap();
         }
-        
+
         let mut page_streams = soroban_sdk::Vec::new(&env);
         for i in start_idx..end_idx {
             page_streams.push_back(streams.get(i).unwrap());
         }
-        
-        Page { stream_ids: page_streams, next_cursor }
+
+        Page {
+            stream_ids: page_streams,
+            next_cursor,
+        }
     }
 
-     /// Count the total number of streams for a recipient.
+    /// Count the total number of streams for a recipient.
     ///
     /// Returns the count of streams where the recipient is the stream's recipient address.
     /// This is a convenience function that avoids fetching the full vector when only
@@ -5245,11 +5249,7 @@ impl FluxoraStream {
     /// - CEI pattern: stream is marked Cancelled before any token transfer.
     /// - Keeper fee is deducted from the sender's unstreamed refund, never from the recipient.
     /// - Reentrancy is mitigated by the terminal-state write preceding all transfers.
-    pub fn keeper_cancel(
-        env: Env,
-        stream_id: u64,
-        keeper: Address,
-    ) -> Result<(), ContractError> {
+    pub fn keeper_cancel(env: Env, stream_id: u64, keeper: Address) -> Result<(), ContractError> {
         keeper.require_auth();
 
         let mut stream = load_stream(&env, stream_id)?;
@@ -5398,7 +5398,8 @@ impl FluxoraStream {
 
         // Check pause/resume cooldown to prevent rapid-toggle DoS
         let current_ledger = env.ledger().sequence();
-        let ledgers_since_last_toggle = current_ledger.saturating_sub(stream.last_pause_toggle_ledger);
+        let ledgers_since_last_toggle =
+            current_ledger.saturating_sub(stream.last_pause_toggle_ledger);
         if ledgers_since_last_toggle < MIN_PAUSE_INTERVAL_LEDGERS {
             return Err(ContractError::PauseCooldownActive);
         }
@@ -5424,7 +5425,10 @@ impl FluxoraStream {
 
         env.events().publish(
             (symbol_short!("paused"), stream_id),
-            StreamPaused { stream_id, reason: reason_str },
+            StreamPaused {
+                stream_id,
+                reason: reason_str,
+            },
         );
         Ok(())
     }
@@ -5469,7 +5473,8 @@ impl FluxoraStream {
 
         // Check pause/resume cooldown to prevent rapid-toggle DoS
         let current_ledger = env.ledger().sequence();
-        let ledgers_since_last_toggle = current_ledger.saturating_sub(stream.last_pause_toggle_ledger);
+        let ledgers_since_last_toggle =
+            current_ledger.saturating_sub(stream.last_pause_toggle_ledger);
         if ledgers_since_last_toggle < MIN_PAUSE_INTERVAL_LEDGERS {
             return Err(ContractError::PauseCooldownActive);
         }
@@ -6189,7 +6194,9 @@ impl FluxoraStream {
             Some(destination) => {
                 // Check if destination is valid
                 if !Self::is_valid_destination(&env, &destination) {
-                    return Ok(AutoClaimStatus::InvalidDestination(AutoClaimInvalidPayload { destination }));
+                    return Ok(AutoClaimStatus::InvalidDestination(
+                        AutoClaimInvalidPayload { destination },
+                    ));
                 }
 
                 // Calculate claimable amount
@@ -6481,7 +6488,11 @@ impl FluxoraStream {
         let start_id = read_stream_count(&env);
         set_stream_count(&env, start_id + count as u64);
 
-        let res = IdReservation { start_id, count, consumed: 0 };
+        let res = IdReservation {
+            start_id,
+            count,
+            consumed: 0,
+        };
         save_id_reservation(&env, &caller, &res);
 
         let mut ids = soroban_sdk::Vec::new(&env);
@@ -6513,179 +6524,181 @@ mod test_issue_39;
 #[cfg(test)]
 mod test_withdrawable_props;
 
-    /// Atomically cancel multiple streams owned by the caller and refund the aggregate
-    /// unstreamed balance in a single token transfer.
-    ///
-    /// This is the batch counterpart to `cancel_stream`. It provides gas-efficient
-    /// off-boarding for senders managing large portfolios (up to `MAX_PAGE_SIZE` streams).
-    ///
-    /// # Two-phase execution
-    /// 1. **Validation phase**: Every `stream_id` is loaded and verified:
-    ///    - Stream must exist (`StreamNotFound` otherwise).
-    ///    - Caller must be the stream sender (`Unauthorized` otherwise).
-    ///    - Stream must be in `Active` or `Paused` state (`InvalidState` otherwise).
-    ///    - Duplicate `stream_id`s are rejected (`DuplicateStreamId`).
-    /// 2. **Execution phase**: Only after all validations pass:
-    ///    - Per-stream accrued amount is computed.
-    ///    - Recipient is paid their accrued entitlement (individual transfers).
-    ///    - Stream is marked `Cancelled` with `cancelled_at` timestamp.
-    ///    - `StreamCancelled` event is emitted per stream.
-    ///    - Aggregate refund is computed and sent to the sender in **one** token transfer.
-    ///
-    /// # Parameters
-    /// - `stream_ids`: Vector of stream IDs to cancel. Must be unique. Max length is
-    ///   bounded by the caller's transaction resources; the contract enforces no hard
-    ///   limit beyond Soroban's own VM limits, but `MAX_PAGE_SIZE = 100` is the
-    ///   recommended batch size for gas predictability.
-    ///
-    /// # Authorization
-    /// - Requires authorization from the caller (who must be the sender of every stream).
-    ///
-    /// # Returns
-    /// - `Ok(())` on success.
-    ///
-    /// # Errors
-    /// - `ContractError::DuplicateStreamId` (14): Duplicate IDs in `stream_ids`.
-    /// - `ContractError::StreamNotFound` (1): A stream ID does not exist.
-    /// - `ContractError::Unauthorized` (7): Caller is not the sender of a stream.
-    /// - `ContractError::InvalidState` (2): A stream is not `Active` or `Paused`.
-    /// - `ContractError::ContractPaused` (4): Global emergency pause is active.
-    ///
-    /// # Gas efficiency
-    /// - One auth check for the entire batch.
-    /// - One token transfer for the aggregate refund (vs. N transfers for N individual
-    ///   `cancel_stream` calls).
-    /// - Per-stream recipient transfers are still individual (required for correct
-    ///   accounting and event emission), but the sender refund is batched.
-    ///
-    /// # Events
-    /// - One `StreamCancelled` event per successfully cancelled stream.
-    /// - One `cancelled` topic event per stream (same shape as `cancel_stream`).
-    ///
-    /// # Security
-    /// - Atomic: any failure in validation or execution reverts the entire batch.
-    /// - CEI pattern: state is persisted before every external token transfer.
-    /// - Liabilities are reduced per-stream before the aggregate refund.
-    pub fn bulk_cancel_streams(
-        env: Env,
-        sender: Address,
-        stream_ids: soroban_sdk::Vec<u64>,
-    ) -> Result<(), ContractError> {
-        require_not_globally_paused(&env)?;
-        sender.require_auth();
+/// Atomically cancel multiple streams owned by the caller and refund the aggregate
+/// unstreamed balance in a single token transfer.
+///
+/// This is the batch counterpart to `cancel_stream`. It provides gas-efficient
+/// off-boarding for senders managing large portfolios (up to `MAX_PAGE_SIZE` streams).
+///
+/// # Two-phase execution
+/// 1. **Validation phase**: Every `stream_id` is loaded and verified:
+///    - Stream must exist (`StreamNotFound` otherwise).
+///    - Caller must be the stream sender (`Unauthorized` otherwise).
+///    - Stream must be in `Active` or `Paused` state (`InvalidState` otherwise).
+///    - Duplicate `stream_id`s are rejected (`DuplicateStreamId`).
+/// 2. **Execution phase**: Only after all validations pass:
+///    - Per-stream accrued amount is computed.
+///    - Recipient is paid their accrued entitlement (individual transfers).
+///    - Stream is marked `Cancelled` with `cancelled_at` timestamp.
+///    - `StreamCancelled` event is emitted per stream.
+///    - Aggregate refund is computed and sent to the sender in **one** token transfer.
+///
+/// # Parameters
+/// - `stream_ids`: Vector of stream IDs to cancel. Must be unique. Max length is
+///   bounded by the caller's transaction resources; the contract enforces no hard
+///   limit beyond Soroban's own VM limits, but `MAX_PAGE_SIZE = 100` is the
+///   recommended batch size for gas predictability.
+///
+/// # Authorization
+/// - Requires authorization from the caller (who must be the sender of every stream).
+///
+/// # Returns
+/// - `Ok(())` on success.
+///
+/// # Errors
+/// - `ContractError::DuplicateStreamId` (14): Duplicate IDs in `stream_ids`.
+/// - `ContractError::StreamNotFound` (1): A stream ID does not exist.
+/// - `ContractError::Unauthorized` (7): Caller is not the sender of a stream.
+/// - `ContractError::InvalidState` (2): A stream is not `Active` or `Paused`.
+/// - `ContractError::ContractPaused` (4): Global emergency pause is active.
+///
+/// # Gas efficiency
+/// - One auth check for the entire batch.
+/// - One token transfer for the aggregate refund (vs. N transfers for N individual
+///   `cancel_stream` calls).
+/// - Per-stream recipient transfers are still individual (required for correct
+///   accounting and event emission), but the sender refund is batched.
+///
+/// # Events
+/// - One `StreamCancelled` event per successfully cancelled stream.
+/// - One `cancelled` topic event per stream (same shape as `cancel_stream`).
+///
+/// # Security
+/// - Atomic: any failure in validation or execution reverts the entire batch.
+/// - CEI pattern: state is persisted before every external token transfer.
+/// - Liabilities are reduced per-stream before the aggregate refund.
+pub fn bulk_cancel_streams(
+    env: Env,
+    sender: Address,
+    stream_ids: soroban_sdk::Vec<u64>,
+) -> Result<(), ContractError> {
+    require_not_globally_paused(&env)?;
+    sender.require_auth();
 
-        let n = stream_ids.len();
-        if n == 0 {
-            return Ok(());
+    let n = stream_ids.len();
+    if n == 0 {
+        return Ok(());
+    }
+
+    // ── Phase 1: Validate all stream IDs and ownership ────────────────────
+    let mut streams = soroban_sdk::Vec::<Stream>::new(&env);
+
+    for i in 0..n {
+        let id = stream_ids.get(i).unwrap();
+
+        // Duplicate detection
+        let mut j = i + 1;
+        while j < n {
+            if stream_ids.get(j).unwrap() == id {
+                return Err(ContractError::DuplicateStreamId);
+            }
+            j += 1;
         }
 
-        // ── Phase 1: Validate all stream IDs and ownership ────────────────────
-        let mut streams = soroban_sdk::Vec::<Stream>::new(&env);
+        let stream = load_stream(&env, id)?;
 
-        for i in 0..n {
-            let id = stream_ids.get(i).unwrap();
-
-            // Duplicate detection
-            let mut j = i + 1;
-            while j < n {
-                if stream_ids.get(j).unwrap() == id {
-                    return Err(ContractError::DuplicateStreamId);
-                }
-                j += 1;
-            }
-
-            let stream = load_stream(&env, id)?;
-
-            if stream.sender != sender {
-                return Err(ContractError::Unauthorized);
-            }
-
-            Self::require_cancellable_status(stream.status)?;
-
-            streams.push_back(stream);
+        if stream.sender != sender {
+            return Err(ContractError::Unauthorized);
         }
 
-        // ── Phase 2: Execute cancellations ────────────────────────────────────
-        let now = env.ledger().timestamp();
-        let mut aggregate_refund: i128 = 0;
+        Self::require_cancellable_status(stream.status)?;
 
-        for i in 0..n {
-            let mut stream = streams.get(i).unwrap();
-            let stream_id = stream.stream_id;
+        streams.push_back(stream);
+    }
 
-            let accrued_at_cancel = accrual::calculate_accrued_amount_checkpointed(
-                accrual::CheckpointState {
-                    checkpointed_amount: stream.checkpointed_amount,
-                    checkpointed_at: stream.checkpointed_at,
-                    cliff_time: stream.cliff_time,
-                    end_time: stream.end_time,
-                    deposit_amount: stream.deposit_amount,
-                },
-                stream.rate_per_second,
-                now,
-            );
+    // ── Phase 2: Execute cancellations ────────────────────────────────────
+    let now = env.ledger().timestamp();
+    let mut aggregate_refund: i128 = 0;
 
-            let refund_amount = stream
-                .deposit_amount
-                .checked_sub(accrued_at_cancel)
-                .ok_or(ContractError::InvalidState)?;
+    for i in 0..n {
+        let mut stream = streams.get(i).unwrap();
+        let stream_id = stream.stream_id;
 
-            let (was_underfunded, _, _) = compute_stream_health(&stream, now);
+        let accrued_at_cancel = accrual::calculate_accrued_amount_checkpointed(
+            accrual::CheckpointState {
+                checkpointed_amount: stream.checkpointed_amount,
+                checkpointed_at: stream.checkpointed_at,
+                cliff_time: stream.cliff_time,
+                end_time: stream.end_time,
+                deposit_amount: stream.deposit_amount,
+            },
+            stream.rate_per_second,
+            now,
+        );
 
-            // ── Pay recipient their accrued entitlement first ─────────────────
-            let recipient_accrual = accrued_at_cancel.saturating_sub(stream.withdrawn_amount).max(0);
-            if recipient_accrual > 0 {
-                stream.withdrawn_amount = stream
-                    .withdrawn_amount
-                    .checked_add(recipient_accrual)
-                    .unwrap_or(i128::MAX);
+        let refund_amount = stream
+            .deposit_amount
+            .checked_sub(accrued_at_cancel)
+            .ok_or(ContractError::InvalidState)?;
 
-                let liabilities = read_total_liabilities(&env)
-                    .checked_sub(recipient_accrual)
-                    .unwrap_or(0);
-                write_total_liabilities(&env, liabilities);
+        let (was_underfunded, _, _) = compute_stream_health(&stream, now);
 
-                push_token(&env, &stream.recipient, recipient_accrual)?;
+        // ── Pay recipient their accrued entitlement first ─────────────────
+        let recipient_accrual = accrued_at_cancel
+            .saturating_sub(stream.withdrawn_amount)
+            .max(0);
+        if recipient_accrual > 0 {
+            stream.withdrawn_amount = stream
+                .withdrawn_amount
+                .checked_add(recipient_accrual)
+                .unwrap_or(i128::MAX);
 
-                env.events().publish(
-                    (symbol_short!("withdrew"), stream_id),
-                    Withdrawal {
-                        stream_id,
-                        recipient: stream.recipient.clone(),
-                        amount: recipient_accrual,
-                    },
-                );
-            }
+            let liabilities = read_total_liabilities(&env)
+                .checked_sub(recipient_accrual)
+                .unwrap_or(0);
+            write_total_liabilities(&env, liabilities);
 
-            // ── Mark stream as cancelled ──────────────────────────────────────
-            stream.status = StreamStatus::Cancelled;
-            stream.cancelled_at = Some(now);
-            save_stream(&env, &stream);
-
-            // ── Accumulate sender refund ──────────────────────────────────────
-            if refund_amount > 0 {
-                aggregate_refund = aggregate_refund
-                    .checked_add(refund_amount)
-                    .ok_or(ContractError::ArithmeticOverflow)?;
-
-                let liabilities = read_total_liabilities(&env)
-                    .checked_sub(refund_amount)
-                    .unwrap_or(0);
-                write_total_liabilities(&env, liabilities);
-            }
+            push_token(&env, &stream.recipient, recipient_accrual)?;
 
             env.events().publish(
-                (symbol_short!("cancelled"), stream_id),
-                StreamEvent::StreamCancelled(stream_id),
+                (symbol_short!("withdrew"), stream_id),
+                Withdrawal {
+                    stream_id,
+                    recipient: stream.recipient.clone(),
+                    amount: recipient_accrual,
+                },
             );
-
-            maybe_emit_health_changed(&env, &stream, was_underfunded, now);
         }
 
-        // ── Single aggregate refund to sender ─────────────────────────────────
-        if aggregate_refund > 0 {
-            push_token(&env, &sender, aggregate_refund)?;
+        // ── Mark stream as cancelled ──────────────────────────────────────
+        stream.status = StreamStatus::Cancelled;
+        stream.cancelled_at = Some(now);
+        save_stream(&env, &stream);
+
+        // ── Accumulate sender refund ──────────────────────────────────────
+        if refund_amount > 0 {
+            aggregate_refund = aggregate_refund
+                .checked_add(refund_amount)
+                .ok_or(ContractError::ArithmeticOverflow)?;
+
+            let liabilities = read_total_liabilities(&env)
+                .checked_sub(refund_amount)
+                .unwrap_or(0);
+            write_total_liabilities(&env, liabilities);
         }
 
-        Ok(())
+        env.events().publish(
+            (symbol_short!("cancelled"), stream_id),
+            StreamEvent::StreamCancelled(stream_id),
+        );
+
+        maybe_emit_health_changed(&env, &stream, was_underfunded, now);
     }
+
+    // ── Single aggregate refund to sender ─────────────────────────────────
+    if aggregate_refund > 0 {
+        push_token(&env, &sender, aggregate_refund)?;
+    }
+
+    Ok(())
+}

--- a/contracts/stream/src/test.rs
+++ b/contracts/stream/src/test.rs
@@ -1,4 +1,4 @@
-﻿extern crate std;
+extern crate std;
 
 use soroban_sdk::{
     testutils::{Address as _, Events, Ledger},
@@ -168,9 +168,9 @@ impl<'a> TestContext<'a> {
             &0u64,      // cliff_time (no cliff)
             &1000u64,   // end_time
             &0,
-            &None,,
+            &None,
             &crate::StreamKind::Linear,
-            )
+        )
     }
 
     /// Create a stream with a cliff at t=500 out of 1000s.
@@ -185,9 +185,9 @@ impl<'a> TestContext<'a> {
             &500u64, // cliff at t=500
             &1000u64,
             &0,
-            &None,,
+            &None,
             &crate::StreamKind::Linear,
-            )
+        )
     }
 
     pub(crate) fn create_max_rate_stream(&self) -> u64 {
@@ -201,9 +201,9 @@ impl<'a> TestContext<'a> {
             &0u64,
             &3,
             &0,
-            &None,,
+            &None,
             &crate::StreamKind::Linear,
-            )
+        )
     }
 
     pub(crate) fn create_half_max_rate_stream(&self) -> u64 {
@@ -217,9 +217,9 @@ impl<'a> TestContext<'a> {
             &0u64,
             &100,
             &0,
-            &None,,
+            &None,
             &crate::StreamKind::Linear,
-            )
+        )
     }
 }
 
@@ -419,9 +419,17 @@ fn test_init_sets_stream_counter_to_zero() {
 
     env.ledger().set_timestamp(0);
     let stream_id = client2.create_stream(
-        &sender, &recipient, &1000_i128, &1_i128, &0u64, &0u64, &1000u64, &0, &None,,
+        &sender,
+        &recipient,
+        &1000_i128,
+        &1_i128,
+        &0u64,
+        &0u64,
+        &1000u64,
+        &0,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     assert_eq!(stream_id, 0, "first stream should have id 0");
 }
@@ -454,9 +462,9 @@ fn test_get_stream_count_tracks_successful_creates() {
         &0u64,
         &1_000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
     assert_eq!(id1, 1);
     assert_eq!(ctx.client().get_stream_count(), 2);
 }
@@ -607,9 +615,17 @@ fn test_operations_work_after_failed_reinit() {
     // Contract must still accept streams
     env.ledger().set_timestamp(0);
     let stream_id = client.create_stream(
-        &sender, &recipient, &1000_i128, &1_i128, &0u64, &0u64, &1000u64, &0, &None,,
+        &sender,
+        &recipient,
+        &1000_i128,
+        &1_i128,
+        &0u64,
+        &0u64,
+        &1000u64,
+        &0,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     let state = client.get_stream_state(&stream_id);
     assert_eq!(state.stream_id, 0);
@@ -654,9 +670,9 @@ fn test_create_stream_emits_event() {
         &0u64,
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     let events = ctx.env.events().all();
     let event = events.last().unwrap();
@@ -686,9 +702,9 @@ fn test_create_stream_panics_when_contract_paused() {
         &0u64,
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
     assert_eq!(result, Err(Ok(ContractError::ContractPaused)));
 }
 
@@ -707,9 +723,9 @@ fn test_create_stream_succeeds_after_unpause() {
         &0u64,
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
     assert_eq!(id, 0);
     assert_eq!(
         ctx.client().get_stream_state(&id).status,
@@ -787,9 +803,9 @@ fn test_create_stream_zero_deposit_panics() {
         &0u64,
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
     assert_eq!(result, Err(Ok(ContractError::InvalidParams)));
 }
 
@@ -806,9 +822,9 @@ fn test_create_stream_invalid_times_panics() {
         &1000u64,
         &500u64, // end before start
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
     assert_eq!(result, Err(Ok(ContractError::InvalidParams)));
 }
 
@@ -825,9 +841,9 @@ fn test_create_stream_multiple() {
         &1000u64, // cliff equals end
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     let stream_id_2 = ctx.client().create_stream(
         &ctx.sender,
@@ -838,9 +854,9 @@ fn test_create_stream_multiple() {
         &1000u64, // cliff equals end
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     let stream_id_3 = ctx.client().create_stream(
         &ctx.sender,
@@ -851,9 +867,9 @@ fn test_create_stream_multiple() {
         &0u64, // cliff equals end
         &500u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     let stream_id_4 = ctx.client().create_stream(
         &ctx.sender,
@@ -864,9 +880,9 @@ fn test_create_stream_multiple() {
         &0u64, // cliff equals end
         &4000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     let stream_id_5 = ctx.client().create_stream(
         &ctx.sender,
@@ -877,9 +893,9 @@ fn test_create_stream_multiple() {
         &0u64, // cliff equals end
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     let state = ctx.client().get_stream_state(&stream_id_1);
     assert_eq!(state.stream_id, 0);
@@ -914,9 +930,9 @@ fn test_create_stream_multiple_loop() {
             &0u64, // cliff equals end
             &10u64,
             &0,
-            &None,,
+            &None,
             &crate::StreamKind::Linear,
-            );
+        );
 
         counter += 1;
 
@@ -974,9 +990,9 @@ fn test_create_stream_large_deposit_accepted() {
         &0u64,
         &duration,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     let state = ctx.client().get_stream_state(&stream_id);
     assert_eq!(state.deposit_amount, large_deposit);
@@ -1008,9 +1024,9 @@ fn test_create_stream_long_duration_accepted() {
         &0u64,
         &duration,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     let state = ctx.client().get_stream_state(&stream_id);
     assert_eq!(state.end_time - state.start_time, duration);
@@ -1042,9 +1058,9 @@ fn test_large_deposit_amount_sanity() {
         &0u64,
         &duration,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     // Check midway
     let midway = duration / 2;
@@ -1082,9 +1098,9 @@ fn test_create_stream_end_equals_start_panics() {
         &500u64,
         &500u64, // end == start
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 }
 
 /// end_time strictly less than start_time must panic
@@ -1102,9 +1118,9 @@ fn test_create_stream_end_before_start_panics() {
         &1000u64,
         &999u64, // end < start
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 }
 
 /// end_time exactly one second before start_time (boundary)
@@ -1122,9 +1138,9 @@ fn test_create_stream_end_one_less_than_start_panics() {
         &100u64,
         &99u64, // end = start - 1
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 }
 
 // --- Group 2: cliff_time outside [start_time, end_time] ---
@@ -1144,9 +1160,9 @@ fn test_create_stream_cliff_one_before_start_panics() {
         &99u64, // cliff = start - 1
         &1100u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 }
 
 /// cliff_time one second after end_time (upper boundary violation)
@@ -1164,9 +1180,9 @@ fn test_create_stream_cliff_one_after_end_panics() {
         &1001u64, // cliff = end + 1
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 }
 
 /// cliff_time far before start_time
@@ -1184,9 +1200,9 @@ fn test_create_stream_cliff_far_before_start_panics() {
         &0u64, // cliff far before start
         &1500u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 }
 
 /// cliff_time far after end_time
@@ -1204,9 +1220,9 @@ fn test_create_stream_cliff_far_after_end_panics() {
         &9999u64, // cliff far after end
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 }
 
 /// cliff_time at start_time is valid (inclusive lower bound)
@@ -1223,9 +1239,9 @@ fn test_create_stream_cliff_at_start_valid() {
         &100u64, // cliff == start
         &1100u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
     let state = ctx.client().get_stream_state(&id);
     assert_eq!(state.cliff_time, 100);
     assert_eq!(state.start_time, 100);
@@ -1245,9 +1261,9 @@ fn test_create_stream_cliff_at_end_valid() {
         &1000u64, // cliff == end
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
     let state = ctx.client().get_stream_state(&id);
     assert_eq!(state.cliff_time, 1000);
     assert_eq!(state.end_time, 1000);
@@ -1270,9 +1286,9 @@ fn test_create_stream_deposit_zero_panics() {
         &0u64,
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 }
 
 /// deposit_amount of -1 must panic
@@ -1290,9 +1306,9 @@ fn test_create_stream_deposit_minus_one_panics() {
         &0u64,
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 }
 
 /// deposit_amount of i128::MIN must panic
@@ -1310,9 +1326,9 @@ fn test_create_stream_deposit_i128_min_panics() {
         &0u64,
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 }
 
 /// deposit_amount of 1 is valid (minimum positive)
@@ -1353,9 +1369,9 @@ fn test_create_stream_rate_zero_panics() {
         &0u64,
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 }
 
 /// rate_per_second of -1 must panic
@@ -1373,9 +1389,9 @@ fn test_create_stream_rate_minus_one_panics() {
         &0u64,
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 }
 
 /// rate_per_second of i128::MIN must panic
@@ -1393,9 +1409,9 @@ fn test_create_stream_rate_i128_min_panics() {
         &0u64,
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 }
 
 /// rate_per_second of 1 is valid (minimum positive)
@@ -1412,9 +1428,9 @@ fn test_create_stream_rate_one_valid() {
         &0u64,
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
     let state = ctx.client().get_stream_state(&id);
     assert_eq!(state.rate_per_second, 1);
 }
@@ -1437,9 +1453,9 @@ fn test_create_stream_deposit_one_less_than_required_panics() {
         &0u64,
         &500u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 }
 
 /// deposit exactly equal to rate * duration is valid (boundary pass)
@@ -1457,9 +1473,9 @@ fn test_create_stream_deposit_exactly_required_valid() {
         &0u64,
         &500u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
     let state = ctx.client().get_stream_state(&id);
     assert_eq!(state.deposit_amount, 1000);
 }
@@ -1480,9 +1496,9 @@ fn test_create_stream_deposit_far_below_required_panics() {
         &0u64,
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 }
 
 /// deposit greater than required is valid (excess stays in contract)
@@ -1499,9 +1515,9 @@ fn test_create_stream_deposit_above_required_valid() {
         &0u64,
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
     let state = ctx.client().get_stream_state(&id);
     assert_eq!(state.deposit_amount, 5000);
     assert_eq!(state.status, StreamStatus::Active);
@@ -1524,9 +1540,9 @@ fn test_create_stream_sender_is_recipient_panics() {
         &0u64,
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 }
 
 /// Self-streaming must not persist state, move tokens, or emit events.
@@ -1550,9 +1566,9 @@ fn test_create_stream_sender_equals_recipient_has_no_side_effects() {
         &0u64,
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     assert_eq!(
         ctx.client().get_stream_count(),
@@ -1591,9 +1607,9 @@ fn test_create_stream_different_sender_recipient_valid() {
         &0u64,
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
     let state = ctx.client().get_stream_state(&id);
     assert_ne!(state.sender, state.recipient);
 }
@@ -1616,9 +1632,9 @@ fn test_create_stream_zero_rate_panics() {
         &0u64,
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 }
 
 #[test]
@@ -1635,9 +1651,9 @@ fn test_create_stream_sender_equals_recipient_panics() {
         &0u64,
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -1658,9 +1674,9 @@ fn test_create_stream_cliff_before_start_panics() {
         &50u64,   // cliff_time before start
         &1100u64, // end_time
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 }
 
 #[test]
@@ -1677,9 +1693,9 @@ fn test_create_stream_cliff_after_end_panics() {
         &1500u64, // cliff_time after end
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 }
 
 #[test]
@@ -1695,9 +1711,9 @@ fn test_create_stream_cliff_equals_start_succeeds() {
         &0u64, // cliff equals start
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
     let state = ctx.client().get_stream_state(&stream_id);
     assert_eq!(state.cliff_time, 0);
 }
@@ -1715,9 +1731,9 @@ fn test_create_stream_cliff_equals_end_succeeds() {
         &1000u64, // cliff equals end
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
     let state = ctx.client().get_stream_state(&stream_id);
     assert_eq!(state.cliff_time, 1000);
 }
@@ -1758,9 +1774,9 @@ fn test_create_stream_deposit_equals_total_succeeds() {
         &0u64,
         &1000u64, // duration = 1000s
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
     let state = ctx.client().get_stream_state(&stream_id);
     assert_eq!(state.deposit_amount, 1000);
 }
@@ -1804,9 +1820,9 @@ fn test_create_stream_insufficient_balance_panics() {
         &0u64,
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 }
 
 #[test]
@@ -1825,9 +1841,9 @@ fn test_create_stream_transfer_failure_no_state_change() {
             &0u64,
             &1000u64,
             &0,
-            &None,,
+            &None,
             &crate::StreamKind::Linear,
-            )
+        )
     }));
 
     assert!(
@@ -1867,9 +1883,9 @@ fn test_calculate_accrued_before_cliff() {
         &500u64,
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
     ctx.env.ledger().set_timestamp(300);
     let accrued = ctx.client().calculate_accrued(&stream_id);
     assert_eq!(accrued, 0);
@@ -1932,9 +1948,9 @@ fn test_accrued_after_cliff_before_end() {
         &500u64,
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     ctx.env.ledger().set_timestamp(500);
     assert_eq!(ctx.client().calculate_accrued(&stream_id), 5000);
@@ -1967,9 +1983,9 @@ fn test_create_stream_with_cliff_equals_start_accrues_immediately() {
         &0u64,      // cliff_time (equal to start_time)
         &1000u64,   // end_time
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     // Advance time past start; since cliff == start, accrual should begin immediately
     ctx.env.ledger().set_timestamp(500);
@@ -2126,9 +2142,9 @@ fn test_calculate_accrued_paused_before_cliff() {
         &500u64,  // cliff_time
         &1000u64, // end_time
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     // Advance to t=300 (before cliff) and pause
     ctx.env.ledger().set_timestamp(300);
@@ -2159,9 +2175,9 @@ fn test_calculate_accrued_paused_after_cliff() {
         &500u64,  // cliff_time
         &1000u64, // end_time
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     // Advance past cliff and pause
     ctx.env.ledger().set_timestamp(600);
@@ -2198,9 +2214,9 @@ fn test_calculate_accrued_paused_at_end_time() {
         &0u64,
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     // Advance to nearly end_time and pause
     ctx.env.ledger().set_timestamp(999);
@@ -2276,9 +2292,9 @@ fn test_calculate_accrued_cancelled_before_cliff() {
         &500u64,  // cliff_time
         &1000u64, // end_time
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     // Cancel at t=300 (before cliff)
     ctx.env.ledger().set_timestamp(300);
@@ -2312,9 +2328,9 @@ fn test_calculate_accrued_cancelled_at_cliff() {
         &500u64,  // cliff_time
         &1000u64, // end_time
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     // Cancel at exact cliff time (t=500)
     ctx.env.ledger().set_timestamp(500);
@@ -2442,9 +2458,9 @@ fn test_calculate_accrued_zero_duration_stream() {
         &500u64, // cliff_time
         &500u64, // end_time
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     assert_eq!(result, Err(Ok(ContractError::InvalidParams)));
 }
@@ -2466,9 +2482,9 @@ fn test_calculate_accrued_zero_deposit_stream() {
         &100u64,
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     assert_eq!(result, Err(Ok(ContractError::InvalidParams)));
 }
@@ -2490,9 +2506,9 @@ fn test_calculate_accrued_zero_rate_stream() {
         &100u64,
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     assert_eq!(result, Err(Ok(ContractError::InvalidParams)));
 }
@@ -2523,9 +2539,9 @@ fn test_large_rate_no_overflow() {
         &0u64,
         &2u64, // Very short duration
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     ctx.env.ledger().set_timestamp(1);
 
@@ -2557,9 +2573,9 @@ fn test_large_duration_no_overflow() {
         &0u64,
         &duration,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     // Set time to a very large value past the end
     ctx.env.ledger().set_timestamp(duration + 1_000_000);
@@ -2598,9 +2614,9 @@ fn test_combined_large_rate_and_duration() {
         &0u64,
         &duration,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     // Set time to cause potential overflow in multiplication
     ctx.env.ledger().set_timestamp(50);
@@ -2632,9 +2648,9 @@ fn test_boundary_max_rate_per_second() {
         &0u64,
         &2u64, // Short duration
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     ctx.env.ledger().set_timestamp(2);
 
@@ -2660,9 +2676,9 @@ fn test_boundary_min_positive_values() {
         &0u64,
         &1u64, // Minimum duration
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     ctx.env.ledger().set_timestamp(1);
 
@@ -2687,9 +2703,9 @@ fn test_zero_rate_returns_zero() {
         &0u64,
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     // Even with time elapsed, if rate were 0, accrued would be 0
     ctx.env.ledger().set_timestamp(500);
@@ -2715,9 +2731,9 @@ fn test_zero_duration_returns_zero() {
         &0u64, // No cliff
         &0u64,
         &0, // End at 0 (duration is zero)
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     assert_eq!(result, Err(Ok(crate::ContractError::InvalidParams)));
 }
@@ -2743,9 +2759,9 @@ fn test_result_capping_at_deposit() {
         &0u64,
         &duration,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     // Set time way past end
     ctx.env.ledger().set_timestamp(10000);
@@ -2782,9 +2798,9 @@ fn test_result_capping_with_overflow() {
         &0u64,
         &duration,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     ctx.env.ledger().set_timestamp(1);
 
@@ -2819,9 +2835,9 @@ fn test_no_panic_on_extreme_inputs() {
         &0u64,
         &duration,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     // Test at various timestamps
     ctx.env.ledger().set_timestamp(2);
@@ -2854,9 +2870,9 @@ fn test_no_underflow_negative_result() {
         &1000u64,
         &2000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     // Query before start (though this shouldn't happen in practice)
     ctx.env.ledger().set_timestamp(500);
@@ -2881,9 +2897,9 @@ fn test_elapsed_time_checked_subtraction() {
         &1000u64,
         &2000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     // Set time before start (edge case)
     ctx.env.ledger().set_timestamp(500);
@@ -2920,9 +2936,9 @@ fn test_rate_times_duration_overflow_caps() {
         &0u64,
         &duration,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     ctx.env.ledger().set_timestamp(5);
 
@@ -3001,9 +3017,9 @@ fn test_cliff_with_overflow_scenario() {
         &50u64, // Cliff at 50
         &100u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     // Before cliff - should return 0
     ctx.env.ledger().set_timestamp(25);
@@ -3534,9 +3550,9 @@ fn test_withdraw_to_requires_recipient_auth() {
         &0u64,
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     ctx.env.ledger().set_timestamp(500);
 
@@ -3617,9 +3633,9 @@ fn test_batch_withdraw_mixed_active_and_completed() {
         &0u64,
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        ); // will be completed
+    ); // will be completed
     let id2 = ctx.client().create_stream(
         &ctx.sender,
         &ctx.recipient,
@@ -3629,9 +3645,9 @@ fn test_batch_withdraw_mixed_active_and_completed() {
         &0u64,
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        ); // active
+    ); // active
 
     // Complete id1
     ctx.env.ledger().set_timestamp(1000);
@@ -3673,9 +3689,9 @@ fn test_batch_withdraw_all_completed_all_zero() {
         &0u64,
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     // Complete both
     ctx.env.ledger().set_timestamp(1000);
@@ -3791,9 +3807,9 @@ fn test_batch_withdraw_multiple_streams() {
         &0u64,
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
     ctx.env.ledger().set_timestamp(0);
     let id2 = ctx.client().create_stream(
         &ctx.sender,
@@ -3804,9 +3820,9 @@ fn test_batch_withdraw_multiple_streams() {
         &0u64,
         &500u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     ctx.env.ledger().set_timestamp(400);
     let stream_ids = stream_ids_vec(&ctx.env, &[id0, id1, id2]);
@@ -3838,9 +3854,9 @@ fn test_batch_withdraw_mixed_state_some_zero() {
         &0u64,
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     // Test batch withdraw with mixed states
     ctx.env.ledger().set_timestamp(500);
@@ -3927,9 +3943,9 @@ fn test_batch_withdraw_emits_events_per_stream() {
         &0u64,
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     ctx.env.ledger().set_timestamp(250);
     let stream_ids = stream_ids_vec(&ctx.env, &[id0, id1]);
@@ -3979,9 +3995,9 @@ fn test_withdraw_recipient_success() {
         &0u64,
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     ctx.env.ledger().set_timestamp(500);
 
@@ -4040,9 +4056,9 @@ fn test_withdraw_not_recipient_unauthorized() {
         &0u64,
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     ctx.env.ledger().set_timestamp(500);
 
@@ -4098,9 +4114,9 @@ fn test_withdraw_not_recipient_unauthorized_has_no_side_effects() {
         &0u64,
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     ctx.env.ledger().set_timestamp(700);
     let state_before = ctx.client().get_stream_state(&stream_id);
@@ -4286,9 +4302,9 @@ fn test_close_completed_stream_multiple_streams_closes_correct_one() {
         &0u64,
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     let id1 = ctx.client().create_stream(
         &ctx.sender,
@@ -4299,9 +4315,9 @@ fn test_close_completed_stream_multiple_streams_closes_correct_one() {
         &0u64,
         &2000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     let id2 = ctx.client().create_stream(
         &ctx.sender,
@@ -4312,9 +4328,9 @@ fn test_close_completed_stream_multiple_streams_closes_correct_one() {
         &0u64,
         &500u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     // Complete all three streams
     ctx.env.ledger().set_timestamp(2000);
@@ -4379,9 +4395,9 @@ fn test_close_completed_stream_recipient_index_sorted_after_close() {
             &0u64,
             &100u64,
             &0,
-            &None,,
+            &None,
             &crate::StreamKind::Linear,
-            );
+        );
     }
 
     let streams = ctx.client().get_recipient_streams(&ctx.recipient);
@@ -4437,9 +4453,9 @@ fn test_close_completed_stream_after_cliff_passed() {
         &500u64, // cliff at 500
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     // Advance past cliff and end time
     ctx.env.ledger().set_timestamp(1000);
@@ -4472,9 +4488,9 @@ fn test_close_completed_stream_count_decreases() {
             &0u64,
             &100u64,
             &0,
-            &None,,
+            &None,
             &crate::StreamKind::Linear,
-            );
+        );
     }
 
     assert_eq!(ctx.client().get_recipient_stream_count(&ctx.recipient), 3);
@@ -4510,9 +4526,9 @@ fn test_close_completed_stream_different_recipients_independent() {
         &0u64,
         &100u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     // Create stream for recipient2
     let id_r2 = ctx.client().create_stream(
@@ -4524,9 +4540,9 @@ fn test_close_completed_stream_different_recipients_independent() {
         &0u64,
         &100u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     assert_eq!(ctx.client().get_recipient_stream_count(&ctx.recipient), 1);
     assert_eq!(ctx.client().get_recipient_stream_count(&recipient2), 1);
@@ -4962,9 +4978,9 @@ fn test_multiple_streams_independent() {
         &100,
         &100,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     assert_eq!(id0, 0);
     assert_eq!(id1, 1);
@@ -5372,9 +5388,9 @@ fn test_pause_stream_recipient_unauthorized() {
         &0u64,
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     // Recipient attempts to pause (should be unauthorized)
     ctx.env.mock_auths(&[MockAuth {
@@ -5429,9 +5445,9 @@ fn test_pause_stream_third_party_unauthorized() {
         &0u64,
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     let other = Address::generate(&ctx.env);
     ctx.env.mock_auths(&[MockAuth {
@@ -5485,9 +5501,9 @@ fn test_pause_stream_sender_success() {
         &0u64,
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     // Sender authorises pause
     ctx.env.mock_auths(&[MockAuth {
@@ -5544,9 +5560,9 @@ fn test_pause_stream_admin_success() {
         &0u64,
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     // Admin authorises pause via the admin-specific entrypoint
     ctx.env.mock_auths(&[MockAuth {
@@ -5604,9 +5620,9 @@ fn test_pause_stream_as_admin_non_admin_unauthorized() {
         &0u64,
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     // A non-admin cannot use the admin override entrypoint.
     let non_admin = Address::generate(&ctx.env);
@@ -5664,9 +5680,9 @@ fn test_cancel_stream_recipient_unauthorized() {
         &0u64,
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     ctx.env.mock_auths(&[MockAuth {
         address: &ctx.recipient,
@@ -5719,9 +5735,9 @@ fn test_cancel_stream_third_party_unauthorized() {
         &0u64,
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     let other = Address::generate(&ctx.env);
     ctx.env.mock_auths(&[MockAuth {
@@ -5774,9 +5790,9 @@ fn test_cancel_stream_sender_success() {
         &0u64,
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     ctx.env.mock_auths(&[MockAuth {
         address: &ctx.sender,
@@ -5830,9 +5846,9 @@ fn test_cancel_stream_admin_success() {
         &0u64,
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     ctx.env.mock_auths(&[MockAuth {
         address: &ctx.admin,
@@ -5868,9 +5884,9 @@ fn test_create_stream_negative_deposit_panics() {
         &0u64,
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 }
 
 /// Test creating a stream with negative rate_per_second panics
@@ -5888,9 +5904,9 @@ fn test_create_stream_negative_rate_panics() {
         &0u64,
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 }
 
 /// Test creating a stream where start_time equals end_time panics
@@ -5908,9 +5924,9 @@ fn test_create_stream_equal_start_end_times_panics() {
         &500u64,
         &500u64, // start == end
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 }
 
 /// Test creating a stream with cliff_time equal to start_time (valid edge case)
@@ -5928,9 +5944,9 @@ fn test_create_stream_cliff_equals_start() {
         &100u64, // cliff == start (valid)
         &1100u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     let state = ctx.client().get_stream_state(&stream_id);
     assert_eq!(state.cliff_time, 100);
@@ -5953,9 +5969,9 @@ fn test_create_stream_cliff_equals_end() {
         &1000u64, // cliff == end (valid)
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     let state = ctx.client().get_stream_state(&stream_id);
     assert_eq!(state.cliff_time, 1000);
@@ -5978,9 +5994,9 @@ fn test_create_stream_increments_id_correctly() {
         &0u64,
         &100u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     let id1 = ctx.client().create_stream(
         &ctx.sender,
@@ -5991,9 +6007,9 @@ fn test_create_stream_increments_id_correctly() {
         &0u64,
         &200u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     let id2 = ctx.client().create_stream(
         &ctx.sender,
@@ -6004,9 +6020,9 @@ fn test_create_stream_increments_id_correctly() {
         &0u64,
         &300u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     assert_eq!(id0, 0);
     assert_eq!(id1, 1);
@@ -6042,9 +6058,9 @@ fn test_create_stream_large_deposit() {
         &0u64,
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     let state = ctx.client().get_stream_state(&stream_id);
     assert_eq!(state.deposit_amount, large_amount);
@@ -6070,9 +6086,9 @@ fn test_create_stream_high_rate() {
         &0u64,
         &duration,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     let state = ctx.client().get_stream_state(&stream_id);
     assert_eq!(state.rate_per_second, high_rate);
@@ -6097,9 +6113,9 @@ fn test_create_stream_different_addresses() {
         &0u64,
         &500u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     let state = ctx.client().get_stream_state(&stream_id);
     assert_eq!(state.sender, ctx.sender);
@@ -6121,9 +6137,9 @@ fn test_create_stream_future_start_time() {
         &1000u64,
         &2000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     let state = ctx.client().get_stream_state(&stream_id);
     assert_eq!(state.start_time, 1000);
@@ -6151,9 +6167,9 @@ fn test_create_stream_token_balances() {
         &0u64,
         &500u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     // Sender balance should decrease by deposit
     assert_eq!(
@@ -6189,9 +6205,9 @@ fn test_create_stream_minimum_duration() {
         &0u64,
         &1u64, // 1 second duration
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     let state = ctx.client().get_stream_state(&stream_id);
     assert_eq!(state.end_time - state.start_time, 1);
@@ -6219,9 +6235,9 @@ fn test_create_stream_all_fields_correct() {
         &cliff,
         &end,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     let state = ctx.client().get_stream_state(&stream_id);
 
@@ -6254,9 +6270,9 @@ fn test_create_stream_self_stream_panics() {
         &0u64,
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -6353,9 +6369,9 @@ fn test_create_stream_invalid_cliff_panics() {
         &50,
         &200, // cliff < start
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 }
 
 #[test]
@@ -6372,9 +6388,9 @@ fn test_create_stream_edge_cliffs() {
         &100,
         &1100,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
     assert_eq!(ctx.client().get_stream_state(&id1).cliff_time, 100);
 
     // Cliff at end_time
@@ -6387,9 +6403,9 @@ fn test_create_stream_edge_cliffs() {
         &1100,
         &1100,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
     assert_eq!(ctx.client().get_stream_state(&id2).cliff_time, 1100);
 }
 
@@ -6456,9 +6472,9 @@ fn test_cancel_at_start_full_refund_and_status() {
         &0u64,
         &2000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     // Verify deposit transferred
     assert_eq!(ctx.token().balance(&ctx.sender), sender_initial - 2000);
@@ -6508,9 +6524,9 @@ fn test_cancel_at_25_percent_partial_refund_recipient_withdraws() {
         &0u64,
         &4000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     let sender_initial = ctx.token().balance(&ctx.sender);
     let recipient_initial = ctx.token().balance(&ctx.recipient);
@@ -6576,9 +6592,9 @@ fn test_cancel_at_50_percent_exact_refund_calculation() {
         &0u64,
         &3000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     let sender_before_cancel = ctx.token().balance(&ctx.sender);
     let contract_before_cancel = ctx.token().balance(&ctx.contract_id);
@@ -6625,9 +6641,9 @@ fn test_cancel_at_75_percent_recipient_can_withdraw_accrued() {
         &0u64,
         &4000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     // Advance to 75% completion (3000 seconds)
     ctx.env.ledger().set_timestamp(3000);
@@ -6672,9 +6688,9 @@ fn test_cancel_after_partial_withdrawal_correct_refund() {
         &0u64,
         &5000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     // Advance to 40% and withdraw
     ctx.env.ledger().set_timestamp(2000);
@@ -6722,9 +6738,9 @@ fn test_cancel_before_cliff_full_refund() {
         &1500u64, // cliff at 50%
         &3000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     let sender_before_cancel = ctx.token().balance(&ctx.sender);
 
@@ -6766,9 +6782,9 @@ fn test_cancel_after_cliff_partial_refund() {
         &2000u64, // cliff at 50%
         &4000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     let sender_before_cancel = ctx.token().balance(&ctx.sender);
 
@@ -6814,9 +6830,9 @@ fn test_cancel_paused_stream_accrual_continues() {
         &0u64,
         &3000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     // Advance to 30% and pause
     ctx.env.ledger().set_timestamp(900);
@@ -6867,9 +6883,9 @@ fn test_cancel_balance_consistency() {
         &0u64,
         &7000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     // Verify total supply unchanged after creation
     let total_after_create = ctx.token().balance(&ctx.sender)
@@ -6934,9 +6950,9 @@ fn test_get_stream_state_create_stream() {
         &0u64, // cliff equals start
         &5000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     let state = ctx.client().get_stream_state(&stream_id);
     assert_eq!(state.stream_id, 0);
@@ -6964,9 +6980,9 @@ fn test_get_stream_state_create_stream_withdraw_during_cliff() {
         &1000u64, // cliff equals start
         &5000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
     ctx.env.ledger().set_timestamp(1000);
     ctx.client().withdraw(&stream_id);
 
@@ -6996,9 +7012,9 @@ fn test_get_stream_state_create_stream_withdraw() {
         &1000u64, // cliff equals start
         &5000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
     ctx.env.ledger().set_timestamp(6000);
     ctx.client().withdraw(&stream_id);
 
@@ -7028,9 +7044,9 @@ fn test_get_stream_state_create_stream_cancel() {
         &1000u64, // cliff equals start
         &5000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
     ctx.client().cancel_stream(&stream_id);
 
     let state = ctx.client().get_stream_state(&stream_id);
@@ -7059,9 +7075,9 @@ fn test_get_stream_state_pause_stream_cancel() {
         &1000u64, // cliff equals start
         &5000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
     ctx.client()
         .pause_stream(&stream_id, &crate::PauseReason::Operational);
 
@@ -7091,9 +7107,9 @@ fn test_get_stream_state_pause_resume_stream_cancel() {
         &1000u64, // cliff equals start
         &5000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
     ctx.client()
         .pause_stream(&stream_id, &crate::PauseReason::Operational);
 
@@ -7636,9 +7652,9 @@ fn test_withdraw_small_rate_no_underflow() {
         &0u64,
         &100u64, // 100 seconds for 100 tokens total
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     // At t=50, accrued should be 50 tokens
     ctx.env.ledger().set_timestamp(50);
@@ -8273,9 +8289,9 @@ fn test_stream_id_first_stream_is_zero() {
         &0u64,
         &100u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     assert_eq!(id, 0, "first stream_id must be 0");
     assert_eq!(
@@ -8301,9 +8317,9 @@ fn test_stream_id_increments_by_one() {
         &0u64,
         &100u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
     let id1 = ctx.client().create_stream(
         &ctx.sender,
         &ctx.recipient,
@@ -8313,9 +8329,9 @@ fn test_stream_id_increments_by_one() {
         &0u64,
         &100u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
     let id2 = ctx.client().create_stream(
         &ctx.sender,
         &ctx.recipient,
@@ -8325,9 +8341,9 @@ fn test_stream_id_increments_by_one() {
         &0u64,
         &100u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     assert_eq!(id0, 0, "first id must be 0");
     assert_eq!(id1, id0 + 1, "second id must be first + 1");
@@ -8351,9 +8367,9 @@ fn test_create_stream_returned_id_matches_stored_id() {
             &0u64,
             &100u64,
             &0,
-            &None,,
+            &None,
             &crate::StreamKind::Linear,
-            );
+        );
         let stored = ctx.client().get_stream_state(&returned_id);
 
         assert_eq!(
@@ -8661,9 +8677,9 @@ fn test_stream_ids_are_unique_no_gaps() {
             &0u64,
             &10u64,
             &0,
-            &None,,
+            &None,
             &crate::StreamKind::Linear,
-            );
+        );
         assert_eq!(id, expected, "stream {expected} must have id {expected}");
         ids.push_back(id);
     }
@@ -8698,9 +8714,9 @@ fn test_failed_create_stream_does_not_advance_counter() {
         &0u64,
         &100u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
     assert_eq!(id0, 0);
 
     // Attempt a stream with an underfunded deposit (1 token, need 100) -> must return InsufficientDeposit
@@ -8713,9 +8729,9 @@ fn test_failed_create_stream_does_not_advance_counter() {
         &0u64,
         &100u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
     assert_eq!(result, Err(Ok(ContractError::InsufficientDeposit)));
 
     // Next successful stream must still be id = 1, not 2
@@ -8728,9 +8744,9 @@ fn test_failed_create_stream_does_not_advance_counter() {
         &0u64,
         &100u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
     assert_eq!(
         id1, 1,
         "counter must not advance after a failed create_stream"
@@ -8759,9 +8775,9 @@ fn test_stream_ids_unique_across_different_senders() {
         &0u64,
         &100u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
     let id_b = ctx.client().create_stream(
         &sender2,
         &recipient2,
@@ -8771,9 +8787,9 @@ fn test_stream_ids_unique_across_different_senders() {
         &0u64,
         &100u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
     let id_c = ctx.client().create_stream(
         &ctx.sender,
         &recipient2,
@@ -8783,9 +8799,9 @@ fn test_stream_ids_unique_across_different_senders() {
         &0u64,
         &100u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     assert_eq!(id_a, 0, "first stream (sender1→recipient1) must be 0");
     assert_eq!(id_b, 1, "second stream (sender2→recipient2) must be 1");
@@ -8812,9 +8828,9 @@ fn test_stream_id_stability_after_state_changes() {
         &0u64,
         &100u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
     let id1 = ctx.client().create_stream(
         &ctx.sender,
         &ctx.recipient,
@@ -8824,9 +8840,9 @@ fn test_stream_id_stability_after_state_changes() {
         &0u64,
         &100u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
     let id2 = ctx.client().create_stream(
         &ctx.sender,
         &ctx.recipient,
@@ -8836,9 +8852,9 @@ fn test_stream_id_stability_after_state_changes() {
         &0u64,
         &100u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     // Mutate stream 1: pause then cancel
     ctx.client()
@@ -8860,9 +8876,9 @@ fn test_stream_id_stability_after_state_changes() {
         &0u64,
         &100u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
     assert_eq!(
         id3, 3,
         "counter must continue monotonically after state mutations"
@@ -9264,9 +9280,9 @@ fn test_create_stream_large_rate_overflow_in_accrual() {
         &cliff_time,
         &end_time,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     ctx.env.ledger().set_timestamp(end_time);
     let accrued = ctx.client().calculate_accrued(&stream_id);
@@ -9298,9 +9314,9 @@ fn test_accrual_capped_at_exact_total() {
         &cliff_time,
         &end_time,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     ctx.env.ledger().set_timestamp(end_time);
 
@@ -9332,9 +9348,9 @@ fn test_accrual_capped_when_deposit_exceeds_total() {
         &cliff_time,
         &end_time,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     ctx.env.ledger().set_timestamp(end_time);
 
@@ -10101,9 +10117,9 @@ fn test_create_stream_start_time_in_past_panics() {
         &999u64,
         &1999u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
     assert_eq!(result, Err(Ok(ContractError::StartTimeInPast)));
 }
 
@@ -10121,9 +10137,9 @@ fn test_create_stream_start_time_one_second_before_now_panics() {
         &499u64,
         &1499u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
     assert_eq!(result, Err(Ok(ContractError::StartTimeInPast)));
 }
 
@@ -10141,9 +10157,9 @@ fn test_create_stream_start_time_far_in_past_panics() {
         &0u64,
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
     assert_eq!(result, Err(Ok(ContractError::StartTimeInPast)));
 }
 
@@ -10161,9 +10177,9 @@ fn test_create_stream_start_time_equals_now_succeeds() {
         &500u64,
         &1500u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
     let state = ctx.client().get_stream_state(&stream_id);
     assert_eq!(state.start_time, 500);
     assert_eq!(state.status, StreamStatus::Active);
@@ -10183,9 +10199,9 @@ fn test_create_stream_start_time_one_second_in_future_succeeds() {
         &501u64,
         &1501u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
     let state = ctx.client().get_stream_state(&stream_id);
     assert_eq!(state.start_time, 501);
     assert_eq!(state.status, StreamStatus::Active);
@@ -10205,9 +10221,9 @@ fn test_create_stream_start_time_future_succeeds() {
         &5000u64,
         &6000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
     let state = ctx.client().get_stream_state(&stream_id);
     assert_eq!(state.start_time, 5000);
     assert_eq!(state.status, StreamStatus::Active);
@@ -10229,9 +10245,9 @@ fn test_create_stream_start_time_zero_at_genesis_succeeds() {
         &0u64,
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
     let state = ctx.client().get_stream_state(&stream_id);
     assert_eq!(state.start_time, 0);
     assert_eq!(state.status, StreamStatus::Active);
@@ -10258,9 +10274,9 @@ fn test_create_stream_past_start_no_token_transfer() {
         &500u64,
         &1500u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
     assert_eq!(result, Err(Ok(ContractError::StartTimeInPast)));
 
     // Sender balance must be unchanged — no token was transferred
@@ -10590,9 +10606,9 @@ fn test_update_rate_per_second_increases_rate_and_preserves_accrual() {
         &0u64,
         &1_000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     // Mid-stream, record accrued with the original rate.
     ctx.env.ledger().set_timestamp(500);
@@ -10685,9 +10701,9 @@ fn test_update_rate_per_second_works_on_paused_stream() {
         &0u64,
         &1_000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     // Pause the stream.
     ctx.client()
@@ -10739,9 +10755,9 @@ fn test_update_rate_per_second_rejects_rate_decrease() {
         &0u64,
         &1_000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     // Attempting to decrease rate from 5 → 3 must panic.
     ctx.client().update_rate_per_second(&stream_id, &3_i128);
@@ -10762,9 +10778,9 @@ fn test_update_rate_per_second_before_cliff() {
         &500,
         &1000,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     // Before cliff at t=100, accrued is 0.
     ctx.env.ledger().set_timestamp(100);
@@ -10800,9 +10816,9 @@ fn test_update_rate_per_second_at_cliff() {
         &500,
         &1000,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     // Exactly at cliff time t=500.
     ctx.env.ledger().set_timestamp(500);
@@ -10848,9 +10864,9 @@ fn test_update_rate_per_second_near_end_time() {
         &0u64,
         &1_000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     // Near end at t=950.
     ctx.env.ledger().set_timestamp(950);
@@ -10886,9 +10902,9 @@ fn test_update_rate_per_second_after_end_time() {
         &0u64,
         &1_000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     // After end_time at t=1500.
     ctx.env.ledger().set_timestamp(1500);
@@ -10919,9 +10935,9 @@ fn test_update_rate_per_second_with_partial_withdrawal() {
         &0u64,
         &1_000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     // At t=300, withdraw partial amount.
     ctx.env.ledger().set_timestamp(300);
@@ -10960,9 +10976,9 @@ fn test_update_rate_per_second_emits_event() {
         &0u64,
         &1_000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     // Update rate from 1 → 5.
     ctx.env.ledger().set_timestamp(500);
@@ -11006,9 +11022,9 @@ fn test_update_rate_per_second_on_paused_stream_after_partial_withdrawal() {
         &0u64,
         &1_000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     // At t=300, withdraw partial amount.
     ctx.env.ledger().set_timestamp(300);
@@ -11053,9 +11069,9 @@ fn test_update_rate_per_second_after_partial_withdrawal_then_resume_and_withdraw
         &0u64,
         &1_000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     // At t=200, withdraw partial amount.
     ctx.env.ledger().set_timestamp(200);
@@ -11120,9 +11136,9 @@ fn test_update_rate_per_second_unauthorized_caller() {
         &0u64,
         &1_000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     // Attempt to update rate as recipient (not sender) without proper auth.
     // This should panic due to authorization failure.
@@ -11154,9 +11170,9 @@ fn test_update_rate_per_second_multiple_times() {
         &0u64,
         &1_000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     // First update: 1 → 5.
     ctx.env.ledger().set_timestamp(100);
@@ -11195,9 +11211,9 @@ fn test_update_rate_per_second_preserves_other_fields() {
         &200u64,
         &1_000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     let state_before = ctx.client().get_stream_state(&stream_id);
 
@@ -11250,9 +11266,9 @@ fn test_update_rate_per_second_interaction_with_pause_resume() {
         &0u64,
         &1_000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     // Pause at t=100.
     ctx.env.ledger().set_timestamp(100);
@@ -11288,9 +11304,9 @@ fn test_update_rate_per_second_exact_deposit_coverage() {
         &0u64,
         &1_000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     // Update to rate that exactly matches deposit.
     // deposit = 1000, duration = 1000, so max rate = 1.
@@ -11375,9 +11391,9 @@ fn test_shorten_stream_end_time_rejects_equal_or_later_end_time() {
         &0u64,
         &1_000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     // Equal old end_time is not a shorten.
     let same = ctx
@@ -11451,9 +11467,9 @@ fn test_shorten_stream_end_time_unauthorized_caller() {
         &0u64,
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     // No sender auth is provided for shorten; strict mode must trap.
     ctx.client().shorten_stream_end_time(&stream_id, &700u64);
@@ -11547,9 +11563,9 @@ fn test_extend_stream_end_time_preserves_accrued_and_allows_longer_accrual() {
         &0u64,
         &1_000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     // At t=800, accrued should be 800.
     ctx.env.ledger().set_timestamp(800);
@@ -11622,9 +11638,9 @@ fn test_recipient_stream_index_sorted_order() {
         &0u64,
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     let id2 = ctx.client().create_stream(
         &ctx.sender,
@@ -11635,9 +11651,9 @@ fn test_recipient_stream_index_sorted_order() {
         &0u64,
         &2000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     let id3 = ctx.client().create_stream(
         &ctx.sender,
@@ -11648,9 +11664,9 @@ fn test_recipient_stream_index_sorted_order() {
         &0u64,
         &500u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     // Verify IDs are sequential
     assert_eq!(id1, 0);
@@ -11688,9 +11704,9 @@ fn test_recipient_stream_count() {
         &0u64,
         &2000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
     assert_eq!(ctx.client().get_recipient_stream_count(&ctx.recipient), 2);
 
     // Create third stream
@@ -11703,9 +11719,9 @@ fn test_recipient_stream_count() {
         &0u64,
         &500u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
     assert_eq!(ctx.client().get_recipient_stream_count(&ctx.recipient), 3);
 }
 
@@ -11728,9 +11744,9 @@ fn test_recipient_stream_index_separate_per_recipient() {
         &0u64,
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     let id2 = ctx.client().create_stream(
         &ctx.sender,
@@ -11741,9 +11757,9 @@ fn test_recipient_stream_index_separate_per_recipient() {
         &0u64,
         &2000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     let id3 = ctx.client().create_stream(
         &ctx.sender,
@@ -11754,9 +11770,9 @@ fn test_recipient_stream_index_separate_per_recipient() {
         &0u64,
         &500u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     let id4 = ctx.client().create_stream(
         &ctx.sender,
@@ -11767,9 +11783,9 @@ fn test_recipient_stream_index_separate_per_recipient() {
         &0u64,
         &3000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     // Verify each recipient has the correct streams
     let streams1 = ctx.client().get_recipient_streams(&ctx.recipient);
@@ -11831,9 +11847,9 @@ fn test_recipient_stream_index_sorted_after_operations() {
         &0u64,
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     let id1 = ctx.client().create_stream(
         &ctx.sender,
@@ -11844,9 +11860,9 @@ fn test_recipient_stream_index_sorted_after_operations() {
         &0u64,
         &2000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     let _id2 = ctx.client().create_stream(
         &ctx.sender,
@@ -11857,9 +11873,9 @@ fn test_recipient_stream_index_sorted_after_operations() {
         &0u64,
         &500u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     // Verify sorted order
     let streams = ctx.client().get_recipient_streams(&ctx.recipient);
@@ -11897,9 +11913,9 @@ fn test_recipient_stream_index_with_batch_withdraw() {
         &0u64,
         &2000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
     let id2 = ctx.client().create_stream(
         &ctx.sender,
         &ctx.recipient,
@@ -11909,9 +11925,9 @@ fn test_recipient_stream_index_with_batch_withdraw() {
         &0u64,
         &500u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     // Verify all streams are in the index
     let streams = ctx.client().get_recipient_streams(&ctx.recipient);
@@ -12038,9 +12054,9 @@ fn test_recipient_stream_index_many_streams() {
             &0u64,
             &100u64,
             &0,
-            &None,,
+            &None,
             &crate::StreamKind::Linear,
-            );
+        );
     }
 
     // Verify all streams are in the index
@@ -12099,9 +12115,9 @@ fn test_recipient_stream_index_multiple_senders() {
         &0u64,
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     let id2 = ctx.client().create_stream(
         &sender2,
@@ -12112,9 +12128,9 @@ fn test_recipient_stream_index_multiple_senders() {
         &0u64,
         &2000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     let id3 = ctx.client().create_stream(
         &sender3,
@@ -12125,9 +12141,9 @@ fn test_recipient_stream_index_multiple_senders() {
         &0u64,
         &500u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     // Verify all streams are in the recipient's index
     let streams = ctx.client().get_recipient_streams(&ctx.recipient);
@@ -12468,9 +12484,9 @@ fn test_create_stream_contract_paused_returns_structured_error() {
         &0u64,
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 }
 
 /// Verify ContractPaused fires as a structured error for batch creations.
@@ -12484,7 +12500,7 @@ fn test_create_streams_batch_contract_paused_returns_structured_error() {
     let params = soroban_sdk::Vec::from_array(
         &ctx.env,
         [CreateStreamParams {
-        kind: crate::StreamKind::Linear,
+            kind: crate::StreamKind::Linear,
             withdraw_dust_threshold: None,
             recipient: ctx.recipient.clone(),
             deposit_amount: 1000,
@@ -12517,9 +12533,9 @@ fn test_global_pause_does_not_affect_existing_streams() {
         &0u64,
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     // Now admin pauses the contract
     ctx.client().set_contract_paused(&true);
@@ -12559,7 +12575,7 @@ fn test_create_streams_batch_start_time_in_past_returns_structured_error() {
     let params = soroban_sdk::Vec::from_array(
         &ctx.env,
         [CreateStreamParams {
-        kind: crate::StreamKind::Linear,
+            kind: crate::StreamKind::Linear,
             withdraw_dust_threshold: None,
             recipient: ctx.recipient.clone(),
             deposit_amount: 1000,
@@ -12614,9 +12630,9 @@ fn test_create_stream_rate_times_duration_overflow_panics_no_state_change() {
             &start,
             &end,
             &0,
-            &None,,
+            &None,
             &crate::StreamKind::Linear,
-            )
+        )
     }));
 
     assert!(
@@ -12662,9 +12678,9 @@ fn test_create_stream_event_payload_matches_events_md_schema() {
         &cliff,
         &end,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     // The last event must be the StreamCreated event.
     let events = ctx.env.events().all();
@@ -12702,9 +12718,9 @@ fn test_create_stream_past_start_emits_no_events() {
         &400u64,
         &1400u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
     assert!(result.is_err());
 
     assert_eq!(
@@ -12735,9 +12751,9 @@ fn test_create_stream_exact_minimum_deposit_stored_fields_are_exact() {
         &0u64,
         &duration,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     let state = ctx.client().get_stream_state(&stream_id);
 
@@ -12813,9 +12829,9 @@ fn test_create_stream_only_sender_auth_required() {
         &0u64,
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     let state = ctx.client().get_stream_state(&stream_id);
     assert_eq!(state.status, StreamStatus::Active);
@@ -12880,9 +12896,9 @@ fn test_extend_end_time_deposit_exactly_covers_new_duration() {
         &0u64,
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     // Extend to 2000: rate(1) * new_duration(2000) == deposit(2000) — exact boundary
     ctx.client().extend_stream_end_time(&stream_id, &2000u64);
@@ -12910,9 +12926,9 @@ fn test_extend_end_time_deposit_exceeds_new_duration_requirement() {
         &0u64,
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     // Extend to 3000: rate(1) * 3000 = 3000 < deposit(5000) — surplus remains
     ctx.client().extend_stream_end_time(&stream_id, &3000u64);
@@ -12937,9 +12953,9 @@ fn test_extend_end_time_paused_stream_succeeds() {
         &0u64,
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     ctx.client()
         .pause_stream(&stream_id, &crate::PauseReason::Operational);
@@ -12974,9 +12990,9 @@ fn test_extend_end_time_accrual_unchanged_at_extension_time() {
         &0u64,
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     ctx.env.ledger().set_timestamp(600);
     let accrued_before = ctx.client().calculate_accrued(&stream_id);
@@ -13007,9 +13023,9 @@ fn test_extend_end_time_accrual_continues_to_new_end() {
         &0u64,
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     ctx.client().extend_stream_end_time(&stream_id, &3000u64);
 
@@ -13047,9 +13063,9 @@ fn test_extend_end_time_recipient_can_withdraw_extended_accrual() {
         &0u64,
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     // Withdraw up to old end_time
     ctx.env.ledger().set_timestamp(1000);
@@ -13090,9 +13106,9 @@ fn test_extend_end_time_after_top_up_succeeds() {
         &0u64,
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     // Extension to 1500 would need 1500 tokens — currently blocked
     let result = ctx
@@ -13130,9 +13146,9 @@ fn test_extend_end_time_emits_correct_event() {
         &0u64,
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     ctx.client().extend_stream_end_time(&stream_id, &2000u64);
 
@@ -13162,9 +13178,9 @@ fn test_extend_end_time_no_token_transfer() {
         &0u64,
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     let sender_before = ctx.token().balance(&ctx.sender);
     let contract_before = ctx.token().balance(&ctx.contract_id);
@@ -13194,9 +13210,9 @@ fn test_extend_end_time_deposit_one_short_rejected() {
         &0u64,
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     // Extending to 1001 requires 1001 tokens; deposit is only 1000
     let result = ctx
@@ -13219,9 +13235,9 @@ fn test_extend_end_time_deposit_far_below_new_requirement_rejected() {
         &0u64,
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     // Extending to 10000 requires 10000 tokens; deposit is only 1000
     let result = ctx
@@ -13245,9 +13261,9 @@ fn test_extend_end_time_completed_stream_rejected() {
         &0u64,
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     ctx.env.ledger().set_timestamp(1000);
     ctx.client().withdraw(&stream_id);
@@ -13276,9 +13292,9 @@ fn test_extend_end_time_cancelled_stream_rejected() {
         &0u64,
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     ctx.client().cancel_stream(&stream_id);
 
@@ -13426,7 +13442,7 @@ fn test_get_recipient_streams_batch_create_updates_index() {
         &ctx.env,
         [
             CreateStreamParams {
-        kind: crate::StreamKind::Linear,
+                kind: crate::StreamKind::Linear,
                 withdraw_dust_threshold: None,
                 recipient: ctx.recipient.clone(),
                 deposit_amount: 500,
@@ -13438,7 +13454,7 @@ fn test_get_recipient_streams_batch_create_updates_index() {
                 metadata: None,
             },
             CreateStreamParams {
-        kind: crate::StreamKind::Linear,
+                kind: crate::StreamKind::Linear,
                 withdraw_dust_threshold: None,
                 recipient: ctx.recipient.clone(),
                 deposit_amount: 1000,
@@ -13478,7 +13494,7 @@ fn test_get_recipient_streams_batch_create_separate_recipient_indices() {
         &ctx.env,
         [
             CreateStreamParams {
-        kind: crate::StreamKind::Linear,
+                kind: crate::StreamKind::Linear,
                 withdraw_dust_threshold: None,
                 recipient: ctx.recipient.clone(),
                 deposit_amount: 500,
@@ -13490,7 +13506,7 @@ fn test_get_recipient_streams_batch_create_separate_recipient_indices() {
                 metadata: None,
             },
             CreateStreamParams {
-        kind: crate::StreamKind::Linear,
+                kind: crate::StreamKind::Linear,
                 withdraw_dust_threshold: None,
                 recipient: recipient2.clone(),
                 deposit_amount: 1000,
@@ -13534,9 +13550,9 @@ fn test_get_recipient_streams_sorted_after_interleaved_close() {
             &0u64,
             &1000u64,
             &0,
-            &None,,
+            &None,
             &crate::StreamKind::Linear,
-            );
+        );
     }
 
     // Complete and close stream 1 (middle).
@@ -13581,9 +13597,9 @@ fn test_get_recipient_stream_count_matches_list_len() {
             &0u64,
             &1000u64,
             &0,
-            &None,,
+            &None,
             &crate::StreamKind::Linear,
-            );
+        );
     }
     assert_eq!(
         ctx.client().get_recipient_stream_count(&ctx.recipient),
@@ -13634,9 +13650,9 @@ fn test_get_recipient_streams_ids_resolve_to_correct_recipient() {
             &0u64,
             &1000u64,
             &0,
-            &None,,
+            &None,
             &crate::StreamKind::Linear,
-            );
+        );
     }
 
     let streams = ctx.client().get_recipient_streams(&ctx.recipient);
@@ -13670,9 +13686,9 @@ fn test_get_recipient_streams_single_second_stream() {
         &0u64,
         &1u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     assert_eq!(ctx.client().get_recipient_stream_count(&ctx.recipient), 1);
 
@@ -13743,9 +13759,9 @@ fn test_extend_end_time_same_end_time_rejected() {
         &0u64,
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     // Same end_time — not an extension
     ctx.client().extend_stream_end_time(&stream_id, &1000u64);
@@ -13767,9 +13783,9 @@ fn test_extend_end_time_shorter_end_time_rejected() {
         &0u64,
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     ctx.client().extend_stream_end_time(&stream_id, &500u64);
 }
@@ -13813,9 +13829,9 @@ fn test_extend_end_time_recipient_unauthorized() {
         &0u64,
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     // Recipient attempts to extend — must fail
     ctx.env.mock_auths(&[MockAuth {
@@ -13870,9 +13886,9 @@ fn test_extend_end_time_third_party_unauthorized() {
         &0u64,
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     let other = Address::generate(&ctx.env);
     ctx.env.mock_auths(&[MockAuth {
@@ -13926,9 +13942,9 @@ fn test_extend_end_time_sender_authorized() {
         &0u64,
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     ctx.env.mock_auths(&[MockAuth {
         address: &ctx.sender,
@@ -13968,9 +13984,9 @@ fn test_extend_end_time_overflow_panics_no_state_change() {
         &0u64,
         &1u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     let end_before = ctx.client().get_stream_state(&stream_id).end_time;
 
@@ -14011,9 +14027,9 @@ fn test_extend_end_time_high_rate_exact_boundary() {
         &0u64,
         &1u64, // 1 second initially
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     // Extend to 2 seconds: rate(1_000_000) * 2 = 2_000_000 == deposit — exact boundary
     ctx.client().extend_stream_end_time(&stream_id, &2u64);
@@ -14040,9 +14056,9 @@ fn test_extend_end_time_failed_leaves_state_unchanged() {
         &0u64,
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     let state_before = ctx.client().get_stream_state(&stream_id);
 
@@ -14074,9 +14090,9 @@ fn test_extend_end_time_failed_emits_no_event() {
         &0u64,
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     let events_before = ctx.env.events().all().len();
 
@@ -14109,9 +14125,9 @@ fn test_extend_end_time_cliff_preserved() {
         &500u64, // cliff at 500
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     ctx.client().extend_stream_end_time(&stream_id, &3000u64);
 
@@ -14145,9 +14161,9 @@ fn test_extend_end_time_integration_full_withdrawal() {
         &0u64,
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     ctx.client().extend_stream_end_time(&stream_id, &2000u64);
 
@@ -14221,9 +14237,9 @@ fn strict_create_stream(ctx: &TestContext) -> u64 {
         &0u64,
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        )
+    )
 }
 
 /// Authorise sender to call pause_stream in strict mode.
@@ -14662,9 +14678,9 @@ fn test_admin_pause_at_start_time() {
         &start_time,
         &1100,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     ctx.env.ledger().set_timestamp(start_time);
     ctx.client()
@@ -14689,9 +14705,9 @@ fn test_admin_pause_at_cliff_time() {
         &cliff_time,
         &1100,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     ctx.env.ledger().set_timestamp(cliff_time);
     ctx.client()
@@ -14716,9 +14732,9 @@ fn test_admin_pause_at_end_time_fails() {
         &200,
         &end_time,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     ctx.env.ledger().set_timestamp(end_time);
     // Note: Stored status will still be Active until a state-changing call is made,
@@ -14744,9 +14760,9 @@ fn test_withdraw_from_paused_at_end_time() {
         &0,
         &end_time,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     // Pause at t=500
     ctx.env.ledger().set_timestamp(500);
@@ -14877,9 +14893,9 @@ fn test_pause_stream_as_admin_recipient_is_not_admin() {
         &0u64,
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     // Recipient tries to use pause_stream_as_admin - must fail
     // MockAuth as recipient (not admin)
@@ -14916,9 +14932,9 @@ fn test_pause_stream_as_admin_third_party_unauthorized() {
         &0u64,
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     // Third party tries to use pause_stream_as_admin - must fail
     let third_party = Address::generate(&ctx.env);
@@ -14959,9 +14975,9 @@ fn test_resume_stream_as_admin_recipient_unauthorized() {
         &0u64,
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     // Admin pauses the stream first
     ctx.client()
@@ -15000,9 +15016,9 @@ fn test_resume_stream_as_admin_third_party_unauthorized() {
         &0u64,
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     // Admin pauses the stream first
     ctx.client()
@@ -15042,9 +15058,9 @@ fn test_pause_authorization_matrix() {
         &0u64,
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     // Admin can pause
     ctx.client()
@@ -15071,9 +15087,9 @@ fn test_resume_authorization_matrix() {
         &0u64,
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
     ctx.client()
         .pause_stream_as_admin(&stream_id, &crate::PauseReason::Administrative);
 
@@ -15271,9 +15287,17 @@ fn regression_double_init_repeated_attacks_do_not_degrade_contract() {
     // Contract must still work normally — create a stream, withdraw, verify
     env.ledger().set_timestamp(0);
     let stream_id = client.create_stream(
-        &sender, &recipient, &1000_i128, &1_i128, &0u64, &0u64, &1000u64, &0, &None,,
+        &sender,
+        &recipient,
+        &1000_i128,
+        &1_i128,
+        &0u64,
+        &0u64,
+        &1000u64,
+        &0,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
     assert_eq!(stream_id, 0);
     assert_eq!(client.get_stream_count(), 1);
 
@@ -15318,9 +15342,17 @@ fn regression_double_init_existing_stream_survives() {
     // Create a stream
     env.ledger().set_timestamp(0);
     let stream_id = client.create_stream(
-        &sender, &recipient, &1000_i128, &1_i128, &0u64, &0u64, &1000u64, &0, &None,,
+        &sender,
+        &recipient,
+        &1000_i128,
+        &1_i128,
+        &0u64,
+        &0u64,
+        &1000u64,
+        &0,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     // Attempt re-init
     let r = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
@@ -15371,13 +15403,29 @@ fn regression_double_init_counter_continuity() {
     // Create two streams (counter should be 2)
     env.ledger().set_timestamp(0);
     let id0 = client.create_stream(
-        &sender, &recipient, &1000_i128, &1_i128, &0u64, &0u64, &1000u64, &0, &None,,
+        &sender,
+        &recipient,
+        &1000_i128,
+        &1_i128,
+        &0u64,
+        &0u64,
+        &1000u64,
+        &0,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
     let id1 = client.create_stream(
-        &sender, &recipient, &1000_i128, &1_i128, &0u64, &0u64, &1000u64, &0, &None,,
+        &sender,
+        &recipient,
+        &1000_i128,
+        &1_i128,
+        &0u64,
+        &0u64,
+        &1000u64,
+        &0,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
     assert_eq!(id0, 0);
     assert_eq!(id1, 1);
     assert_eq!(client.get_stream_count(), 2);
@@ -15390,9 +15438,17 @@ fn regression_double_init_counter_continuity() {
     // Counter must still be 2 and next stream must be ID 2
     assert_eq!(client.get_stream_count(), 2);
     let id2 = client.create_stream(
-        &sender, &recipient, &1000_i128, &1_i128, &0u64, &0u64, &1000u64, &0, &None,,
+        &sender,
+        &recipient,
+        &1000_i128,
+        &1_i128,
+        &0u64,
+        &0u64,
+        &1000u64,
+        &0,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
     assert_eq!(
         id2, 2,
         "stream ID must continue from 2 after failed re-init"
@@ -15473,9 +15529,17 @@ fn regression_missing_config_create_stream_panics() {
 
     env.ledger().set_timestamp(0);
     client.create_stream(
-        &sender, &recipient, &1000_i128, &1_i128, &0u64, &0u64, &1000u64, &0, &None,,
+        &sender,
+        &recipient,
+        &1000_i128,
+        &1_i128,
+        &0u64,
+        &0u64,
+        &1000u64,
+        &0,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 }
 
 /// `create_streams()` (batch) on uninitialised contract must also fail.
@@ -15875,9 +15939,17 @@ fn regression_double_init_interleaved_with_lifecycle() {
     // Phase 1: Create stream, attempt re-init, verify stream
     env.ledger().set_timestamp(0);
     let stream_id = client.create_stream(
-        &sender, &recipient, &1000_i128, &1_i128, &0u64, &0u64, &1000u64, &0, &None,,
+        &sender,
+        &recipient,
+        &1000_i128,
+        &1_i128,
+        &0u64,
+        &0u64,
+        &1000u64,
+        &0,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
     assert_eq!(stream_id, 0);
 
     let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
@@ -15919,9 +15991,17 @@ fn regression_double_init_interleaved_with_lifecycle() {
     // Phase 4: Create another stream after all the chaos — counter must be correct
     env.ledger().set_timestamp(2000);
     let stream_id2 = client.create_stream(
-        &sender, &recipient, &2000_i128, &1_i128, &2000u64, &2000u64, &4000u64, &0, &None,,
+        &sender,
+        &recipient,
+        &2000_i128,
+        &1_i128,
+        &2000u64,
+        &2000u64,
+        &4000u64,
+        &0,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
     assert_eq!(stream_id2, 1);
     assert_eq!(client.get_stream_count(), 2);
 }
@@ -16578,9 +16658,9 @@ fn test_batch_withdraw_mixed_stream_states_comprehensive() {
         &0u64,
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     let id_paused = ctx.client().create_stream(
         &ctx.sender,
@@ -16591,9 +16671,9 @@ fn test_batch_withdraw_mixed_stream_states_comprehensive() {
         &0u64,
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     let id_cancelled = ctx.client().create_stream(
         &ctx.sender,
@@ -16604,9 +16684,9 @@ fn test_batch_withdraw_mixed_stream_states_comprehensive() {
         &0u64,
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     let id_completed = ctx.client().create_stream(
         &ctx.sender,
@@ -16617,9 +16697,9 @@ fn test_batch_withdraw_mixed_stream_states_comprehensive() {
         &0u64,
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     let id_active_2 = ctx.client().create_stream(
         &ctx.sender,
@@ -16630,9 +16710,9 @@ fn test_batch_withdraw_mixed_stream_states_comprehensive() {
         &0u64,
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     // Set up different states
     ctx.env.ledger().set_timestamp(500);
@@ -16742,7 +16822,7 @@ fn test_create_streams_batch_recipient_index_consistency() {
         &ctx.env,
         [
             CreateStreamParams {
-        kind: crate::StreamKind::Linear,
+                kind: crate::StreamKind::Linear,
                 withdraw_dust_threshold: None,
                 recipient: recipient1.clone(),
                 deposit_amount: 1000,
@@ -16754,7 +16834,7 @@ fn test_create_streams_batch_recipient_index_consistency() {
                 metadata: None,
             },
             CreateStreamParams {
-        kind: crate::StreamKind::Linear,
+                kind: crate::StreamKind::Linear,
                 withdraw_dust_threshold: None,
                 recipient: recipient2.clone(),
                 deposit_amount: 2000,
@@ -16766,7 +16846,7 @@ fn test_create_streams_batch_recipient_index_consistency() {
                 metadata: None,
             },
             CreateStreamParams {
-        kind: crate::StreamKind::Linear,
+                kind: crate::StreamKind::Linear,
                 withdraw_dust_threshold: None,
                 recipient: recipient1.clone(),
                 deposit_amount: 1500,
@@ -16778,7 +16858,7 @@ fn test_create_streams_batch_recipient_index_consistency() {
                 metadata: None,
             },
             CreateStreamParams {
-        kind: crate::StreamKind::Linear,
+                kind: crate::StreamKind::Linear,
                 withdraw_dust_threshold: None,
                 recipient: recipient3.clone(),
                 deposit_amount: 3000,
@@ -16790,7 +16870,7 @@ fn test_create_streams_batch_recipient_index_consistency() {
                 metadata: None,
             },
             CreateStreamParams {
-        kind: crate::StreamKind::Linear,
+                kind: crate::StreamKind::Linear,
                 withdraw_dust_threshold: None,
                 recipient: recipient2.clone(),
                 deposit_amount: 2500,
@@ -16857,7 +16937,7 @@ fn test_create_streams_batch_recipient_index_consistency() {
     let params2 = soroban_sdk::Vec::from_array(
         &ctx.env,
         [CreateStreamParams {
-        kind: crate::StreamKind::Linear,
+            kind: crate::StreamKind::Linear,
             withdraw_dust_threshold: None,
             recipient: recipient1.clone(),
             deposit_amount: 500,
@@ -16900,9 +16980,9 @@ fn test_create_stream_total_streamable_overflow() {
         &0u64,
         &2u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     assert_eq!(result, Err(Ok(ContractError::InvalidParams)));
 }
@@ -16967,9 +17047,9 @@ fn test_top_up_stream_overflow() {
         &0,
         &10,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     // Top up by more than 100 should overflow
     let result = ctx
@@ -17078,9 +17158,9 @@ fn test_budget_batch_withdraw_10_streams() {
             &0u64,
             &1000u64,
             &0,
-            &None,,
+            &None,
             &crate::StreamKind::Linear,
-            );
+        );
         ids.push_back(id);
     }
 
@@ -17126,9 +17206,9 @@ fn test_budget_batch_withdraw_cheaper_than_n_singles() {
             &0u64,
             &1000u64,
             &0,
-            &None,,
+            &None,
             &crate::StreamKind::Linear,
-            );
+        );
         ids.push_back(id);
     }
 
@@ -17248,7 +17328,7 @@ fn test_budget_create_streams_batch_5() {
     let mut params = soroban_sdk::Vec::new(&ctx.env);
     for _ in 0..5 {
         params.push_back(CreateStreamParams {
-        kind: crate::StreamKind::Linear,
+            kind: crate::StreamKind::Linear,
             withdraw_dust_threshold: None,
             recipient: Address::generate(&ctx.env),
             deposit_amount: 1000,
@@ -17351,9 +17431,9 @@ fn test_create_streams_single_entry_matches_create_stream() {
         &0u64,
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     // Single-entry create_streams
     let mut params = soroban_sdk::Vec::new(&ctx.env);
@@ -17399,7 +17479,7 @@ fn test_create_streams_batch_deposit_overflow_is_atomic() {
     let mut params = soroban_sdk::Vec::new(&ctx.env);
     for _ in 0..2 {
         params.push_back(CreateStreamParams {
-        kind: crate::StreamKind::Linear,
+            kind: crate::StreamKind::Linear,
             withdraw_dust_threshold: None,
             recipient: Address::generate(&ctx.env),
             deposit_amount: half_max,
@@ -17467,9 +17547,9 @@ mod negative_pause_resume_auth {
             &0,
             &1000,
             &0,
-            &None,,
+            &None,
             &crate::StreamKind::Linear,
-            );
+        );
         (ctx, stream_id)
     }
 
@@ -17901,9 +17981,9 @@ mod i128_boundary_streams {
             &0u64,
             &1u64,
             &0,
-            &None,,
+            &None,
             &crate::StreamKind::Linear,
-            );
+        );
 
         let state = client.get_stream_state(&stream_id);
         assert_eq!(state.deposit_amount, NEAR_MAX_DEPOSIT);
@@ -17933,9 +18013,9 @@ mod i128_boundary_streams {
             &500u64, // cliff at t=500
             &1_000u64,
             &0,
-            &None,,
+            &None,
             &crate::StreamKind::Linear,
-            );
+        );
 
         let state = client.get_stream_state(&stream_id);
         assert_eq!(state.deposit_amount, large_deposit);
@@ -17960,9 +18040,9 @@ mod i128_boundary_streams {
             &0u64,
             &1u64,
             &0,
-            &None,,
+            &None,
             &crate::StreamKind::Linear,
-            );
+        );
 
         let events = env.events().all();
         let last = events.last().unwrap();
@@ -17990,10 +18070,17 @@ mod i128_boundary_streams {
 
         let count_before = client.get_stream_count();
         let result = client.try_create_stream(
-            &sender, &recipient, &deposit, &rate, &0u64, &0u64, &3u64, // rate * 3 overflows
-            &0, &None,,
+            &sender,
+            &recipient,
+            &deposit,
+            &rate,
+            &0u64,
+            &0u64,
+            &3u64, // rate * 3 overflows
+            &0,
+            &None,
             &crate::StreamKind::Linear,
-            );
+        );
 
         assert_eq!(result, Err(Ok(ContractError::InvalidParams)));
         assert_eq!(
@@ -18021,9 +18108,17 @@ mod i128_boundary_streams {
         env.ledger().set_timestamp(0);
 
         let result = client.try_create_stream(
-            &sender, &recipient, &deposit, &rate, &0u64, &0u64, &duration, &0, &None,,
+            &sender,
+            &recipient,
+            &deposit,
+            &rate,
+            &0u64,
+            &0u64,
+            &duration,
+            &0,
+            &None,
             &crate::StreamKind::Linear,
-            );
+        );
 
         assert_eq!(result, Err(Ok(ContractError::InsufficientDeposit)));
         assert_eq!(
@@ -18053,9 +18148,9 @@ mod i128_boundary_streams {
             &0u64,
             &1u64,
             &0,
-            &None,,
+            &None,
             &crate::StreamKind::Linear,
-            );
+        );
 
         let accrued = client.calculate_accrued(&stream_id);
         assert_eq!(accrued, 0, "nothing accrued at start");
@@ -18077,9 +18172,9 @@ mod i128_boundary_streams {
             &0u64,
             &1u64,
             &0,
-            &None,,
+            &None,
             &crate::StreamKind::Linear,
-            );
+        );
 
         env.ledger().set_timestamp(1);
         let accrued = client.calculate_accrued(&stream_id);
@@ -18102,9 +18197,9 @@ mod i128_boundary_streams {
             &0u64,
             &1u64,
             &0,
-            &None,,
+            &None,
             &crate::StreamKind::Linear,
-            );
+        );
 
         env.ledger().set_timestamp(u64::MAX / 2);
         let accrued = client.calculate_accrued(&stream_id);
@@ -18129,9 +18224,9 @@ mod i128_boundary_streams {
             &500u64, // cliff at t=500
             &1_000u64,
             &0,
-            &None,,
+            &None,
             &crate::StreamKind::Linear,
-            );
+        );
 
         env.ledger().set_timestamp(499);
         let accrued = client.calculate_accrued(&stream_id);
@@ -18156,9 +18251,9 @@ mod i128_boundary_streams {
             &500u64,
             &1_000u64,
             &0,
-            &None,,
+            &None,
             &crate::StreamKind::Linear,
-            );
+        );
 
         env.ledger().set_timestamp(500);
         let accrued = client.calculate_accrued(&stream_id);
@@ -18195,9 +18290,9 @@ mod i128_boundary_streams {
             &0u64,
             &1u64,
             &0,
-            &None,,
+            &None,
             &crate::StreamKind::Linear,
-            );
+        );
 
         // Set time far past end — elapsed is capped at end_time=1, no overflow possible
         env.ledger().set_timestamp(u64::MAX);
@@ -18229,9 +18324,9 @@ mod i128_boundary_streams {
             &0u64,
             &1u64,
             &0,
-            &None,,
+            &None,
             &crate::StreamKind::Linear,
-            );
+        );
 
         env.ledger().set_timestamp(1);
         let withdrawn = client.withdraw(&stream_id);
@@ -18261,9 +18356,9 @@ mod i128_boundary_streams {
             &0u64,
             &1u64,
             &0,
-            &None,,
+            &None,
             &crate::StreamKind::Linear,
-            );
+        );
 
         env.ledger().set_timestamp(1);
         client.withdraw(&stream_id);
@@ -18306,9 +18401,9 @@ mod i128_boundary_streams {
             &0u64,
             &1_000u64,
             &0,
-            &None,,
+            &None,
             &crate::StreamKind::Linear,
-            );
+        );
 
         // First withdrawal at t=400
         env.ledger().set_timestamp(400);
@@ -18356,9 +18451,9 @@ mod i128_boundary_streams {
             &0u64,
             &1_000u64,
             &0,
-            &None,,
+            &None,
             &crate::StreamKind::Linear,
-            );
+        );
 
         // Cancel immediately at t=0
         client.cancel_stream(&stream_id);
@@ -18390,9 +18485,9 @@ mod i128_boundary_streams {
             &0u64,
             &1_000u64,
             &0,
-            &None,,
+            &None,
             &crate::StreamKind::Linear,
-            );
+        );
 
         env.ledger().set_timestamp(500);
         client.cancel_stream(&stream_id);
@@ -18430,9 +18525,9 @@ mod i128_boundary_streams {
             &0u64,
             &1_000u64,
             &0,
-            &None,,
+            &None,
             &crate::StreamKind::Linear,
-            );
+        );
 
         env.ledger().set_timestamp(300);
         client.cancel_stream(&stream_id);
@@ -18466,9 +18561,9 @@ mod i128_boundary_streams {
             &0u64,
             &1_000u64,
             &0,
-            &None,,
+            &None,
             &crate::StreamKind::Linear,
-            );
+        );
 
         env.ledger().set_timestamp(700);
         client.cancel_stream(&stream_id);
@@ -18505,9 +18600,9 @@ mod i128_boundary_streams {
             &0u64,
             &1_000u64,
             &0,
-            &None,,
+            &None,
             &crate::StreamKind::Linear,
-            );
+        );
 
         // Sender can cancel — must succeed
         env.ledger().set_timestamp(100);
@@ -18536,9 +18631,9 @@ mod i128_boundary_streams {
             &0u64,
             &1_000u64,
             &0,
-            &None,,
+            &None,
             &crate::StreamKind::Linear,
-            );
+        );
 
         env.ledger().set_timestamp(500);
         let withdrawn = client.withdraw(&stream_id);
@@ -18568,9 +18663,9 @@ mod i128_boundary_streams {
             &0u64,
             &1_000u64,
             &0,
-            &None,,
+            &None,
             &crate::StreamKind::Linear,
-            );
+        );
 
         env.ledger().set_timestamp(200);
         client.pause_stream(&stream_id, &crate::PauseReason::Operational);
@@ -18600,9 +18695,9 @@ mod i128_boundary_streams {
             &0u64,
             &1_000u64,
             &0,
-            &None,,
+            &None,
             &crate::StreamKind::Linear,
-            );
+        );
 
         env.ledger().set_timestamp(300);
         client.pause_stream(&stream_id, &crate::PauseReason::Operational);
@@ -18637,7 +18732,7 @@ mod i128_boundary_streams {
         let mut params = soroban_sdk::Vec::new(&env);
         for _ in 0..2 {
             params.push_back(CreateStreamParams {
-        kind: crate::StreamKind::Linear,
+                kind: crate::StreamKind::Linear,
                 withdraw_dust_threshold: None,
                 recipient: Address::generate(&env),
                 deposit_amount: per_deposit,
@@ -18678,7 +18773,7 @@ mod i128_boundary_streams {
         let balance_before = token.balance(&sender);
 
         let valid = CreateStreamParams {
-        kind: crate::StreamKind::Linear,
+            kind: crate::StreamKind::Linear,
             withdraw_dust_threshold: None,
             recipient: Address::generate(&env),
             deposit_amount: valid_deposit,
@@ -18691,7 +18786,7 @@ mod i128_boundary_streams {
         };
         // Invalid: deposit < rate * duration
         let invalid = CreateStreamParams {
-        kind: crate::StreamKind::Linear,
+            kind: crate::StreamKind::Linear,
             withdraw_dust_threshold: None,
             recipient: Address::generate(&env),
             deposit_amount: 1,
@@ -18732,9 +18827,9 @@ mod i128_boundary_streams {
             &0u64,
             &1_000u64,
             &0,
-            &None,,
+            &None,
             &crate::StreamKind::Linear,
-            );
+        );
 
         // Partial withdrawal at t=300
         env.ledger().set_timestamp(300);
@@ -18774,7 +18869,7 @@ mod recipient_index_stress {
             let mut streams = Vec::new(&ctx.env);
             for _ in 0..batch_size {
                 streams.push_back(CreateStreamParams {
-        kind: crate::StreamKind::Linear,
+                    kind: crate::StreamKind::Linear,
                     withdraw_dust_threshold: None,
                     recipient: recipient.clone(),
                     deposit_amount: 1000,
@@ -18838,9 +18933,9 @@ mod recipient_index_stress {
                 &0u64,
                 &100u64,
                 &0,
-                &None,,
+                &None,
                 &crate::StreamKind::Linear,
-                );
+            );
             stream_ids.push_back(id);
         }
 
@@ -18905,9 +19000,9 @@ mod recipient_index_stress {
                 &0u64,
                 &1000u64,
                 &0,
-                &None,,
+                &None,
                 &crate::StreamKind::Linear,
-                );
+            );
             ids.push_back(id);
         }
 
@@ -18936,9 +19031,9 @@ mod recipient_index_stress {
             &0u64,
             &1000u64,
             &0,
-            &None,,
+            &None,
             &crate::StreamKind::Linear,
-            );
+        );
 
         // Range with start > end returns empty
         let streams = ctx.client().get_streams_by_id_range(&5, &1, &10);
@@ -18964,9 +19059,9 @@ mod recipient_index_stress {
                 &0u64,
                 &100u64,
                 &0,
-                &None,,
+                &None,
                 &crate::StreamKind::Linear,
-                );
+            );
         }
 
         // Request 200, should be capped at MAX_PAGE_SIZE (100)
@@ -18994,9 +19089,9 @@ mod recipient_index_stress {
                 &0,
                 &1000,
                 &0,
-                &None,,
+                &None,
                 &crate::StreamKind::Linear,
-                );
+            );
         }
 
         // Close stream 2 (make it completed first)
@@ -19028,9 +19123,9 @@ mod recipient_index_stress {
                 &0u64,
                 &100u64,
                 &0,
-                &None,,
+                &None,
                 &crate::StreamKind::Linear,
-                );
+            );
         }
 
         // Use u64::MAX for open-ended range with limit 5
@@ -19055,9 +19150,9 @@ mod recipient_index_stress {
             &0u64,
             &1000u64,
             &0,
-            &None,,
+            &None,
             &crate::StreamKind::Linear,
-            );
+        );
 
         let streams = ctx.client().get_streams_by_id_range(&0, &10, &0);
         assert_eq!(streams.len(), 0, "Zero limit should return empty");
@@ -19081,9 +19176,9 @@ mod recipient_index_stress {
                 &0u64,
                 &1000u64,
                 &0,
-                &None,,
+                &None,
                 &crate::StreamKind::Linear,
-                );
+            );
         }
 
         // Page 1: cursor=0, limit=3
@@ -19145,9 +19240,9 @@ mod recipient_index_stress {
                 &100,
                 &100,
                 &0,
-                &None,,
+                &None,
                 &crate::StreamKind::Linear,
-                );
+            );
         }
 
         // Request 200, should be capped at MAX_PAGE_SIZE (100)
@@ -19172,9 +19267,9 @@ mod recipient_index_stress {
             &0u64,
             &1000u64,
             &0,
-            &None,,
+            &None,
             &crate::StreamKind::Linear,
-            );
+        );
 
         // Cursor beyond total count
         let result = ctx
@@ -19198,9 +19293,9 @@ mod recipient_index_stress {
             &0u64,
             &1000u64,
             &0,
-            &None,,
+            &None,
             &crate::StreamKind::Linear,
-            );
+        );
 
         let result = ctx
             .client()
@@ -19227,9 +19322,9 @@ mod recipient_index_stress {
                 &0u64,
                 &1000u64,
                 &0,
-                &None,,
+                &None,
                 &crate::StreamKind::Linear,
-                );
+            );
         }
 
         // Create 3 streams for recipient2
@@ -19243,9 +19338,9 @@ mod recipient_index_stress {
                 &0u64,
                 &1000u64,
                 &0,
-                &None,,
+                &None,
                 &crate::StreamKind::Linear,
-                );
+            );
         }
 
         // Paginate recipient1
@@ -19279,9 +19374,9 @@ mod recipient_index_stress {
                 &0u64,
                 &1000u64,
                 &0,
-                &None,,
+                &None,
                 &crate::StreamKind::Linear,
-                );
+            );
         }
 
         // Close stream 2 (make completed first)
@@ -19328,9 +19423,9 @@ mod recipient_index_stress {
                 &100,
                 &100,
                 &0,
-                &None,,
+                &None,
                 &crate::StreamKind::Linear,
-                );
+            );
         }
 
         // Simulate full export using pagination
@@ -19378,9 +19473,9 @@ mod recipient_index_stress {
                 &0u64,
                 &1000u64,
                 &0,
-                &None,,
+                &None,
                 &crate::StreamKind::Linear,
-                );
+            );
         }
 
         // Request range [0, 100] with limit 10 - only 3 exist
@@ -19418,9 +19513,9 @@ mod structured_error_tests {
             &0u64,
             &1000u64,
             &0,
-            &None,,
+            &None,
             &crate::StreamKind::Linear,
-            );
+        );
 
         ctx.env.ledger().set_timestamp(500);
 
@@ -19452,7 +19547,7 @@ mod structured_error_tests {
         let params = soroban_sdk::vec![
             &ctx.env,
             CreateStreamParams {
-        kind: crate::StreamKind::Linear,
+                kind: crate::StreamKind::Linear,
                 withdraw_dust_threshold: None,
                 recipient: ctx.recipient.clone(),
                 deposit_amount: half,
@@ -19464,7 +19559,7 @@ mod structured_error_tests {
                 metadata: None,
             },
             CreateStreamParams {
-        kind: crate::StreamKind::Linear,
+                kind: crate::StreamKind::Linear,
                 withdraw_dust_threshold: None,
                 recipient: ctx.recipient.clone(),
                 deposit_amount: half,
@@ -19509,9 +19604,9 @@ mod structured_error_tests {
             &0u64,
             &large_end,
             &0,
-            &None,,
+            &None,
             &crate::StreamKind::Linear,
-            );
+        );
 
         // new_rate * large_end overflows i128
         let overflow_rate = i128::MAX / (large_end as i128) + 2;
@@ -19541,9 +19636,9 @@ mod structured_error_tests {
             &0u64,
             &1000u64,
             &0,
-            &None,,
+            &None,
             &crate::StreamKind::Linear,
-            );
+        );
 
         ctx.env.ledger().set_timestamp(500);
         client.set_global_emergency_paused(&true);
@@ -19571,9 +19666,9 @@ mod structured_error_tests {
             &0u64,
             &1000u64,
             &0,
-            &None,,
+            &None,
             &crate::StreamKind::Linear,
-            );
+        );
 
         client.set_global_emergency_paused(&true);
 
@@ -19601,9 +19696,9 @@ mod structured_error_tests {
             &0u64,
             &1000u64,
             &0,
-            &None,,
+            &None,
             &crate::StreamKind::Linear,
-            );
+        );
 
         ctx.env.ledger().set_timestamp(500);
         client.set_global_emergency_paused(&true);
@@ -19642,9 +19737,9 @@ mod structured_error_tests {
             &0u64,
             &1_000u64,
             &0,
-            &None,,
+            &None,
             &crate::StreamKind::Linear,
-            );
+        );
 
         client.set_global_emergency_paused(&true);
 
@@ -19706,9 +19801,9 @@ fn test_batch_withdraw_non_adjacent_duplicates_rejected() {
         &0u64,
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     ctx.env.ledger().set_timestamp(300);
     let balance_before = ctx.token().balance(&ctx.recipient);
@@ -20008,9 +20103,9 @@ fn make_stream_end_1000(ctx: &TestContext) -> u64 {
         &0u64,
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        )
+    )
 }
 
 // ── pause_stream: Active stream ──────────────────────────────────────────────

--- a/contracts/stream/src/test_issue_39.rs
+++ b/contracts/stream/src/test_issue_39.rs
@@ -1,4 +1,4 @@
-﻿#[cfg(test)]
+#[cfg(test)]
 use crate::test::TestContext;
 use crate::StreamStatus;
 use soroban_sdk::{testutils::Address as _, testutils::Ledger, Address};
@@ -124,9 +124,9 @@ fn test_batch_withdraw_running_balance_cap() {
         &500,
         &500,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
     let id2 = ctx.client().create_stream(
         &ctx.sender,
         &ctx.recipient,
@@ -136,9 +136,9 @@ fn test_batch_withdraw_running_balance_cap() {
         &500,
         &500,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
 
     ctx.env.ledger().set_timestamp(500); // both fully accrued
 

--- a/contracts/stream/src/test_withdrawable_props.rs
+++ b/contracts/stream/src/test_withdrawable_props.rs
@@ -1,4 +1,4 @@
-﻿//! Property-based tests for withdrawable arithmetic invariants.
+//! Property-based tests for withdrawable arithmetic invariants.
 //!
 //! Proves that across every status transition (Active → Paused → Resumed →
 //! Cancelled / Completed) the following invariants always hold:
@@ -157,7 +157,7 @@ proptest! {
             &0u64,
             &0u64,
             &duration,
-            &0, &None,,
+            &0, &None,
             &crate::StreamKind::Linear,
             );
         for t in &times {
@@ -182,7 +182,7 @@ proptest! {
             &0u64,
             &0u64,
             &duration,
-            &0, &None,,
+            &0, &None,
             &crate::StreamKind::Linear,
             );
         for t in &times {
@@ -208,7 +208,7 @@ proptest! {
             &0u64,
             &0u64,
             &duration,
-            &0, &None,,
+            &0, &None,
             &crate::StreamKind::Linear,
             );
         let mut paused = false;
@@ -244,7 +244,7 @@ proptest! {
             &0u64,
             &0u64,
             &duration,
-            &0, &None,,
+            &0, &None,
             &crate::StreamKind::Linear,
             );
         ctx.env.ledger().set_timestamp(cancel_at);
@@ -270,7 +270,7 @@ proptest! {
             &0u64,
             &0u64,
             &duration,
-            &0, &None,,
+            &0, &None,
             &crate::StreamKind::Linear,
             );
         let mut prev = 0_i128;
@@ -304,9 +304,9 @@ fn setup_standard(deposit: i128) -> (PropCtx, u64) {
         &0u64,
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
     (ctx, id)
 }
 
@@ -407,9 +407,9 @@ fn invariants_cancelled_before_cliff() {
         &500u64,
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
     ctx.env.ledger().set_timestamp(200);
     ctx.client().cancel_stream(&id);
     assert_invariants(&ctx, id, "cancelled before cliff");
@@ -449,9 +449,9 @@ fn invariants_high_rate_deposit_capped() {
         &0u64,
         &100u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
     for t in [0u64, 10, 50, 99, 100, 200] {
         ctx.env.ledger().set_timestamp(t);
         assert_invariants(&ctx, id, &std::format!("high-rate t={t}"));
@@ -472,9 +472,9 @@ fn invariants_excess_deposit_stream() {
         &0u64,
         &1000u64,
         &0,
-        &None,,
+        &None,
         &crate::StreamKind::Linear,
-        );
+    );
     for t in [0u64, 500, 1000, 1500] {
         ctx.env.ledger().set_timestamp(t);
         assert_invariants(&ctx, id, &std::format!("excess-deposit t={t}"));

--- a/contracts/stream/tests/adaptive_ttl.rs
+++ b/contracts/stream/tests/adaptive_ttl.rs
@@ -1,4 +1,4 @@
-﻿//! Tests for issue #516: adaptive TTL thresholds for stream ledger entries.
+//! Tests for issue #516: adaptive TTL thresholds for stream ledger entries.
 //!
 //! Verifies that `compute_adaptive_ttl` scales correctly with remaining stream
 //! lifetime and that the floor/cap invariants hold.
@@ -54,7 +54,7 @@ impl<'a> Ctx<'a> {
             &soroban_sdk::vec![
                 &self.env,
                 CreateStreamParams {
-        kind: fluxora_stream::StreamKind::Linear,
+                    kind: fluxora_stream::StreamKind::Linear,
                     recipient: recipient.clone(),
                     deposit_amount: duration as i128,
                     rate_per_second: 1,

--- a/contracts/stream/tests/adversarial_auth.rs
+++ b/contracts/stream/tests/adversarial_auth.rs
@@ -1,4 +1,4 @@
-﻿extern crate std;
+extern crate std;
 
 use ed25519_dalek::{Signer, SigningKey};
 use fluxora_stream::{
@@ -126,7 +126,7 @@ impl<'a> Ctx<'a> {
             &0,
             &None,
             &fluxora_stream::StreamKind::Linear,
-            )
+        )
     }
 
     /// Pause a stream as the sender (helper to reach Paused state).
@@ -1096,7 +1096,7 @@ mod delegated_withdraw_adversarial {
                 &0,
                 &None,
                 &fluxora_stream::StreamKind::Linear,
-                )
+            )
         }
 
         fn sign(&self, stream_id: u64, dest: &Address, nonce: u64, deadline: u64) -> BytesN<64> {
@@ -1144,15 +1144,8 @@ mod delegated_withdraw_adversarial {
         // First withdrawal consumes nonce 0.
         ctx.env.ledger().set_timestamp(300);
         let sig0 = ctx.sign(stream_id, &dest, 0, 9999);
-        ctx.client().delegated_withdraw(
-            &stream_id,
-            &ctx.relayer,
-            &dest,
-            &0,
-            &9999,
-            &0i128,
-            &sig0,
-        );
+        ctx.client()
+            .delegated_withdraw(&stream_id, &ctx.relayer, &dest, &0, &9999, &0i128, &sig0);
 
         // Replay with nonce 0 must fail.
         ctx.env.ledger().set_timestamp(600);
@@ -1251,7 +1244,8 @@ mod delegated_withdraw_adversarial {
         // Drain the stream to Completed.
         ctx.env.ledger().set_timestamp(1000);
         let sig0 = ctx.sign(stream_id, &dest, 0, 9999);
-        ctx.client().delegated_withdraw(&stream_id, &ctx.relayer, &dest, &0, &9999, &0i128, &sig0);
+        ctx.client()
+            .delegated_withdraw(&stream_id, &ctx.relayer, &dest, &0, &9999, &0i128, &sig0);
 
         // Second attempt on a Completed stream must fail.
         let sig1 = ctx.sign(stream_id, &dest, 1, 9999);
@@ -1362,7 +1356,15 @@ fn delegated_withdraw_below_minimum_rejected() {
 
     let relayer = Address::generate(&ctx.env);
 
-    let result = ctx.client().try_delegated_withdraw(&stream_id, &relayer, &pub_key, &nonce, &deadline, &expected_minimum, &sig);
+    let result = ctx.client().try_delegated_withdraw(
+        &stream_id,
+        &relayer,
+        &pub_key,
+        &nonce,
+        &deadline,
+        &expected_minimum,
+        &sig,
+    );
 
     assert_eq!(
         result,
@@ -1406,7 +1408,15 @@ fn delegated_withdraw_nonce_increments_preventing_replay() {
 
     // Nonce is now 1; replaying nonce=0 must fail
     // stale nonce
-    let replay = ctx.client().try_delegated_withdraw(&stream_id, &relayer, &pub_key, &nonce, &deadline, &min_amount, &sig);
+    let replay = ctx.client().try_delegated_withdraw(
+        &stream_id,
+        &relayer,
+        &pub_key,
+        &nonce,
+        &deadline,
+        &min_amount,
+        &sig,
+    );
     assert_eq!(
         replay,
         Err(Ok(fluxora_stream::ContractError::InvalidSignature)),

--- a/contracts/stream/tests/balance_conservation.rs
+++ b/contracts/stream/tests/balance_conservation.rs
@@ -65,7 +65,9 @@ impl TestContext {
         let client = FluxoraStreamClient::new(&env, &contract_id);
 
         let token_admin = Address::generate(&env);
-        let token_id = env.register_stellar_asset_contract_v2(token_admin).address();
+        let token_id = env
+            .register_stellar_asset_contract_v2(token_admin)
+            .address();
         let token = TokenClient::new(&env, &token_id);
 
         let admin = Address::generate(&env);
@@ -143,9 +145,7 @@ impl TestContext {
 /// - start < end
 /// - cliff in [start, end]
 /// - deposit >= rate * (end - start)
-fn valid_stream_params()
-    -> impl Strategy<Value = (i128, i128, u64, u64, u64)>
-{
+fn valid_stream_params() -> impl Strategy<Value = (i128, i128, u64, u64, u64)> {
     // Use reasonable ranges for efficient testing while covering edge cases
     (1u64..10_000u64, 1u64..10_000u64, 1i128..1_000_000i128)
         .prop_filter("valid stream params", |(duration, cliff_offset, rate)| {
@@ -163,9 +163,7 @@ fn valid_stream_params()
 }
 
 /// Strategy for valid stream parameters with excess deposit (deposit > rate * duration).
-fn stream_with_excess_deposit()
-    -> impl Strategy<Value = (i128, i128, u64, u64, u64)>
-{
+fn stream_with_excess_deposit() -> impl Strategy<Value = (i128, i128, u64, u64, u64)> {
     valid_stream_params().prop_map(|(deposit, rate, start, cliff, end)| {
         let duration = end - start;
         let excess = deposit / 2; // 50% excess
@@ -194,7 +192,7 @@ fn operation_sequence(
     start: u64,
     cliff: u64,
     end: u64,
-) -> impl Strategy<Value = Vec<<StreamOp>> {
+) -> impl Strategy<Value = Vec<StreamOp>> {
     let duration = end - start;
     let max_time = end + 1000; // Allow some post-end operations
 
@@ -216,8 +214,8 @@ fn operation_sequence(
 
     // IncreaseRate: new_rate in (rate, rate * 2] but must satisfy deposit >= new_rate * (end - start)
     // For simplicity, keep within bounds
-    let increase_rate_op = (rate + 1..=rate * 2)
-        .prop_map(|new_rate| StreamOp::IncreaseRate { new_rate });
+    let increase_rate_op =
+        (rate + 1..=rate * 2).prop_map(|new_rate| StreamOp::IncreaseRate { new_rate });
 
     // DecreaseRate: new_rate in [1, rate)
     let decrease_rate_op = (1i128..rate).prop_map(|new_rate| StreamOp::DecreaseRate { new_rate });
@@ -297,9 +295,7 @@ fn assert_stream_balance_conservation(ctx: &TestContext, stream_id: u64) {
         assert_eq!(
             stream.withdrawn_amount, stream.deposit_amount,
             "Stream {}: Completed but withdrawn {} != deposit {}",
-            stream_id,
-            stream.withdrawn_amount,
-            stream.deposit_amount
+            stream_id, stream.withdrawn_amount, stream.deposit_amount
         );
     }
 
@@ -923,7 +919,8 @@ fn cancel_immediately_refunds_full_deposit() {
 
     let deposit = 1000i128;
     let rate = 1i128;
-    let stream_id = ctx.create_stream(deposit, rate, 0, 0, 1000)
+    let stream_id = ctx
+        .create_stream(deposit, rate, 0, 0, 1000)
         .expect("creation should succeed");
 
     let sender_before = ctx.token.balance(&ctx.sender);
@@ -963,7 +960,8 @@ fn cancel_at_cliff_refunds_correct_amount() {
     let start = 0u64;
     let cliff = 500u64;
     let end = 1000u64;
-    let stream_id = ctx.create_stream(deposit, rate, start, cliff, end)
+    let stream_id = ctx
+        .create_stream(deposit, rate, start, cliff, end)
         .expect("creation should succeed");
 
     ctx.set_time(cliff);
@@ -1000,7 +998,8 @@ fn withdraw_after_end_gets_full_deposit() {
 
     let deposit = 1000i128;
     let rate = 1i128;
-    let stream_id = ctx.create_stream(deposit, rate, 0, 0, 1000)
+    let stream_id = ctx
+        .create_stream(deposit, rate, 0, 0, 1000)
         .expect("creation should succeed");
 
     ctx.set_time(2000); // Well past end
@@ -1038,7 +1037,8 @@ fn shorten_refunds_exact_unstreamed() {
 
     let deposit = 1000i128;
     let rate = 1i128;
-    let stream_id = ctx.create_stream(deposit, rate, 0, 0, 1000)
+    let stream_id = ctx
+        .create_stream(deposit, rate, 0, 0, 1000)
         .expect("creation should succeed");
 
     // Shorten from 1000 to 600 at t=100
@@ -1082,7 +1082,8 @@ fn decrease_rate_refunds_excess() {
     // Stream: 1000 tokens, 10/s, 100s
     let deposit = 1000i128;
     let rate = 10i128;
-    let stream_id = ctx.create_stream(deposit, rate, 0, 0, 100)
+    let stream_id = ctx
+        .create_stream(deposit, rate, 0, 0, 100)
         .expect("creation should succeed");
 
     // At t=50, decrease rate from 10 to 5
@@ -1174,9 +1175,8 @@ fn global_conservation_complex_scenario() {
     assert_global_balance_conservation(&ctx);
 
     // Final check: total tokens in system
-    let total = ctx.token.balance(&ctx.sender)
-        + ctx.token.balance(&ctx.recipient)
-        + ctx.contract_balance();
+    let total =
+        ctx.token.balance(&ctx.sender) + ctx.token.balance(&ctx.recipient) + ctx.contract_balance();
     assert_eq!(total, 2_000_000_000_000i128);
 }
 
@@ -1200,7 +1200,11 @@ fn sweep_excess_preserves_liabilities() {
     let swept = ctx.client.sweep_excess(&sweep_recipient);
 
     assert_eq!(swept, extra, "Must sweep exactly the excess amount");
-    assert_eq!(ctx.contract_balance(), deposit, "Contract must retain exactly liabilities");
+    assert_eq!(
+        ctx.contract_balance(),
+        deposit,
+        "Contract must retain exactly liabilities"
+    );
     assert_eq!(
         ctx.token.balance(&sweep_recipient),
         extra,
@@ -1231,10 +1235,9 @@ fn batch_withdraw_partial_completion() {
     // At t=600 > end=500, accrued = min(2*500, 2000) = 1000
 
     let recipient_before = ctx.token.balance(&ctx.recipient);
-    let results = ctx.client.batch_withdraw(
-        &ctx.recipient,
-        &vec![&ctx.env, s1, s2],
-    );
+    let results = ctx
+        .client
+        .batch_withdraw(&ctx.recipient, &vec![&ctx.env, s1, s2]);
     let recipient_after = ctx.token.balance(&ctx.recipient);
 
     let total: i128 = results.iter().map(|r| r.amount).sum();

--- a/contracts/stream/tests/batch_recipient_cache.rs
+++ b/contracts/stream/tests/batch_recipient_cache.rs
@@ -1,4 +1,4 @@
-﻿//! Tests for issue #514: recipient stream index caching in `create_streams`.
+//! Tests for issue #514: recipient stream index caching in `create_streams`.
 //!
 //! Verifies that batching multiple streams to the same recipient produces the
 //! same index state as creating them one-by-one, and that the O(1)-per-recipient
@@ -134,7 +134,7 @@ fn test_batch_index_matches_sequential_creation() {
         &0,
         &None,
         &fluxora_stream::StreamKind::Linear,
-        );
+    );
     ctx1.client.create_stream(
         &ctx1.sender,
         &p2.recipient,

--- a/contracts/stream/tests/bulk_cancel.rs
+++ b/contracts/stream/tests/bulk_cancel.rs
@@ -6,8 +6,7 @@ use soroban_sdk::{
 };
 
 use crate::{
-    accrual, FluxoraStream, FluxoraStreamClient, StreamStatus,
-    ContractError, DataKey, Config,
+    accrual, Config, ContractError, DataKey, FluxoraStream, FluxoraStreamClient, StreamStatus,
 };
 
 // ── Test helpers ───────────────────────────────────────────────────────────
@@ -41,20 +40,13 @@ fn create_test_stream(
 ) -> u64 {
     env.mock_all_auths();
     client.create_stream(
-        sender,
-        recipient,
-        &deposit,
-        &rate,
-        &start,
-        &cliff,
-        &end,
-        &0i128,
-        &None,
+        sender, recipient, &deposit, &rate, &start, &cliff, &end, &0i128, &None,
     )
 }
 
 fn advance_time(env: &Env, seconds: u64) {
-    env.ledger().set_timestamp(env.ledger().timestamp() + seconds);
+    env.ledger()
+        .set_timestamp(env.ledger().timestamp() + seconds);
 }
 
 // ── bulk_cancel_streams tests ──────────────────────────────────────────────

--- a/contracts/stream/tests/chaos.rs
+++ b/contracts/stream/tests/chaos.rs
@@ -11,14 +11,14 @@
 //! On failure the permutation seed is printed for reproducibility.
 
 use fluxora_stream::{
-    FluxoraStreamClient, FluxoraStream, CreateStreamParams, StreamStatus, PauseReason,
-    ContractError,
+    ContractError, CreateStreamParams, FluxoraStream, FluxoraStreamClient, PauseReason,
+    StreamStatus,
 };
 use proptest::prelude::*;
 use soroban_sdk::{
     testutils::{Address as _, Events, Ledger},
     token::Client as TokenClient,
-    vec, Address, Env, Symbol, IntoVal,
+    vec, Address, Env, IntoVal, Symbol,
 };
 
 struct TestContext {
@@ -40,7 +40,9 @@ impl TestContext {
         let client = FluxoraStreamClient::new(&env, &contract_id);
 
         let token_admin = Address::generate(&env);
-        let token_id = env.register_stellar_asset_contract_v2(token_admin).address();
+        let token_id = env
+            .register_stellar_asset_contract_v2(token_admin)
+            .address();
         let token = TokenClient::new(&env, &token_id);
 
         let admin = Address::generate(&env);
@@ -50,7 +52,15 @@ impl TestContext {
         // Initialise contract
         client.init(&token_id, &admin);
 
-        Self { env, client, sender, recipient, token, contract_id, admin }
+        Self {
+            env,
+            client,
+            sender,
+            recipient,
+            token,
+            contract_id,
+            admin,
+        }
     }
 
     fn create_stream(&self) -> u64 {
@@ -93,7 +103,8 @@ fn apply_op(ctx: &TestContext, stream_id: u64, op: Op) -> Result<(), ContractErr
             Ok(())
         }
         Op::Pause => {
-            ctx.client.pause_stream(&stream_id, &PauseReason::Operational);
+            ctx.client
+                .pause_stream(&stream_id, &PauseReason::Operational);
             Ok(())
         }
     }
@@ -107,7 +118,10 @@ fn post_conditions_hold(ctx: &TestContext, stream_id: u64) {
     // Stream status must be a valid enum value.
     let status = ctx.client.get_stream_state(&stream_id).status;
     match status {
-        StreamStatus::Active | StreamStatus::Paused | StreamStatus::Completed | StreamStatus::Cancelled => {}
+        StreamStatus::Active
+        | StreamStatus::Paused
+        | StreamStatus::Completed
+        | StreamStatus::Cancelled => {}
         _ => panic!("invalid stream status"),
     }
 
@@ -116,7 +130,11 @@ fn post_conditions_hold(ctx: &TestContext, stream_id: u64) {
     // For simplicity we just ensure contract balance + sender balance + recipient balance == 1000.
     let sender_bal = ctx.token.balance(&ctx.sender);
     let recipient_bal = ctx.token.balance(&ctx.recipient);
-    assert_eq!(contract_bal + sender_bal + recipient_bal, 1000, "tokens mismatch");
+    assert_eq!(
+        contract_bal + sender_bal + recipient_bal,
+        1000,
+        "tokens mismatch"
+    );
 }
 
 proptest! {
@@ -151,15 +169,21 @@ proptest! {
 // Helper: generate next lexicographic permutation (returns false when finished).
 fn next_permutation<T: Ord>(data: &mut [T]) -> bool {
     // Find the largest index i such that data[i] < data[i + 1]
-    if data.len() < 2 { return false; }
+    if data.len() < 2 {
+        return false;
+    }
     let mut i = data.len() - 2;
     while i != usize::MAX && data[i] >= data[i + 1] {
-        if i == 0 { return false; }
+        if i == 0 {
+            return false;
+        }
         i -= 1;
     }
     // Find the largest index j > i such that data[i] < data[j]
     let mut j = data.len() - 1;
-    while data[i] >= data[j] { j -= 1; }
+    while data[i] >= data[j] {
+        j -= 1;
+    }
     data.swap(i, j);
     data[i + 1..].reverse();
     true

--- a/contracts/stream/tests/cliff_only_variant.rs
+++ b/contracts/stream/tests/cliff_only_variant.rs
@@ -1,11 +1,9 @@
 extern crate std;
 
-use fluxora_stream::{
-    ContractError, FluxoraStream, FluxoraStreamClient, StreamStatus, StreamKind,
-};
+use fluxora_stream::{ContractError, FluxoraStream, FluxoraStreamClient, StreamKind, StreamStatus};
 use soroban_sdk::{
     testutils::{Address as _, Ledger},
-    token::{Client as TokenClient},
+    token::Client as TokenClient,
     Address, Env,
 };
 
@@ -27,9 +25,11 @@ impl<'a> TestContext<'a> {
         let client = FluxoraStreamClient::new(&env, &contract_id);
 
         let token_admin = Address::generate(&env);
-        let token_id = env.register_stellar_asset_contract_v2(token_admin).address();
+        let token_id = env
+            .register_stellar_asset_contract_v2(token_admin)
+            .address();
         let token = TokenClient::new(&env, &token_id);
-        
+
         let admin = Address::generate(&env);
         let sender = Address::generate(&env);
         let recipient = Address::generate(&env);
@@ -60,8 +60,8 @@ impl<'a> TestContext<'a> {
             &start,
             &cliff,
             &end,
-            &0,      // dust threshold
-            &None,   // memo
+            &0,    // dust threshold
+            &None, // memo
             &StreamKind::CliffOnly,
         )
     }
@@ -132,7 +132,9 @@ fn test_cliff_only_rejects_mutations() {
     assert_eq!(res, Err(Ok(ContractError::UnsupportedStreamKind)));
 
     // Attempt: top_up_stream
-    let res = ctx.client.try_top_up_stream(&stream_id, &ctx.sender, &500_i128);
+    let res = ctx
+        .client
+        .try_top_up_stream(&stream_id, &ctx.sender, &500_i128);
     assert_eq!(res, Err(Ok(ContractError::UnsupportedStreamKind)));
 }
 
@@ -174,7 +176,10 @@ fn test_cliff_only_cancel_before_cliff() {
     let sender_balance_before = ctx.token.balance(&ctx.sender);
     let stream_id = ctx.create_cliff_only_stream(deposit, 100, 500, 1000);
 
-    assert_eq!(ctx.token.balance(&ctx.sender), sender_balance_before - deposit);
+    assert_eq!(
+        ctx.token.balance(&ctx.sender),
+        sender_balance_before - deposit
+    );
 
     // Cancel before cliff (t = 400)
     ctx.env.ledger().set_timestamp(400);
@@ -204,8 +209,11 @@ fn test_cliff_only_cancel_after_cliff() {
     ctx.client.cancel_stream(&stream_id);
 
     // Sender gets 0 refund, recipient is entitled to 100%
-    assert_eq!(ctx.token.balance(&ctx.sender), sender_balance_before - deposit);
-    
+    assert_eq!(
+        ctx.token.balance(&ctx.sender),
+        sender_balance_before - deposit
+    );
+
     // Recipient pulls their funds
     let withdrawn = ctx.client.withdraw(&stream_id);
     assert_eq!(withdrawn, deposit);

--- a/contracts/stream/tests/clone_stream.rs
+++ b/contracts/stream/tests/clone_stream.rs
@@ -14,7 +14,10 @@
 //! - Multiple sequential clones (recurring payroll pattern)
 extern crate std;
 
-use fluxora_stream::{ContractError, FluxoraStream, FluxoraStreamClient, PauseReason, StreamCloned, StreamCreated, StreamStatus};
+use fluxora_stream::{
+    ContractError, FluxoraStream, FluxoraStreamClient, PauseReason, StreamCloned, StreamCreated,
+    StreamStatus,
+};
 use soroban_sdk::{
     testutils::{Address as _, Ledger, MockAuth, MockAuthInvoke},
     token::{Client as TokenClient, StellarAssetClient},
@@ -61,7 +64,16 @@ impl<'a> Ctx<'a> {
         let token = TokenClient::new(&env, &token_id);
         token.approve(&sender, &contract_id, &i128::MAX, &100_000);
 
-        Ctx { env, contract_id, token_id, admin, sender, recipient, sac, token }
+        Ctx {
+            env,
+            contract_id,
+            token_id,
+            admin,
+            sender,
+            recipient,
+            sac,
+            token,
+        }
     }
 
     fn client(&self) -> FluxoraStreamClient<'_> {
@@ -72,10 +84,15 @@ impl<'a> Ctx<'a> {
     fn create_default_stream(&self) -> u64 {
         self.env.ledger().set_timestamp(0);
         self.client().create_stream(
-            &self.sender, &self.recipient,
-            &1000_i128, &1_i128,
-            &0u64, &0u64, &1000u64,
-            &0, &None,
+            &self.sender,
+            &self.recipient,
+            &1000_i128,
+            &1_i128,
+            &0u64,
+            &0u64,
+            &1000u64,
+            &0,
+            &None,
         )
     }
 
@@ -83,10 +100,15 @@ impl<'a> Ctx<'a> {
     fn create_cliff_stream(&self) -> u64 {
         self.env.ledger().set_timestamp(0);
         self.client().create_stream(
-            &self.sender, &self.recipient,
-            &1000_i128, &1_i128,
-            &0u64, &500u64, &1000u64,
-            &0, &None,
+            &self.sender,
+            &self.recipient,
+            &1000_i128,
+            &1_i128,
+            &0u64,
+            &500u64,
+            &1000u64,
+            &0,
+            &None,
         )
     }
 }
@@ -104,14 +126,20 @@ fn clone_from_completed_stream_succeeds() {
     // Complete the source stream.
     ctx.env.ledger().set_timestamp(1000);
     ctx.client().withdraw(&source_id);
-    assert_eq!(ctx.client().get_stream_state(&source_id).status, StreamStatus::Completed);
+    assert_eq!(
+        ctx.client().get_stream_state(&source_id).status,
+        StreamStatus::Completed
+    );
 
     // Clone it for the next period.
     ctx.env.ledger().set_timestamp(1000);
     let new_id = ctx.client().clone_stream(
-        &source_id, &ctx.recipient,
-        &1000u64, &2000u64,
-        &1000_i128, &false,
+        &source_id,
+        &ctx.recipient,
+        &1000u64,
+        &2000u64,
+        &1000_i128,
+        &false,
     );
 
     let new_state = ctx.client().get_stream_state(&new_id);
@@ -133,13 +161,19 @@ fn clone_from_cancelled_stream_succeeds() {
 
     ctx.env.ledger().set_timestamp(400);
     ctx.client().cancel_stream(&source_id);
-    assert_eq!(ctx.client().get_stream_state(&source_id).status, StreamStatus::Cancelled);
+    assert_eq!(
+        ctx.client().get_stream_state(&source_id).status,
+        StreamStatus::Cancelled
+    );
 
     ctx.env.ledger().set_timestamp(1000);
     let new_id = ctx.client().clone_stream(
-        &source_id, &ctx.recipient,
-        &1000u64, &2000u64,
-        &1000_i128, &false,
+        &source_id,
+        &ctx.recipient,
+        &1000u64,
+        &2000u64,
+        &1000_i128,
+        &false,
     );
 
     let new_state = ctx.client().get_stream_state(&new_id);
@@ -155,15 +189,24 @@ fn clone_from_active_stream_succeeds() {
 
     ctx.env.ledger().set_timestamp(500);
     let new_id = ctx.client().clone_stream(
-        &source_id, &ctx.recipient,
-        &1000u64, &2000u64,
-        &1000_i128, &false,
+        &source_id,
+        &ctx.recipient,
+        &1000u64,
+        &2000u64,
+        &1000_i128,
+        &false,
     );
 
     // Source stream is still Active and unaffected.
-    assert_eq!(ctx.client().get_stream_state(&source_id).status, StreamStatus::Active);
+    assert_eq!(
+        ctx.client().get_stream_state(&source_id).status,
+        StreamStatus::Active
+    );
     // New stream is also Active.
-    assert_eq!(ctx.client().get_stream_state(&new_id).status, StreamStatus::Active);
+    assert_eq!(
+        ctx.client().get_stream_state(&new_id).status,
+        StreamStatus::Active
+    );
 }
 
 /// Cloning a Paused stream is allowed.
@@ -173,19 +216,32 @@ fn clone_from_paused_stream_succeeds() {
     let source_id = ctx.create_default_stream();
 
     ctx.env.ledger().set_timestamp(300);
-    ctx.client().pause_stream(&source_id, &PauseReason::Operational);
-    assert_eq!(ctx.client().get_stream_state(&source_id).status, StreamStatus::Paused);
+    ctx.client()
+        .pause_stream(&source_id, &PauseReason::Operational);
+    assert_eq!(
+        ctx.client().get_stream_state(&source_id).status,
+        StreamStatus::Paused
+    );
 
     ctx.env.ledger().set_timestamp(1000);
     let new_id = ctx.client().clone_stream(
-        &source_id, &ctx.recipient,
-        &1000u64, &2000u64,
-        &1000_i128, &false,
+        &source_id,
+        &ctx.recipient,
+        &1000u64,
+        &2000u64,
+        &1000_i128,
+        &false,
     );
 
-    assert_eq!(ctx.client().get_stream_state(&new_id).status, StreamStatus::Active);
+    assert_eq!(
+        ctx.client().get_stream_state(&new_id).status,
+        StreamStatus::Active
+    );
     // Source stream remains Paused.
-    assert_eq!(ctx.client().get_stream_state(&source_id).status, StreamStatus::Paused);
+    assert_eq!(
+        ctx.client().get_stream_state(&source_id).status,
+        StreamStatus::Paused
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -198,10 +254,15 @@ fn clone_inherits_rate_per_second() {
     let ctx = Ctx::setup();
     ctx.env.ledger().set_timestamp(0);
     let source_id = ctx.client().create_stream(
-        &ctx.sender, &ctx.recipient,
-        &5000_i128, &5_i128,
-        &0u64, &0u64, &1000u64,
-        &0, &None,
+        &ctx.sender,
+        &ctx.recipient,
+        &5000_i128,
+        &5_i128,
+        &0u64,
+        &0u64,
+        &1000u64,
+        &0,
+        &None,
     );
 
     ctx.env.ledger().set_timestamp(1000);
@@ -209,9 +270,12 @@ fn clone_inherits_rate_per_second() {
 
     ctx.env.ledger().set_timestamp(1000);
     let new_id = ctx.client().clone_stream(
-        &source_id, &ctx.recipient,
-        &1000u64, &2000u64,
-        &5000_i128, &false,
+        &source_id,
+        &ctx.recipient,
+        &1000u64,
+        &2000u64,
+        &5000_i128,
+        &false,
     );
 
     assert_eq!(ctx.client().get_stream_state(&new_id).rate_per_second, 5);
@@ -230,9 +294,12 @@ fn clone_preserves_cliff_offset() {
     // Clone: new_start=2000, expected new_cliff = 2000 + 500 = 2500.
     ctx.env.ledger().set_timestamp(1000);
     let new_id = ctx.client().clone_stream(
-        &source_id, &ctx.recipient,
-        &2000u64, &3000u64,
-        &1000_i128, &false,
+        &source_id,
+        &ctx.recipient,
+        &2000u64,
+        &3000u64,
+        &1000_i128,
+        &false,
     );
 
     let new_state = ctx.client().get_stream_state(&new_id);
@@ -252,13 +319,19 @@ fn clone_preserves_zero_cliff_offset() {
 
     ctx.env.ledger().set_timestamp(1000);
     let new_id = ctx.client().clone_stream(
-        &source_id, &ctx.recipient,
-        &2000u64, &3000u64,
-        &1000_i128, &false,
+        &source_id,
+        &ctx.recipient,
+        &2000u64,
+        &3000u64,
+        &1000_i128,
+        &false,
     );
 
     let new_state = ctx.client().get_stream_state(&new_id);
-    assert_eq!(new_state.cliff_time, new_state.start_time, "zero cliff offset must be preserved");
+    assert_eq!(
+        new_state.cliff_time, new_state.start_time,
+        "zero cliff offset must be preserved"
+    );
 }
 
 /// withdraw_dust_threshold is copied verbatim.
@@ -267,10 +340,15 @@ fn clone_inherits_withdraw_dust_threshold() {
     let ctx = Ctx::setup();
     ctx.env.ledger().set_timestamp(0);
     let source_id = ctx.client().create_stream(
-        &ctx.sender, &ctx.recipient,
-        &1000_i128, &1_i128,
-        &0u64, &0u64, &1000u64,
-        &100_i128, &None, // dust threshold = 100
+        &ctx.sender,
+        &ctx.recipient,
+        &1000_i128,
+        &1_i128,
+        &0u64,
+        &0u64,
+        &1000u64,
+        &100_i128,
+        &None, // dust threshold = 100
     );
 
     ctx.env.ledger().set_timestamp(1000);
@@ -278,12 +356,20 @@ fn clone_inherits_withdraw_dust_threshold() {
 
     ctx.env.ledger().set_timestamp(1000);
     let new_id = ctx.client().clone_stream(
-        &source_id, &ctx.recipient,
-        &1000u64, &2000u64,
-        &1000_i128, &false,
+        &source_id,
+        &ctx.recipient,
+        &1000u64,
+        &2000u64,
+        &1000_i128,
+        &false,
     );
 
-    assert_eq!(ctx.client().get_stream_state(&new_id).withdraw_dust_threshold, 100);
+    assert_eq!(
+        ctx.client()
+            .get_stream_state(&new_id)
+            .withdraw_dust_threshold,
+        100
+    );
 }
 
 /// Memo is copied verbatim.
@@ -293,10 +379,15 @@ fn clone_inherits_memo() {
     ctx.env.ledger().set_timestamp(0);
     let memo = Some(soroban_sdk::Bytes::from_slice(&ctx.env, b"payroll-jan"));
     let source_id = ctx.client().create_stream(
-        &ctx.sender, &ctx.recipient,
-        &1000_i128, &1_i128,
-        &0u64, &0u64, &1000u64,
-        &0, &memo,
+        &ctx.sender,
+        &ctx.recipient,
+        &1000_i128,
+        &1_i128,
+        &0u64,
+        &0u64,
+        &1000u64,
+        &0,
+        &memo,
     );
 
     ctx.env.ledger().set_timestamp(1000);
@@ -304,9 +395,12 @@ fn clone_inherits_memo() {
 
     ctx.env.ledger().set_timestamp(1000);
     let new_id = ctx.client().clone_stream(
-        &source_id, &ctx.recipient,
-        &1000u64, &2000u64,
-        &1000_i128, &false,
+        &source_id,
+        &ctx.recipient,
+        &1000u64,
+        &2000u64,
+        &1000_i128,
+        &false,
     );
 
     let new_state = ctx.client().get_stream_state(&new_id);
@@ -327,9 +421,12 @@ fn clone_with_different_recipient() {
     let new_recipient = Address::generate(&ctx.env);
     ctx.env.ledger().set_timestamp(1000);
     let new_id = ctx.client().clone_stream(
-        &source_id, &new_recipient,
-        &1000u64, &2000u64,
-        &1000_i128, &false,
+        &source_id,
+        &new_recipient,
+        &1000u64,
+        &2000u64,
+        &1000_i128,
+        &false,
     );
 
     let new_state = ctx.client().get_stream_state(&new_id);
@@ -347,7 +444,9 @@ fn clone_sender_authorized_strict() {
     let env = Env::default();
     let contract_id = env.register_contract(None, FluxoraStream);
     let token_admin = Address::generate(&env);
-    let token_id = env.register_stellar_asset_contract_v2(token_admin.clone()).address();
+    let token_id = env
+        .register_stellar_asset_contract_v2(token_admin.clone())
+        .address();
     let admin = Address::generate(&env);
     let sender = Address::generate(&env);
     let recipient = Address::generate(&env);
@@ -362,10 +461,7 @@ fn clone_sender_authorized_strict() {
 
     env.ledger().set_timestamp(0);
     let source_id = client.create_stream(
-        &sender, &recipient,
-        &1000_i128, &1_i128,
-        &0u64, &0u64, &1000u64,
-        &0, &None,
+        &sender, &recipient, &1000_i128, &1_i128, &0u64, &0u64, &1000u64, &0, &None,
     );
 
     env.ledger().set_timestamp(1000);
@@ -377,14 +473,18 @@ fn clone_sender_authorized_strict() {
         invoke: &MockAuthInvoke {
             contract: &contract_id,
             fn_name: "clone_stream",
-            args: (&source_id, &recipient, 1000u64, 2000u64, 1000_i128, false)
-                .into_val(&env),
+            args: (&source_id, &recipient, 1000u64, 2000u64, 1000_i128, false).into_val(&env),
             sub_invokes: &[],
         },
     }]);
 
-    let new_id = client.clone_stream(&source_id, &recipient, &1000u64, &2000u64, &1000_i128, &false);
-    assert_eq!(client.get_stream_state(&new_id).status, StreamStatus::Active);
+    let new_id = client.clone_stream(
+        &source_id, &recipient, &1000u64, &2000u64, &1000_i128, &false,
+    );
+    assert_eq!(
+        client.get_stream_state(&new_id).status,
+        StreamStatus::Active
+    );
 }
 
 /// Recipient cannot clone a stream they receive (strict mode).
@@ -394,7 +494,9 @@ fn clone_recipient_unauthorized() {
     let env = Env::default();
     let contract_id = env.register_contract(None, FluxoraStream);
     let token_admin = Address::generate(&env);
-    let token_id = env.register_stellar_asset_contract_v2(token_admin.clone()).address();
+    let token_id = env
+        .register_stellar_asset_contract_v2(token_admin.clone())
+        .address();
     let admin = Address::generate(&env);
     let sender = Address::generate(&env);
     let recipient = Address::generate(&env);
@@ -409,10 +511,7 @@ fn clone_recipient_unauthorized() {
 
     env.ledger().set_timestamp(0);
     let source_id = client.create_stream(
-        &sender, &recipient,
-        &1000_i128, &1_i128,
-        &0u64, &0u64, &1000u64,
-        &0, &None,
+        &sender, &recipient, &1000_i128, &1_i128, &0u64, &0u64, &1000u64, &0, &None,
     );
 
     env.ledger().set_timestamp(1000);
@@ -424,13 +523,14 @@ fn clone_recipient_unauthorized() {
         invoke: &MockAuthInvoke {
             contract: &contract_id,
             fn_name: "clone_stream",
-            args: (&source_id, &recipient, 1000u64, 2000u64, 1000_i128, false)
-                .into_val(&env),
+            args: (&source_id, &recipient, 1000u64, 2000u64, 1000_i128, false).into_val(&env),
             sub_invokes: &[],
         },
     }]);
 
-    client.clone_stream(&source_id, &recipient, &1000u64, &2000u64, &1000_i128, &false);
+    client.clone_stream(
+        &source_id, &recipient, &1000u64, &2000u64, &1000_i128, &false,
+    );
 }
 
 /// Third party cannot clone a stream they have no relation to (strict mode).
@@ -440,7 +540,9 @@ fn clone_third_party_unauthorized() {
     let env = Env::default();
     let contract_id = env.register_contract(None, FluxoraStream);
     let token_admin = Address::generate(&env);
-    let token_id = env.register_stellar_asset_contract_v2(token_admin.clone()).address();
+    let token_id = env
+        .register_stellar_asset_contract_v2(token_admin.clone())
+        .address();
     let admin = Address::generate(&env);
     let sender = Address::generate(&env);
     let recipient = Address::generate(&env);
@@ -456,10 +558,7 @@ fn clone_third_party_unauthorized() {
 
     env.ledger().set_timestamp(0);
     let source_id = client.create_stream(
-        &sender, &recipient,
-        &1000_i128, &1_i128,
-        &0u64, &0u64, &1000u64,
-        &0, &None,
+        &sender, &recipient, &1000_i128, &1_i128, &0u64, &0u64, &1000u64, &0, &None,
     );
 
     env.ledger().set_timestamp(1000);
@@ -471,13 +570,14 @@ fn clone_third_party_unauthorized() {
         invoke: &MockAuthInvoke {
             contract: &contract_id,
             fn_name: "clone_stream",
-            args: (&source_id, &recipient, 1000u64, 2000u64, 1000_i128, false)
-                .into_val(&env),
+            args: (&source_id, &recipient, 1000u64, 2000u64, 1000_i128, false).into_val(&env),
             sub_invokes: &[],
         },
     }]);
 
-    client.clone_stream(&source_id, &recipient, &1000u64, &2000u64, &1000_i128, &false);
+    client.clone_stream(
+        &source_id, &recipient, &1000u64, &2000u64, &1000_i128, &false,
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -491,10 +591,15 @@ fn clone_cliff_only_sentinel_rejected_without_force() {
     ctx.env.ledger().set_timestamp(0);
     // Create a stream with the CliffOnly sentinel threshold.
     let source_id = ctx.client().create_stream(
-        &ctx.sender, &ctx.recipient,
-        &1000_i128, &1_i128,
-        &0u64, &0u64, &1000u64,
-        &i128::MAX, &None, // sentinel
+        &ctx.sender,
+        &ctx.recipient,
+        &1000_i128,
+        &1_i128,
+        &0u64,
+        &0u64,
+        &1000u64,
+        &i128::MAX,
+        &None, // sentinel
     );
 
     ctx.env.ledger().set_timestamp(1000);
@@ -502,9 +607,12 @@ fn clone_cliff_only_sentinel_rejected_without_force() {
 
     ctx.env.ledger().set_timestamp(1000);
     let result = ctx.client().try_clone_stream(
-        &source_id, &ctx.recipient,
-        &1000u64, &2000u64,
-        &1000_i128, &false, // force=false → must reject
+        &source_id,
+        &ctx.recipient,
+        &1000u64,
+        &2000u64,
+        &1000_i128,
+        &false, // force=false → must reject
     );
 
     assert_eq!(result, Err(Ok(ContractError::InvalidParams)));
@@ -516,10 +624,15 @@ fn clone_cliff_only_sentinel_allowed_with_force() {
     let ctx = Ctx::setup();
     ctx.env.ledger().set_timestamp(0);
     let source_id = ctx.client().create_stream(
-        &ctx.sender, &ctx.recipient,
-        &1000_i128, &1_i128,
-        &0u64, &0u64, &1000u64,
-        &i128::MAX, &None,
+        &ctx.sender,
+        &ctx.recipient,
+        &1000_i128,
+        &1_i128,
+        &0u64,
+        &0u64,
+        &1000u64,
+        &i128::MAX,
+        &None,
     );
 
     ctx.env.ledger().set_timestamp(1000);
@@ -527,9 +640,12 @@ fn clone_cliff_only_sentinel_allowed_with_force() {
 
     ctx.env.ledger().set_timestamp(1000);
     let new_id = ctx.client().clone_stream(
-        &source_id, &ctx.recipient,
-        &1000u64, &2000u64,
-        &1000_i128, &true, // force=true → allowed
+        &source_id,
+        &ctx.recipient,
+        &1000u64,
+        &2000u64,
+        &1000_i128,
+        &true, // force=true → allowed
     );
 
     let new_state = ctx.client().get_stream_state(&new_id);
@@ -549,12 +665,18 @@ fn clone_normal_stream_force_false_succeeds() {
     ctx.env.ledger().set_timestamp(1000);
     // force=false on a normal stream must succeed.
     let new_id = ctx.client().clone_stream(
-        &source_id, &ctx.recipient,
-        &1000u64, &2000u64,
-        &1000_i128, &false,
+        &source_id,
+        &ctx.recipient,
+        &1000u64,
+        &2000u64,
+        &1000_i128,
+        &false,
     );
 
-    assert_eq!(ctx.client().get_stream_state(&new_id).status, StreamStatus::Active);
+    assert_eq!(
+        ctx.client().get_stream_state(&new_id).status,
+        StreamStatus::Active
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -567,11 +689,9 @@ fn clone_source_not_found() {
     let ctx = Ctx::setup();
     ctx.env.ledger().set_timestamp(0);
 
-    let result = ctx.client().try_clone_stream(
-        &999u64, &ctx.recipient,
-        &0u64, &1000u64,
-        &1000_i128, &false,
-    );
+    let result =
+        ctx.client()
+            .try_clone_stream(&999u64, &ctx.recipient, &0u64, &1000u64, &1000_i128, &false);
 
     assert_eq!(result, Err(Ok(ContractError::StreamNotFound)));
 }
@@ -588,9 +708,12 @@ fn clone_start_time_in_past_rejected() {
     // Ledger is at t=1000; start_time=500 is in the past.
     ctx.env.ledger().set_timestamp(1000);
     let result = ctx.client().try_clone_stream(
-        &source_id, &ctx.recipient,
-        &500u64, &1500u64, // start_time < now
-        &1000_i128, &false,
+        &source_id,
+        &ctx.recipient,
+        &500u64,
+        &1500u64, // start_time < now
+        &1000_i128,
+        &false,
     );
 
     assert_eq!(result, Err(Ok(ContractError::StartTimeInPast)));
@@ -608,9 +731,12 @@ fn clone_insufficient_deposit_rejected() {
     ctx.env.ledger().set_timestamp(1000);
     // rate=1, duration=1000s → need 1000 tokens; deposit=500 is insufficient.
     let result = ctx.client().try_clone_stream(
-        &source_id, &ctx.recipient,
-        &1000u64, &2000u64,
-        &500_i128, &false, // too small
+        &source_id,
+        &ctx.recipient,
+        &1000u64,
+        &2000u64,
+        &500_i128,
+        &false, // too small
     );
 
     assert_eq!(result, Err(Ok(ContractError::InsufficientDeposit)));
@@ -628,9 +754,12 @@ fn clone_deposit_exactly_covers_duration() {
     ctx.env.ledger().set_timestamp(1000);
     // rate=1, duration=1000 → exactly 1000 tokens needed.
     let new_id = ctx.client().clone_stream(
-        &source_id, &ctx.recipient,
-        &1000u64, &2000u64,
-        &1000_i128, &false,
+        &source_id,
+        &ctx.recipient,
+        &1000u64,
+        &2000u64,
+        &1000_i128,
+        &false,
     );
 
     assert_eq!(ctx.client().get_stream_state(&new_id).deposit_amount, 1000);
@@ -647,9 +776,12 @@ fn clone_deposit_above_required_accepted() {
 
     ctx.env.ledger().set_timestamp(1000);
     let new_id = ctx.client().clone_stream(
-        &source_id, &ctx.recipient,
-        &1000u64, &2000u64,
-        &2000_i128, &false, // excess deposit
+        &source_id,
+        &ctx.recipient,
+        &1000u64,
+        &2000u64,
+        &2000_i128,
+        &false, // excess deposit
     );
 
     assert_eq!(ctx.client().get_stream_state(&new_id).deposit_amount, 2000);
@@ -667,9 +799,12 @@ fn clone_sender_equals_new_recipient_rejected() {
     ctx.env.ledger().set_timestamp(1000);
     // new_recipient == sender → invalid.
     let result = ctx.client().try_clone_stream(
-        &source_id, &ctx.sender, // same as source.sender
-        &1000u64, &2000u64,
-        &1000_i128, &false,
+        &source_id,
+        &ctx.sender, // same as source.sender
+        &1000u64,
+        &2000u64,
+        &1000_i128,
+        &false,
     );
 
     assert_eq!(result, Err(Ok(ContractError::InvalidParams)));
@@ -688,9 +823,12 @@ fn clone_blocked_when_globally_paused() {
 
     ctx.env.ledger().set_timestamp(1000);
     let result = ctx.client().try_clone_stream(
-        &source_id, &ctx.recipient,
-        &1000u64, &2000u64,
-        &1000_i128, &false,
+        &source_id,
+        &ctx.recipient,
+        &1000u64,
+        &2000u64,
+        &1000_i128,
+        &false,
     );
 
     assert_eq!(result, Err(Ok(ContractError::ContractPaused)));
@@ -709,9 +847,12 @@ fn clone_blocked_when_creation_paused() {
 
     ctx.env.ledger().set_timestamp(1000);
     let result = ctx.client().try_clone_stream(
-        &source_id, &ctx.recipient,
-        &1000u64, &2000u64,
-        &1000_i128, &false,
+        &source_id,
+        &ctx.recipient,
+        &1000u64,
+        &2000u64,
+        &1000_i128,
+        &false,
     );
 
     assert_eq!(result, Err(Ok(ContractError::ContractPaused)));
@@ -734,9 +875,12 @@ fn clone_emits_created_and_cloned_events() {
 
     ctx.env.ledger().set_timestamp(1000);
     let new_id = ctx.client().clone_stream(
-        &source_id, &ctx.recipient,
-        &1000u64, &2000u64,
-        &1000_i128, &false,
+        &source_id,
+        &ctx.recipient,
+        &1000u64,
+        &2000u64,
+        &1000_i128,
+        &false,
     );
 
     let events = ctx.env.events().all();
@@ -745,7 +889,9 @@ fn clone_emits_created_and_cloned_events() {
 
     for i in events_before..events.len() {
         let event = events.get(i).unwrap();
-        if event.0 != ctx.contract_id { continue; }
+        if event.0 != ctx.contract_id {
+            continue;
+        }
         let topic0 = Symbol::from_val(&ctx.env, &event.1.get(0).unwrap());
         if topic0 == Symbol::new(&ctx.env, "created") {
             let payload = StreamCreated::try_from_val(&ctx.env, &event.2).unwrap();
@@ -787,16 +933,21 @@ fn clone_event_carries_correct_source_stream_id() {
 
     ctx.env.ledger().set_timestamp(1000);
     let new_id = ctx.client().clone_stream(
-        &source_id, &ctx.recipient,
-        &1000u64, &2000u64,
-        &1000_i128, &false,
+        &source_id,
+        &ctx.recipient,
+        &1000u64,
+        &2000u64,
+        &1000_i128,
+        &false,
     );
 
     let events = ctx.env.events().all();
     let mut found = false;
     for i in events_before..events.len() {
         let event = events.get(i).unwrap();
-        if event.0 != ctx.contract_id { continue; }
+        if event.0 != ctx.contract_id {
+            continue;
+        }
         let topic0 = Symbol::from_val(&ctx.env, &event.1.get(0).unwrap());
         if topic0 == Symbol::new(&ctx.env, "cloned") {
             let payload = StreamCloned::try_from_val(&ctx.env, &event.2).unwrap();
@@ -805,7 +956,10 @@ fn clone_event_carries_correct_source_stream_id() {
             found = true;
         }
     }
-    assert!(found, "\"cloned\" event must be emitted with correct source_stream_id");
+    assert!(
+        found,
+        "\"cloned\" event must be emitted with correct source_stream_id"
+    );
 }
 
 /// No events are emitted when clone_stream fails (e.g. insufficient deposit).
@@ -821,13 +975,17 @@ fn clone_no_events_on_failure() {
 
     ctx.env.ledger().set_timestamp(1000);
     let _ = ctx.client().try_clone_stream(
-        &source_id, &ctx.recipient,
-        &1000u64, &2000u64,
-        &1_i128, &false, // insufficient deposit
+        &source_id,
+        &ctx.recipient,
+        &1000u64,
+        &2000u64,
+        &1_i128,
+        &false, // insufficient deposit
     );
 
     assert_eq!(
-        ctx.env.events().all().len(), events_before,
+        ctx.env.events().all().len(),
+        events_before,
         "no events must be emitted on failed clone"
     );
 }
@@ -850,9 +1008,12 @@ fn clone_sender_balance_decreases_by_deposit() {
 
     ctx.env.ledger().set_timestamp(1000);
     ctx.client().clone_stream(
-        &source_id, &ctx.recipient,
-        &1000u64, &2000u64,
-        &1000_i128, &false,
+        &source_id,
+        &ctx.recipient,
+        &1000u64,
+        &2000u64,
+        &1000_i128,
+        &false,
     );
 
     assert_eq!(ctx.token.balance(&ctx.sender), sender_before - 1000);
@@ -872,9 +1033,12 @@ fn clone_recipient_balance_unchanged_immediately() {
 
     ctx.env.ledger().set_timestamp(1000);
     ctx.client().clone_stream(
-        &source_id, &ctx.recipient,
-        &1000u64, &2000u64,
-        &1000_i128, &false,
+        &source_id,
+        &ctx.recipient,
+        &1000u64,
+        &2000u64,
+        &1000_i128,
+        &false,
     );
 
     assert_eq!(ctx.token.balance(&ctx.recipient), recipient_before);
@@ -891,9 +1055,12 @@ fn clone_recipient_can_withdraw_from_new_stream() {
 
     ctx.env.ledger().set_timestamp(1000);
     let new_id = ctx.client().clone_stream(
-        &source_id, &ctx.recipient,
-        &1000u64, &2000u64,
-        &1000_i128, &false,
+        &source_id,
+        &ctx.recipient,
+        &1000u64,
+        &2000u64,
+        &1000_i128,
+        &false,
     );
 
     // Advance to t=1500 (500s into new stream).
@@ -916,15 +1083,24 @@ fn clone_does_not_mutate_source_stream() {
 
     ctx.env.ledger().set_timestamp(1000);
     ctx.client().clone_stream(
-        &source_id, &ctx.recipient,
-        &1000u64, &2000u64,
-        &1000_i128, &false,
+        &source_id,
+        &ctx.recipient,
+        &1000u64,
+        &2000u64,
+        &1000_i128,
+        &false,
     );
 
     let source_state_after = ctx.client().get_stream_state(&source_id);
     assert_eq!(source_state_after.status, source_state_before.status);
-    assert_eq!(source_state_after.withdrawn_amount, source_state_before.withdrawn_amount);
-    assert_eq!(source_state_after.deposit_amount, source_state_before.deposit_amount);
+    assert_eq!(
+        source_state_after.withdrawn_amount,
+        source_state_before.withdrawn_amount
+    );
+    assert_eq!(
+        source_state_after.deposit_amount,
+        source_state_before.deposit_amount
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -946,9 +1122,12 @@ fn clone_recurring_payroll_three_months() {
     // Month 2: clone from month 1.
     ctx.env.ledger().set_timestamp(1000);
     let m2_id = ctx.client().clone_stream(
-        &m1_id, &ctx.recipient,
-        &1000u64, &2000u64,
-        &1000_i128, &false,
+        &m1_id,
+        &ctx.recipient,
+        &1000u64,
+        &2000u64,
+        &1000_i128,
+        &false,
     );
 
     ctx.env.ledger().set_timestamp(2000);
@@ -957,9 +1136,12 @@ fn clone_recurring_payroll_three_months() {
     // Month 3: clone from month 2.
     ctx.env.ledger().set_timestamp(2000);
     let m3_id = ctx.client().clone_stream(
-        &m2_id, &ctx.recipient,
-        &2000u64, &3000u64,
-        &1000_i128, &false,
+        &m2_id,
+        &ctx.recipient,
+        &2000u64,
+        &3000u64,
+        &1000_i128,
+        &false,
     );
 
     // All three IDs are distinct and sequential.
@@ -989,9 +1171,12 @@ fn clone_cliff_offset_preserved_across_generations() {
     // Gen 2: start=1000, expected cliff=1500.
     ctx.env.ledger().set_timestamp(1000);
     let gen2_id = ctx.client().clone_stream(
-        &source_id, &ctx.recipient,
-        &1000u64, &2000u64,
-        &1000_i128, &false,
+        &source_id,
+        &ctx.recipient,
+        &1000u64,
+        &2000u64,
+        &1000_i128,
+        &false,
     );
     let gen2 = ctx.client().get_stream_state(&gen2_id);
     assert_eq!(gen2.cliff_time, 1500);
@@ -1002,9 +1187,12 @@ fn clone_cliff_offset_preserved_across_generations() {
     // Gen 3: start=2000, expected cliff=2500.
     ctx.env.ledger().set_timestamp(2000);
     let gen3_id = ctx.client().clone_stream(
-        &gen2_id, &ctx.recipient,
-        &2000u64, &3000u64,
-        &1000_i128, &false,
+        &gen2_id,
+        &ctx.recipient,
+        &2000u64,
+        &3000u64,
+        &1000_i128,
+        &false,
     );
     let gen3 = ctx.client().get_stream_state(&gen3_id);
     assert_eq!(gen3.cliff_time, 2500);
@@ -1022,17 +1210,23 @@ fn clone_increments_stream_count() {
 
     ctx.env.ledger().set_timestamp(1000);
     ctx.client().clone_stream(
-        &source_id, &ctx.recipient,
-        &1000u64, &2000u64,
-        &1000_i128, &false,
+        &source_id,
+        &ctx.recipient,
+        &1000u64,
+        &2000u64,
+        &1000_i128,
+        &false,
     );
     assert_eq!(ctx.client().get_stream_count(), 2);
 
     ctx.env.ledger().set_timestamp(2000);
     ctx.client().clone_stream(
-        &source_id, &ctx.recipient,
-        &2000u64, &3000u64,
-        &1000_i128, &false,
+        &source_id,
+        &ctx.recipient,
+        &2000u64,
+        &3000u64,
+        &1000_i128,
+        &false,
     );
     assert_eq!(ctx.client().get_stream_count(), 3);
 }
@@ -1051,9 +1245,12 @@ fn clone_new_stream_appears_in_recipient_index() {
 
     ctx.env.ledger().set_timestamp(1000);
     let new_id = ctx.client().clone_stream(
-        &source_id, &ctx.recipient,
-        &1000u64, &2000u64,
-        &1000_i128, &false,
+        &source_id,
+        &ctx.recipient,
+        &1000u64,
+        &2000u64,
+        &1000_i128,
+        &false,
     );
 
     let index_after = ctx.client().get_recipient_streams(&ctx.recipient);
@@ -1072,10 +1269,15 @@ fn clone_cliff_equals_end_in_source() {
     ctx.env.ledger().set_timestamp(0);
     // cliff == end_time (degenerate but valid).
     let source_id = ctx.client().create_stream(
-        &ctx.sender, &ctx.recipient,
-        &1000_i128, &1_i128,
-        &0u64, &1000u64, &1000u64, // cliff == end
-        &0, &None,
+        &ctx.sender,
+        &ctx.recipient,
+        &1000_i128,
+        &1_i128,
+        &0u64,
+        &1000u64,
+        &1000u64, // cliff == end
+        &0,
+        &None,
     );
 
     ctx.env.ledger().set_timestamp(1000);
@@ -1084,9 +1286,12 @@ fn clone_cliff_equals_end_in_source() {
     // cliff_offset = 1000 - 0 = 1000. new_cliff = 1000 + 1000 = 2000 == new_end.
     ctx.env.ledger().set_timestamp(1000);
     let new_id = ctx.client().clone_stream(
-        &source_id, &ctx.recipient,
-        &1000u64, &2000u64,
-        &1000_i128, &false,
+        &source_id,
+        &ctx.recipient,
+        &1000u64,
+        &2000u64,
+        &1000_i128,
+        &false,
     );
 
     let new_state = ctx.client().get_stream_state(&new_id);
@@ -1106,9 +1311,12 @@ fn clone_with_larger_deposit_for_raise() {
     // "Raise": same rate but larger deposit (excess stays in contract).
     ctx.env.ledger().set_timestamp(1000);
     let new_id = ctx.client().clone_stream(
-        &source_id, &ctx.recipient,
-        &1000u64, &2000u64,
-        &5000_i128, &false, // 5x deposit
+        &source_id,
+        &ctx.recipient,
+        &1000u64,
+        &2000u64,
+        &5000_i128,
+        &false, // 5x deposit
     );
 
     let new_state = ctx.client().get_stream_state(&new_id);
@@ -1127,9 +1335,12 @@ fn clone_no_memo_produces_no_memo() {
 
     ctx.env.ledger().set_timestamp(1000);
     let new_id = ctx.client().clone_stream(
-        &source_id, &ctx.recipient,
-        &1000u64, &2000u64,
-        &1000_i128, &false,
+        &source_id,
+        &ctx.recipient,
+        &1000u64,
+        &2000u64,
+        &1000_i128,
+        &false,
     );
 
     assert!(ctx.client().get_stream_state(&new_id).memo.is_none());
@@ -1147,9 +1358,12 @@ fn clone_new_stream_has_zero_withdrawn_amount() {
 
     ctx.env.ledger().set_timestamp(1000);
     let new_id = ctx.client().clone_stream(
-        &source_id, &ctx.recipient,
-        &1000u64, &2000u64,
-        &1000_i128, &false,
+        &source_id,
+        &ctx.recipient,
+        &1000u64,
+        &2000u64,
+        &1000_i128,
+        &false,
     );
 
     assert_eq!(ctx.client().get_stream_state(&new_id).withdrawn_amount, 0);
@@ -1169,10 +1383,15 @@ fn clone_high_rate_large_deposit_no_overflow() {
     sac.mint(&ctx.sender, &(deposit * 2));
 
     let source_id = ctx.client().create_stream(
-        &ctx.sender, &ctx.recipient,
-        &deposit, &rate,
-        &0u64, &0u64, &duration,
-        &0, &None,
+        &ctx.sender,
+        &ctx.recipient,
+        &deposit,
+        &rate,
+        &0u64,
+        &0u64,
+        &duration,
+        &0,
+        &None,
     );
 
     ctx.env.ledger().set_timestamp(duration);
@@ -1180,9 +1399,12 @@ fn clone_high_rate_large_deposit_no_overflow() {
 
     ctx.env.ledger().set_timestamp(duration);
     let new_id = ctx.client().clone_stream(
-        &source_id, &ctx.recipient,
-        &duration, &(duration * 2),
-        &deposit, &false,
+        &source_id,
+        &ctx.recipient,
+        &duration,
+        &(duration * 2),
+        &deposit,
+        &false,
     );
 
     let new_state = ctx.client().get_stream_state(&new_id);

--- a/contracts/stream/tests/create_stream_relative.rs
+++ b/contracts/stream/tests/create_stream_relative.rs
@@ -1,4 +1,4 @@
-﻿extern crate std;
+extern crate std;
 
 use fluxora_stream::{
     ContractError, CreateStreamRelativeParams, FluxoraStream, FluxoraStreamClient, StreamStatus,
@@ -76,7 +76,7 @@ fn create_stream_relative_zero_delays_immediate_start() {
     let stream_id = ctx.client().create_stream_relative(
         &ctx.sender,
         &CreateStreamRelativeParams {
-        kind: fluxora_stream::StreamKind::Linear,
+            kind: fluxora_stream::StreamKind::Linear,
             withdraw_dust_threshold: None,
             recipient: ctx.recipient.clone(),
             deposit_amount: 1000,
@@ -108,7 +108,7 @@ fn create_stream_relative_positive_delays_future_start() {
     let stream_id = ctx.client().create_stream_relative(
         &ctx.sender,
         &CreateStreamRelativeParams {
-        kind: fluxora_stream::StreamKind::Linear,
+            kind: fluxora_stream::StreamKind::Linear,
             withdraw_dust_threshold: None,
             recipient: ctx.recipient.clone(),
             deposit_amount: 4000,
@@ -137,7 +137,7 @@ fn create_stream_relative_zero_duration_rejected() {
     let result = ctx.client().try_create_stream_relative(
         &ctx.sender,
         &CreateStreamRelativeParams {
-        kind: fluxora_stream::StreamKind::Linear,
+            kind: fluxora_stream::StreamKind::Linear,
             withdraw_dust_threshold: None,
             recipient: ctx.recipient.clone(),
             deposit_amount: 1000,
@@ -163,7 +163,7 @@ fn create_stream_relative_cliff_less_than_start_rejected() {
     let result = ctx.client().try_create_stream_relative(
         &ctx.sender,
         &CreateStreamRelativeParams {
-        kind: fluxora_stream::StreamKind::Linear,
+            kind: fluxora_stream::StreamKind::Linear,
             withdraw_dust_threshold: None,
             recipient: ctx.recipient.clone(),
             deposit_amount: 1000,
@@ -190,7 +190,7 @@ fn create_stream_relative_cliff_greater_than_end_rejected() {
     let result = ctx.client().try_create_stream_relative(
         &ctx.sender,
         &CreateStreamRelativeParams {
-        kind: fluxora_stream::StreamKind::Linear,
+            kind: fluxora_stream::StreamKind::Linear,
             withdraw_dust_threshold: None,
             recipient: ctx.recipient.clone(),
             deposit_amount: 1000,
@@ -216,7 +216,7 @@ fn create_stream_relative_start_delay_overflow_rejected() {
     let result = ctx.client().try_create_stream_relative(
         &ctx.sender,
         &CreateStreamRelativeParams {
-        kind: fluxora_stream::StreamKind::Linear,
+            kind: fluxora_stream::StreamKind::Linear,
             withdraw_dust_threshold: None,
             recipient: ctx.recipient.clone(),
             deposit_amount: 1000,
@@ -242,7 +242,7 @@ fn create_stream_relative_duration_overflow_rejected() {
     let result = ctx.client().try_create_stream_relative(
         &ctx.sender,
         &CreateStreamRelativeParams {
-        kind: fluxora_stream::StreamKind::Linear,
+            kind: fluxora_stream::StreamKind::Linear,
             withdraw_dust_threshold: None,
             recipient: ctx.recipient.clone(),
             deposit_amount: 1000,
@@ -269,7 +269,7 @@ fn create_stream_relative_never_start_time_in_past() {
     let stream_id = ctx.client().create_stream_relative(
         &ctx.sender,
         &CreateStreamRelativeParams {
-        kind: fluxora_stream::StreamKind::Linear,
+            kind: fluxora_stream::StreamKind::Linear,
             withdraw_dust_threshold: None,
             recipient: ctx.recipient.clone(),
             deposit_amount: 1000,
@@ -301,7 +301,7 @@ fn create_stream_relative_insufficient_deposit_rejected() {
     let result = ctx.client().try_create_stream_relative(
         &ctx.sender,
         &CreateStreamRelativeParams {
-        kind: fluxora_stream::StreamKind::Linear,
+            kind: fluxora_stream::StreamKind::Linear,
             withdraw_dust_threshold: None,
             recipient: ctx.recipient.clone(),
             deposit_amount: 500,
@@ -326,7 +326,7 @@ fn create_stream_relative_rejects_self_stream() {
     let result = ctx.client().try_create_stream_relative(
         &ctx.sender,
         &CreateStreamRelativeParams {
-        kind: fluxora_stream::StreamKind::Linear,
+            kind: fluxora_stream::StreamKind::Linear,
             withdraw_dust_threshold: None,
             recipient: ctx.sender.clone(),
             deposit_amount: 1000,
@@ -355,7 +355,7 @@ fn create_streams_relative_single_entry() {
     let params = vec![
         &ctx.env,
         CreateStreamRelativeParams {
-        kind: fluxora_stream::StreamKind::Linear,
+            kind: fluxora_stream::StreamKind::Linear,
             withdraw_dust_threshold: None,
             recipient: ctx.recipient.clone(),
             deposit_amount: 1000,
@@ -388,7 +388,7 @@ fn create_streams_relative_multiple_entries_sequential_ids() {
     let params = vec![
         &ctx.env,
         CreateStreamRelativeParams {
-        kind: fluxora_stream::StreamKind::Linear,
+            kind: fluxora_stream::StreamKind::Linear,
             withdraw_dust_threshold: None,
             recipient: ctx.recipient.clone(),
             deposit_amount: 1000,
@@ -400,7 +400,7 @@ fn create_streams_relative_multiple_entries_sequential_ids() {
             metadata: None,
         },
         CreateStreamRelativeParams {
-        kind: fluxora_stream::StreamKind::Linear,
+            kind: fluxora_stream::StreamKind::Linear,
             withdraw_dust_threshold: None,
             recipient: recipient2.clone(),
             deposit_amount: 4000, // 2 * 2000
@@ -459,7 +459,7 @@ fn create_streams_relative_invalid_entry_fails_atomically() {
     let params = vec![
         &ctx.env,
         CreateStreamRelativeParams {
-        kind: fluxora_stream::StreamKind::Linear,
+            kind: fluxora_stream::StreamKind::Linear,
             withdraw_dust_threshold: None,
             recipient: ctx.recipient.clone(),
             deposit_amount: 1000,
@@ -471,7 +471,7 @@ fn create_streams_relative_invalid_entry_fails_atomically() {
             metadata: None,
         },
         CreateStreamRelativeParams {
-        kind: fluxora_stream::StreamKind::Linear,
+            kind: fluxora_stream::StreamKind::Linear,
             withdraw_dust_threshold: None,
             recipient: recipient2.clone(),
             deposit_amount: 500,
@@ -507,7 +507,7 @@ fn create_streams_relative_diverse_schedules() {
     let params = vec![
         &ctx.env,
         CreateStreamRelativeParams {
-        kind: fluxora_stream::StreamKind::Linear,
+            kind: fluxora_stream::StreamKind::Linear,
             withdraw_dust_threshold: None,
             recipient: r1,
             deposit_amount: 100,
@@ -519,7 +519,7 @@ fn create_streams_relative_diverse_schedules() {
             metadata: None,
         },
         CreateStreamRelativeParams {
-        kind: fluxora_stream::StreamKind::Linear,
+            kind: fluxora_stream::StreamKind::Linear,
             withdraw_dust_threshold: None,
             recipient: r2,
             deposit_amount: 400, // 2 * 200
@@ -531,7 +531,7 @@ fn create_streams_relative_diverse_schedules() {
             metadata: None,
         },
         CreateStreamRelativeParams {
-        kind: fluxora_stream::StreamKind::Linear,
+            kind: fluxora_stream::StreamKind::Linear,
             withdraw_dust_threshold: None,
             recipient: r3,
             deposit_amount: 900, // 3 * 300
@@ -579,7 +579,7 @@ fn create_streams_relative_independent_cliff_times() {
     let params = vec![
         &ctx.env,
         CreateStreamRelativeParams {
-        kind: fluxora_stream::StreamKind::Linear,
+            kind: fluxora_stream::StreamKind::Linear,
             withdraw_dust_threshold: None,
             recipient: r1,
             deposit_amount: 1000,
@@ -591,7 +591,7 @@ fn create_streams_relative_independent_cliff_times() {
             metadata: None,
         },
         CreateStreamRelativeParams {
-        kind: fluxora_stream::StreamKind::Linear,
+            kind: fluxora_stream::StreamKind::Linear,
             withdraw_dust_threshold: None,
             recipient: r2,
             deposit_amount: 2000,
@@ -626,7 +626,7 @@ fn create_streams_relative_batch_overflow_detection() {
     let params = vec![
         &ctx.env,
         CreateStreamRelativeParams {
-        kind: fluxora_stream::StreamKind::Linear,
+            kind: fluxora_stream::StreamKind::Linear,
             withdraw_dust_threshold: None,
             recipient: r1,
             deposit_amount: 1000,
@@ -657,7 +657,7 @@ fn create_streams_relative_batch_validates_amounts() {
     let params = vec![
         &ctx.env,
         CreateStreamRelativeParams {
-        kind: fluxora_stream::StreamKind::Linear,
+            kind: fluxora_stream::StreamKind::Linear,
             withdraw_dust_threshold: None,
             recipient: r1,
             deposit_amount: 1000,
@@ -669,7 +669,7 @@ fn create_streams_relative_batch_validates_amounts() {
             metadata: None,
         },
         CreateStreamRelativeParams {
-        kind: fluxora_stream::StreamKind::Linear,
+            kind: fluxora_stream::StreamKind::Linear,
             withdraw_dust_threshold: None,
             recipient: r2,
             deposit_amount: -100, // Invalid: negative amount

--- a/contracts/stream/tests/dust_threshold.rs
+++ b/contracts/stream/tests/dust_threshold.rs
@@ -72,7 +72,7 @@ fn test_withdraw_dust_threshold_enforced() {
         &100_i128, // threshold = 100
         &None,
         &fluxora_stream::StreamKind::Linear,
-        );
+    );
 
     // At t=50, withdrawable is 50. Threshold is 100.
     ctx.env.ledger().set_timestamp(50);
@@ -104,7 +104,7 @@ fn test_withdraw_dust_threshold_ignored_on_final_drain() {
         &500_i128, // threshold = 500
         &None,
         &fluxora_stream::StreamKind::Linear,
-        );
+    );
 
     // Withdraw 950 first (above threshold)
     ctx.env.ledger().set_timestamp(950);
@@ -142,7 +142,7 @@ fn test_withdraw_dust_threshold_ignored_in_terminal_state() {
         &500_i128, // threshold = 500
         &None,
         &fluxora_stream::StreamKind::Linear,
-        );
+    );
 
     // Cancel stream at t=100.
     ctx.env.ledger().set_timestamp(100);
@@ -175,7 +175,7 @@ fn test_withdraw_dust_threshold_ignored_past_end_time() {
         &500_i128,
         &None,
         &fluxora_stream::StreamKind::Linear,
-        );
+    );
 
     // Withdraw 900 at t=900 (above threshold)
     ctx.env.ledger().set_timestamp(900);
@@ -207,7 +207,7 @@ fn test_create_stream_rejects_excessive_dust_threshold() {
         &1100_i128, // threshold > deposit
         &None,
         &fluxora_stream::StreamKind::Linear,
-        );
+    );
 
     match res {
         Err(Ok(fluxora_stream::ContractError::InvalidDustThreshold)) => {}
@@ -236,7 +236,7 @@ fn test_zero_threshold_allows_all_withdrawals() {
         &0_i128, // no filter
         &None,
         &fluxora_stream::StreamKind::Linear,
-        );
+    );
 
     // At t=1, only 1 raw unit has accrued — still allowed with threshold=0.
     ctx.env.ledger().set_timestamp(1);
@@ -264,7 +264,7 @@ fn test_threshold_equal_to_deposit_blocks_until_terminal() {
         &deposit, // threshold == deposit
         &None,
         &fluxora_stream::StreamKind::Linear,
-        );
+    );
 
     // Mid-stream: withdrawable < deposit → blocked.
     ctx.env.ledger().set_timestamp(500);
@@ -302,7 +302,7 @@ fn test_batch_withdraw_respects_dust_threshold() {
         &200_i128,
         &None,
         &fluxora_stream::StreamKind::Linear,
-        );
+    );
 
     // Stream B: threshold = 0 (always allowed)
     let stream_b = ctx.client().create_stream(
@@ -316,7 +316,7 @@ fn test_batch_withdraw_respects_dust_threshold() {
         &0_i128,
         &None,
         &fluxora_stream::StreamKind::Linear,
-        );
+    );
 
     ctx.env.ledger().set_timestamp(100);
     let results = ctx
@@ -349,7 +349,7 @@ fn test_threshold_exactly_at_withdrawable_is_allowed() {
         &100_i128,
         &None,
         &fluxora_stream::StreamKind::Linear,
-        );
+    );
 
     ctx.env.ledger().set_timestamp(100);
     let withdrawn = ctx.client().withdraw(&stream_id);
@@ -378,7 +378,7 @@ fn test_short_stream_threshold_blocks_until_end_time() {
         &600_i128, // requires 6 s of accrual before first withdrawal
         &None,
         &fluxora_stream::StreamKind::Linear,
-        );
+    );
 
     // At t=5: 500 accrued < 600 threshold → blocked
     ctx.env.ledger().set_timestamp(5);
@@ -454,7 +454,7 @@ fn test_withdraw_dust_threshold_enforced() {
         &100_i128, // threshold = 100
         &None,
         &fluxora_stream::StreamKind::Linear,
-        );
+    );
 
     // At t=50, withdrawable is 50. Threshold is 100.
     ctx.env.ledger().set_timestamp(50);
@@ -486,7 +486,7 @@ fn test_withdraw_dust_threshold_ignored_on_final_drain() {
         &500_i128, // threshold = 500
         &None,
         &fluxora_stream::StreamKind::Linear,
-        );
+    );
 
     // Withdraw 950 first (above threshold)
     ctx.env.ledger().set_timestamp(950);
@@ -524,7 +524,7 @@ fn test_withdraw_dust_threshold_ignored_in_terminal_state() {
         &500_i128, // threshold = 500
         &None,
         &fluxora_stream::StreamKind::Linear,
-        );
+    );
 
     // Cancel stream at t=100.
     ctx.env.ledger().set_timestamp(100);
@@ -557,7 +557,7 @@ fn test_withdraw_dust_threshold_ignored_past_end_time() {
         &500_i128,
         &None,
         &fluxora_stream::StreamKind::Linear,
-        );
+    );
 
     // Withdraw 900 at t=900 (above threshold)
     ctx.env.ledger().set_timestamp(900);
@@ -589,7 +589,7 @@ fn test_create_stream_rejects_excessive_dust_threshold() {
         &1100_i128, // threshold > deposit
         &None,
         &fluxora_stream::StreamKind::Linear,
-        );
+    );
 
     match res {
         Err(Ok(fluxora_stream::ContractError::InvalidDustThreshold)) => {}

--- a/contracts/stream/tests/event_snapshots_suite.rs
+++ b/contracts/stream/tests/event_snapshots_suite.rs
@@ -1,4 +1,4 @@
-﻿/// Event Snapshot Tests
+/// Event Snapshot Tests
 ///
 /// This module contains comprehensive deterministic snapshot tests that assert exact event
 /// topics and payload shapes for all emitted events. Each test captures event data at
@@ -170,7 +170,7 @@ fn event_snapshot_stream_created_has_correct_topics_and_payload() {
         &0,
         &None,
         &fluxora_stream::StreamKind::Linear,
-        );
+    );
 
     let events = ctx.env.events().all();
     assert!(
@@ -233,8 +233,18 @@ fn event_snapshot_stream_created_with_memo() {
     let memo = Some(soroban_sdk::Bytes::from_slice(&ctx.env, b"payroll-2024-q1"));
     let events_before = ctx.env.events().all().len();
 
-    let _stream_id = ctx.client().create_stream(&ctx.sender, &ctx.recipient, &5000_i128, &2_i128, &0u64, &100u64, &2500u64, &0, &memo, &fluxora_stream::StreamKind::Linear);
-
+    let _stream_id = ctx.client().create_stream(
+        &ctx.sender,
+        &ctx.recipient,
+        &5000_i128,
+        &2_i128,
+        &0u64,
+        &100u64,
+        &2500u64,
+        &0,
+        &memo,
+        &fluxora_stream::StreamKind::Linear,
+    );
 
     let events = ctx.env.events().all();
     let mut found = false;
@@ -287,7 +297,7 @@ fn event_snapshot_withdrawal_has_correct_topics_and_payload() {
         &0,
         &None,
         &fluxora_stream::StreamKind::Linear,
-        );
+    );
 
     ctx.env.ledger().set_timestamp(500);
     let events_before = ctx.env.events().all().len();
@@ -347,7 +357,7 @@ fn event_snapshot_no_withdrawal_event_when_amount_zero() {
         &0,
         &None,
         &fluxora_stream::StreamKind::Linear,
-        );
+    );
 
     // Try to withdraw before cliff - amount should be 0
     ctx.env.ledger().set_timestamp(100);
@@ -394,7 +404,7 @@ fn event_snapshot_withdrawal_to_has_correct_topics_and_payload() {
         &0,
         &None,
         &fluxora_stream::StreamKind::Linear,
-        );
+    );
 
     let destination = Address::generate(&ctx.env);
     ctx.env.ledger().set_timestamp(400);
@@ -459,7 +469,7 @@ fn event_snapshot_stream_paused_has_correct_topics_and_payload() {
         &0,
         &None,
         &fluxora_stream::StreamKind::Linear,
-        );
+    );
 
     let events_before = ctx.env.events().all().len();
     ctx.client()
@@ -515,7 +525,7 @@ fn event_snapshot_stream_paused_as_admin_has_administrative_reason() {
         &0,
         &None,
         &fluxora_stream::StreamKind::Linear,
-        );
+    );
 
     let events_before = ctx.env.events().all().len();
     ctx.client()
@@ -565,7 +575,7 @@ fn event_snapshot_stream_resumed_has_correct_topics() {
         &0,
         &None,
         &fluxora_stream::StreamKind::Linear,
-        );
+    );
 
     ctx.client()
         .pause_stream(&stream_id, &PauseReason::Operational);
@@ -611,7 +621,7 @@ fn event_snapshot_stream_cancelled_has_correct_topics() {
         &0,
         &None,
         &fluxora_stream::StreamKind::Linear,
-        );
+    );
 
     ctx.env.ledger().set_timestamp(500);
     let events_before = ctx.env.events().all().len();
@@ -659,7 +669,7 @@ fn event_snapshot_stream_completed_emitted_after_withdrew() {
         &0,
         &None,
         &fluxora_stream::StreamKind::Linear,
-        );
+    );
 
     // Partial withdrawal first
     ctx.env.ledger().set_timestamp(300);
@@ -713,7 +723,7 @@ fn event_snapshot_stream_closed_has_correct_topics() {
         &0,
         &None,
         &fluxora_stream::StreamKind::Linear,
-        );
+    );
 
     // Complete the stream
     ctx.env.ledger().set_timestamp(1000);
@@ -765,7 +775,7 @@ fn event_snapshot_rate_updated_has_correct_topics_and_payload() {
         &0,
         &None,
         &fluxora_stream::StreamKind::Linear,
-        );
+    );
 
     ctx.env.ledger().set_timestamp(100);
     let events_before = ctx.env.events().all().len();
@@ -824,7 +834,7 @@ fn event_snapshot_stream_end_shortened_has_correct_topics_and_payload() {
         &0,
         &None,
         &fluxora_stream::StreamKind::Linear,
-        );
+    );
 
     let events_before = ctx.env.events().all().len();
     ctx.client().shorten_stream_end_time(&stream_id, &500u64);
@@ -882,7 +892,7 @@ fn event_snapshot_stream_end_extended_has_correct_topics_and_payload() {
         &0,
         &None,
         &fluxora_stream::StreamKind::Linear,
-        );
+    );
 
     let events_before = ctx.env.events().all().len();
     ctx.client().extend_stream_end_time(&stream_id, &2000u64);
@@ -942,7 +952,7 @@ fn event_snapshot_stream_topped_up_has_correct_topics_and_payload() {
         &0,
         &None,
         &fluxora_stream::StreamKind::Linear,
-        );
+    );
 
     let events_before = ctx.env.events().all().len();
     ctx.client()
@@ -999,7 +1009,7 @@ fn event_snapshot_recipient_updated_has_correct_topics_and_payload() {
         &0,
         &None,
         &fluxora_stream::StreamKind::Linear,
-        );
+    );
 
     let new_recipient = Address::generate(&ctx.env);
     let events_before = ctx.env.events().all().len();
@@ -1186,7 +1196,7 @@ fn event_snapshot_no_events_on_failed_create_stream() {
         &0,
         &None,
         &fluxora_stream::StreamKind::Linear,
-        );
+    );
 
     assert!(
         result.is_err(),
@@ -1231,7 +1241,7 @@ fn event_snapshot_no_events_on_failed_operations() {
         &0,
         &None,
         &fluxora_stream::StreamKind::Linear,
-        );
+    );
 
     // Try to pause an already completed stream (should fail)
     ctx.env.ledger().set_timestamp(1000);
@@ -1324,7 +1334,7 @@ fn event_snapshot_health_changed_top_up_heals_underfunded_stream() {
         &0,
         &None,
         &fluxora_stream::StreamKind::Linear,
-        );
+    );
 
     // Advance to t=100.
     ctx.env.ledger().set_timestamp(100);
@@ -1366,7 +1376,7 @@ fn event_snapshot_health_changed_shorten_heals_underfunded_stream() {
         &0,
         &None,
         &fluxora_stream::StreamKind::Linear,
-        );
+    );
 
     // Advance to t=100.
     ctx.env.ledger().set_timestamp(100);
@@ -1408,7 +1418,7 @@ fn event_snapshot_health_changed_decrease_rate_heals_underfunded_stream() {
         &0,
         &None,
         &fluxora_stream::StreamKind::Linear,
-        );
+    );
 
     // Advance to t=100.
     ctx.env.ledger().set_timestamp(100);
@@ -1452,7 +1462,7 @@ fn event_snapshot_health_changed_cancel_heals_underfunded_stream() {
         &0,
         &None,
         &fluxora_stream::StreamKind::Linear,
-        );
+    );
 
     // Advance to t=100.
     ctx.env.ledger().set_timestamp(100);
@@ -1494,7 +1504,7 @@ fn event_snapshot_health_changed_not_emitted_when_no_transition() {
         &0,
         &None,
         &fluxora_stream::StreamKind::Linear,
-        );
+    );
 
     // Top up an already-funded stream. Health stays funded → no event.
     let events_before = ctx.env.events().all().len();

--- a/contracts/stream/tests/governance_integration.rs
+++ b/contracts/stream/tests/governance_integration.rs
@@ -72,10 +72,9 @@ fn test_init_stores_signers() {
 #[test]
 fn test_init_twice_errors() {
     let ctx = GovCtx::setup();
-    let result = ctx.client.try_init(
-        &ctx.admin,
-        &vec![&ctx.env, ctx.signer_a.clone()],
-    );
+    let result = ctx
+        .client
+        .try_init(&ctx.admin, &vec![&ctx.env, ctx.signer_a.clone()]);
     assert_eq!(result, Err(Ok(GovernanceError::AlreadyInitialized)));
 }
 
@@ -95,8 +94,12 @@ fn test_propose_returns_incremental_ids() {
     let ctx = GovCtx::setup();
     let target = ctx.dummy_target();
 
-    let id0 = ctx.client.propose(&ctx.signer_a, &target, &ctx.calldata("call0"));
-    let id1 = ctx.client.propose(&ctx.signer_b, &target, &ctx.calldata("call1"));
+    let id0 = ctx
+        .client
+        .propose(&ctx.signer_a, &target, &ctx.calldata("call0"));
+    let id1 = ctx
+        .client
+        .propose(&ctx.signer_b, &target, &ctx.calldata("call1"));
 
     assert_eq!(id0, 0);
     assert_eq!(id1, 1);
@@ -134,7 +137,9 @@ fn test_propose_stores_proposal() {
 #[test]
 fn test_approve_increments_approval_count() {
     let ctx = GovCtx::setup();
-    let id = ctx.client.propose(&ctx.signer_a, &ctx.dummy_target(), &ctx.calldata("x"));
+    let id = ctx
+        .client
+        .propose(&ctx.signer_a, &ctx.dummy_target(), &ctx.calldata("x"));
 
     ctx.client.approve(&ctx.signer_a, &id);
     let p = ctx.client.get_proposal(&id);
@@ -148,7 +153,9 @@ fn test_approve_increments_approval_count() {
 #[test]
 fn test_approve_duplicate_errors() {
     let ctx = GovCtx::setup();
-    let id = ctx.client.propose(&ctx.signer_a, &ctx.dummy_target(), &ctx.calldata("x"));
+    let id = ctx
+        .client
+        .propose(&ctx.signer_a, &ctx.dummy_target(), &ctx.calldata("x"));
 
     ctx.client.approve(&ctx.signer_a, &id);
     let result = ctx.client.try_approve(&ctx.signer_a, &id);
@@ -158,7 +165,9 @@ fn test_approve_duplicate_errors() {
 #[test]
 fn test_approve_non_signer_errors() {
     let ctx = GovCtx::setup();
-    let id = ctx.client.propose(&ctx.signer_a, &ctx.dummy_target(), &ctx.calldata("x"));
+    let id = ctx
+        .client
+        .propose(&ctx.signer_a, &ctx.dummy_target(), &ctx.calldata("x"));
     let outsider = Address::generate(&ctx.env);
 
     let result = ctx.client.try_approve(&outsider, &id);
@@ -175,15 +184,15 @@ fn test_approve_nonexistent_proposal_errors() {
 #[test]
 fn test_approve_executed_proposal_errors() {
     let ctx = GovCtx::setup();
-    let id = ctx.client.propose(&ctx.signer_a, &ctx.dummy_target(), &ctx.calldata("x"));
+    let id = ctx
+        .client
+        .propose(&ctx.signer_a, &ctx.dummy_target(), &ctx.calldata("x"));
 
     ctx.client.approve(&ctx.signer_a, &id);
     ctx.client.approve(&ctx.signer_b, &id);
 
     // Advance past timelock
-    ctx.env
-        .ledger()
-        .set_timestamp(1_000_000 + TIMELOCK + 1);
+    ctx.env.ledger().set_timestamp(1_000_000 + TIMELOCK + 1);
 
     let executor = Address::generate(&ctx.env);
     ctx.client.execute(&executor, &id);
@@ -199,15 +208,15 @@ fn test_approve_executed_proposal_errors() {
 #[test]
 fn test_execute_after_quorum_and_timelock_succeeds() {
     let ctx = GovCtx::setup();
-    let id = ctx.client.propose(&ctx.signer_a, &ctx.dummy_target(), &ctx.calldata("x"));
+    let id = ctx
+        .client
+        .propose(&ctx.signer_a, &ctx.dummy_target(), &ctx.calldata("x"));
 
     ctx.client.approve(&ctx.signer_a, &id);
     ctx.client.approve(&ctx.signer_b, &id);
 
     // Advance past timelock
-    ctx.env
-        .ledger()
-        .set_timestamp(1_000_000 + TIMELOCK + 1);
+    ctx.env.ledger().set_timestamp(1_000_000 + TIMELOCK + 1);
 
     let executor = Address::generate(&ctx.env);
     ctx.client.execute(&executor, &id);
@@ -223,14 +232,14 @@ fn test_execute_after_quorum_and_timelock_succeeds() {
 #[test]
 fn test_execute_without_quorum_errors() {
     let ctx = GovCtx::setup();
-    let id = ctx.client.propose(&ctx.signer_a, &ctx.dummy_target(), &ctx.calldata("x"));
+    let id = ctx
+        .client
+        .propose(&ctx.signer_a, &ctx.dummy_target(), &ctx.calldata("x"));
 
     // Only 1 approval (quorum = 2)
     ctx.client.approve(&ctx.signer_a, &id);
 
-    ctx.env
-        .ledger()
-        .set_timestamp(1_000_000 + TIMELOCK + 1);
+    ctx.env.ledger().set_timestamp(1_000_000 + TIMELOCK + 1);
 
     let executor = Address::generate(&ctx.env);
     let result = ctx.client.try_execute(&executor, &id);
@@ -240,15 +249,15 @@ fn test_execute_without_quorum_errors() {
 #[test]
 fn test_execute_before_timelock_errors() {
     let ctx = GovCtx::setup();
-    let id = ctx.client.propose(&ctx.signer_a, &ctx.dummy_target(), &ctx.calldata("x"));
+    let id = ctx
+        .client
+        .propose(&ctx.signer_a, &ctx.dummy_target(), &ctx.calldata("x"));
 
     ctx.client.approve(&ctx.signer_a, &id);
     ctx.client.approve(&ctx.signer_b, &id);
 
     // Advance less than the full timelock
-    ctx.env
-        .ledger()
-        .set_timestamp(1_000_000 + TIMELOCK - 1);
+    ctx.env.ledger().set_timestamp(1_000_000 + TIMELOCK - 1);
 
     let executor = Address::generate(&ctx.env);
     let result = ctx.client.try_execute(&executor, &id);
@@ -258,14 +267,14 @@ fn test_execute_before_timelock_errors() {
 #[test]
 fn test_execute_twice_errors() {
     let ctx = GovCtx::setup();
-    let id = ctx.client.propose(&ctx.signer_a, &ctx.dummy_target(), &ctx.calldata("x"));
+    let id = ctx
+        .client
+        .propose(&ctx.signer_a, &ctx.dummy_target(), &ctx.calldata("x"));
 
     ctx.client.approve(&ctx.signer_a, &id);
     ctx.client.approve(&ctx.signer_b, &id);
 
-    ctx.env
-        .ledger()
-        .set_timestamp(1_000_000 + TIMELOCK + 1);
+    ctx.env.ledger().set_timestamp(1_000_000 + TIMELOCK + 1);
 
     let executor = Address::generate(&ctx.env);
     ctx.client.execute(&executor, &id);
@@ -277,9 +286,7 @@ fn test_execute_twice_errors() {
 #[test]
 fn test_execute_nonexistent_proposal_errors() {
     let ctx = GovCtx::setup();
-    ctx.env
-        .ledger()
-        .set_timestamp(1_000_000 + TIMELOCK + 1);
+    ctx.env.ledger().set_timestamp(1_000_000 + TIMELOCK + 1);
 
     let executor = Address::generate(&ctx.env);
     let result = ctx.client.try_execute(&executor, &9999u32);
@@ -314,7 +321,9 @@ fn test_add_signer_unauthorized_errors() {
     let new_signer = Address::generate(&ctx.env);
     ctx.client.add_signer(&new_signer);
     // New signer can now propose
-    let id = ctx.client.propose(&new_signer, &ctx.dummy_target(), &ctx.calldata("y"));
+    let id = ctx
+        .client
+        .propose(&new_signer, &ctx.dummy_target(), &ctx.calldata("y"));
     let p = ctx.client.get_proposal(&id);
     assert_eq!(p.proposer, new_signer);
     let _ = outsider; // suppress unused warning
@@ -348,9 +357,7 @@ fn test_full_governance_flow() {
     assert_eq!(early_result, Err(Ok(GovernanceError::TimelockNotElapsed)));
 
     // Advance past timelock
-    ctx.env
-        .ledger()
-        .set_timestamp(1_000_000 + TIMELOCK + 1);
+    ctx.env.ledger().set_timestamp(1_000_000 + TIMELOCK + 1);
 
     ctx.client.execute(&executor, &id);
 
@@ -366,7 +373,9 @@ fn test_full_governance_flow() {
 #[test]
 fn test_third_approval_after_quorum_is_stored() {
     let ctx = GovCtx::setup();
-    let id = ctx.client.propose(&ctx.signer_a, &ctx.dummy_target(), &ctx.calldata("x"));
+    let id = ctx
+        .client
+        .propose(&ctx.signer_a, &ctx.dummy_target(), &ctx.calldata("x"));
 
     ctx.client.approve(&ctx.signer_a, &id);
     ctx.client.approve(&ctx.signer_b, &id);
@@ -385,7 +394,9 @@ fn test_third_approval_after_quorum_is_stored() {
 fn test_calldata_preserved_in_proposal() {
     let ctx = GovCtx::setup();
     let data = ctx.calldata("set_min_duration:86400");
-    let id = ctx.client.propose(&ctx.signer_a, &ctx.dummy_target(), &data);
+    let id = ctx
+        .client
+        .propose(&ctx.signer_a, &ctx.dummy_target(), &data);
     let p = ctx.client.get_proposal(&id);
     assert_eq!(p.calldata, data);
 }

--- a/contracts/stream/tests/id_reservation.rs
+++ b/contracts/stream/tests/id_reservation.rs
@@ -42,14 +42,23 @@ impl<'a> Ctx<'a> {
 
         client.init(&token_id, &admin);
 
-        Self { env, client, contract_id, sender, token_id }
+        Self {
+            env,
+            client,
+            contract_id,
+            sender,
+            token_id,
+        }
     }
 
     fn mint(&self, to: &Address) {
-        StellarAssetClient::new(&self.env, &self.token_id)
-            .mint(to, &1_000_000_000_000i128);
-        TokenClient::new(&self.env, &self.token_id)
-            .approve(to, &self.contract_id, &i128::MAX, &100_000u32);
+        StellarAssetClient::new(&self.env, &self.token_id).mint(to, &1_000_000_000_000i128);
+        TokenClient::new(&self.env, &self.token_id).approve(
+            to,
+            &self.contract_id,
+            &i128::MAX,
+            &100_000u32,
+        );
     }
 
     fn create_stream(&self, sender: &Address) -> u64 {
@@ -96,7 +105,9 @@ fn reserve_single_id() {
 #[test]
 fn reserve_max_ids() {
     let ctx = Ctx::setup();
-    let ids = ctx.client.reserve_stream_ids(&ctx.sender, &MAX_ID_RESERVATION);
+    let ids = ctx
+        .client
+        .reserve_stream_ids(&ctx.sender, &MAX_ID_RESERVATION);
     assert_eq!(ids.len(), MAX_ID_RESERVATION);
     assert_eq!(ids.get(0).unwrap(), 0u64);
     assert_eq!(

--- a/contracts/stream/tests/integration_suite.rs
+++ b/contracts/stream/tests/integration_suite.rs
@@ -9,7 +9,8 @@ use fluxora_stream::{
 use proptest::prelude::*;
 use soroban_sdk::log;
 use soroban_sdk::{
-    contract, contractimpl, testutils::{Address as _, Events, Ledger},
+    contract, contractimpl,
+    testutils::{Address as _, Events, Ledger},
     token::{Client as TokenClient, StellarAssetClient},
     vec, Address, Env, FromVal, IntoVal,
 };
@@ -468,7 +469,7 @@ fn get_stream_health_returns_correct_summary_underfunded() {
         &0,
         &None,
         &fluxora_stream::StreamKind::Linear,
-        );
+    );
 
     ctx.env.ledger().set_timestamp(300);
     let health = ctx.client().get_stream_health(&stream_id);
@@ -523,7 +524,8 @@ fn snapshot_event_paused_resumed_cancelled() {
     let stream_id = ctx.create_default_stream();
 
     // 1. paused
-    ctx.client().pause_stream(&stream_id, &PauseReason::Operational);
+    ctx.client()
+        .pause_stream(&stream_id, &PauseReason::Operational);
     let events = ctx.env.events().all();
     let last_event = events.last().unwrap();
     assert_eq!(
@@ -579,7 +581,7 @@ fn snapshot_event_rate_end_topup_recp() {
         &0,
         &None,
         &fluxora_stream::StreamKind::Linear,
-        );
+    );
 
     // 1. rate_upd
     ctx.client().update_rate_per_second(&stream_id, &2_i128);
@@ -600,7 +602,8 @@ fn snapshot_event_rate_end_topup_recp() {
     );
 
     // 3. top_up — refill the deposit so we can subsequently extend the schedule.
-    ctx.client().top_up_stream(&stream_id, &ctx.sender, &1000_i128);
+    ctx.client()
+        .top_up_stream(&stream_id, &ctx.sender, &1000_i128);
     let events = ctx.env.events().all();
     let last_event = events.last().unwrap();
     assert_eq!(
@@ -657,7 +660,7 @@ fn update_rate_accepts_maximum_i128_rate() {
         &0,
         &None,
         &fluxora_stream::StreamKind::Linear,
-        );
+    );
 
     ctx.client().update_rate_per_second(&stream_id, &i128::MAX);
     let state = ctx.client().get_stream_state(&stream_id);
@@ -671,7 +674,8 @@ fn update_rate_on_paused_stream_is_allowed() {
     ctx.env.ledger().set_timestamp(0);
     let stream_id = ctx.create_default_stream();
 
-    ctx.client().pause_stream(&stream_id, &PauseReason::Operational);
+    ctx.client()
+        .pause_stream(&stream_id, &PauseReason::Operational);
     ctx.client().update_rate_per_second(&stream_id, &2_i128);
 
     let state = ctx.client().get_stream_state(&stream_id);
@@ -768,7 +772,7 @@ fn snapshot_no_event_on_revert() {
         &0,
         &None,
         &fluxora_stream::StreamKind::Linear,
-        );
+    );
     assert!(result.is_err());
     assert_eq!(ctx.env.events().all().len(), events_before);
 }
@@ -819,7 +823,7 @@ fn test_accrual_none_checkpoint_returns_zero() {
         &0,
         &None,
         &fluxora_stream::StreamKind::Linear,
-        );
+    );
 
     // At start_time the elapsed seconds are 0 → accrued must be 0.
     let accrued = ctx.client().calculate_accrued(&stream_id);
@@ -851,7 +855,7 @@ fn test_accrual_none_checkpoint_before_cliff_returns_zero() {
         &0,
         &None,
         &fluxora_stream::StreamKind::Linear,
-        );
+    );
 
     // Before cliff → 0, regardless of checkpoint state.
     let accrued = ctx.client().calculate_accrued(&stream_id);
@@ -1618,7 +1622,9 @@ fn init_accepts_valid_sep41_token() {
 
     let admin = Address::generate(&env);
     let token_admin = Address::generate(&env);
-    let token_id = env.register_stellar_asset_contract_v2(token_admin).address();
+    let token_id = env
+        .register_stellar_asset_contract_v2(token_admin)
+        .address();
     let contract_id = env.register_contract(None, FluxoraStream);
     let client = FluxoraStreamClient::new(&env, &contract_id);
 

--- a/contracts/stream/tests/keeper_cancel.rs
+++ b/contracts/stream/tests/keeper_cancel.rs
@@ -189,10 +189,7 @@ fn test_keeper_cancel_too_early_errors() {
     ctx.env.ledger().set_timestamp(1000 + GRACE - 1);
 
     let result = ctx.client().try_keeper_cancel(&stream_id, &ctx.keeper);
-    assert_eq!(
-        result,
-        Err(Ok(ContractError::KeeperGracePeriodNotElapsed))
-    );
+    assert_eq!(result, Err(Ok(ContractError::KeeperGracePeriodNotElapsed)));
 }
 
 // ---------------------------------------------------------------------------
@@ -300,10 +297,8 @@ fn test_keeper_cancel_paused_stream_succeeds() {
 
     // Pause the stream at t=500
     ctx.env.ledger().set_timestamp(500);
-    ctx.client().pause_stream(
-        &stream_id,
-        &fluxora_stream::PauseReason::Operational,
-    );
+    ctx.client()
+        .pause_stream(&stream_id, &fluxora_stream::PauseReason::Operational);
 
     // Advance past grace period (paused streams are still eligible)
     ctx.env.ledger().set_timestamp(2000 + GRACE + 1);

--- a/contracts/stream/tests/max_rate_per_second.rs
+++ b/contracts/stream/tests/max_rate_per_second.rs
@@ -1,4 +1,4 @@
-﻿#![cfg(test)]
+#![cfg(test)]
 extern crate std;
 
 use fluxora_stream::{ContractError, FluxoraStream, FluxoraStreamClient, RateCapEnforced};
@@ -136,7 +136,7 @@ fn test_create_stream_respects_max_rate() {
         &0,
         &None,
         &fluxora_stream::StreamKind::Linear,
-        );
+    );
     assert_eq!(result, Err(Ok(ContractError::InvalidParams)));
 }
 
@@ -198,7 +198,7 @@ fn test_default_max_rate_is_unlimited() {
         &0,
         &None,
         &fluxora_stream::StreamKind::Linear,
-        );
+    );
     assert!(result.is_ok(), "High rates should be allowed by default");
 }
 
@@ -213,7 +213,7 @@ fn test_max_rate_applies_to_all_create_functions() {
     let params = vec![
         &ctx.env,
         fluxora_stream::CreateStreamParams {
-        kind: fluxora_stream::StreamKind::Linear,
+            kind: fluxora_stream::StreamKind::Linear,
             recipient: ctx.recipient.clone(),
             deposit_amount: 1000,
             rate_per_second: 101, // Exceeds max
@@ -272,7 +272,7 @@ fn test_max_rate_boundary_conditions() {
         &0,
         &None,
         &fluxora_stream::StreamKind::Linear,
-        );
+    );
     assert_eq!(result, Err(Ok(ContractError::InvalidParams)));
 
     // Test with max rate = i128::MAX
@@ -291,7 +291,7 @@ fn test_max_rate_boundary_conditions() {
         &0,
         &None,
         &fluxora_stream::StreamKind::Linear,
-        );
+    );
     assert!(result.is_ok());
 }
 

--- a/contracts/stream/tests/metadata_extension.rs
+++ b/contracts/stream/tests/metadata_extension.rs
@@ -1,21 +1,21 @@
 extern crate std;
 
-//! Comprehensive tests for per-stream metadata TLV extension (issue #580).
-//!
-//! Coverage:
-//! - Happy-path: create stream with metadata, query it back
-//! - Batch creation (create_streams / create_streams_relative) with metadata
-//! - Validation: key count limit, per-key/value byte limits, aggregate byte limit
-//! - Immutability: metadata is unchanged by pause/resume/cancel/withdraw
-//! - StreamCreated event includes metadata
-//! - None metadata is stored and returned as None
-//! - Empty metadata map (Some({})) is valid
-//! - Boundary values at exactly MAX_METADATA_KEYS / MAX_METADATA_BYTES limits
+// Comprehensive tests for per-stream metadata TLV extension (issue #580).
+//
+// Coverage:
+// - Happy-path: create stream with metadata, query it back
+// - Batch creation (create_streams / create_streams_relative) with metadata
+// - Validation: key count limit, per-key/value byte limits, aggregate byte limit
+// - Immutability: metadata is unchanged by pause/resume/cancel/withdraw
+// - StreamCreated event includes metadata
+// - None metadata is stored and returned as None
+// - Empty metadata map (Some({})) is valid
+// - Boundary values at exactly MAX_METADATA_KEYS / MAX_METADATA_BYTES limits
 
 use fluxora_stream::{
     ContractError, CreateStreamParams, CreateStreamRelativeParams, FluxoraStream,
-    FluxoraStreamClient, StreamStatus,
-    MAX_METADATA_BYTES, MAX_METADATA_KEY_BYTES, MAX_METADATA_KEYS, MAX_METADATA_VALUE_BYTES,
+    FluxoraStreamClient, StreamStatus, MAX_METADATA_BYTES, MAX_METADATA_KEYS,
+    MAX_METADATA_KEY_BYTES, MAX_METADATA_VALUE_BYTES,
 };
 use soroban_sdk::{
     testutils::{Address as _, Events, Ledger},
@@ -93,10 +93,7 @@ impl<'a> Ctx<'a> {
         m
     }
 
-    fn create_stream_with_metadata(
-        &self,
-        metadata: Option<Map<Bytes, Bytes>>,
-    ) -> u64 {
+    fn create_stream_with_metadata(&self, metadata: Option<Map<Bytes, Bytes>>) -> u64 {
         self.client().create_stream(
             &self.sender,
             &self.recipient,
@@ -141,16 +138,11 @@ fn test_metadata_empty_map_valid() {
 fn test_metadata_single_entry_round_trips() {
     let ctx = Ctx::setup();
     let mut meta: Map<Bytes, Bytes> = Map::new(&ctx.env);
-    meta.set(
-        ctx.make_key("invoice_id"),
-        ctx.make_val("INV-2026-001"),
-    );
+    meta.set(ctx.make_key("invoice_id"), ctx.make_val("INV-2026-001"));
     let stream_id = ctx.create_stream_with_metadata(Some(meta.clone()));
     let got = ctx.client().get_stream_metadata(&stream_id).unwrap();
     assert_eq!(got.len(), 1);
-    let v = got
-        .get(ctx.make_key("invoice_id"))
-        .expect("key must exist");
+    let v = got.get(ctx.make_key("invoice_id")).expect("key must exist");
     assert_eq!(v, ctx.make_val("INV-2026-001"));
 }
 
@@ -160,7 +152,10 @@ fn test_metadata_multiple_entries_round_trip() {
     let mut meta: Map<Bytes, Bytes> = Map::new(&ctx.env);
     meta.set(ctx.make_key("invoice_id"), ctx.make_val("INV-001"));
     meta.set(ctx.make_key("project"), ctx.make_val("PROJ-42"));
-    meta.set(ctx.make_key("ref_uri"), ctx.make_val("https://example.com/inv/001"));
+    meta.set(
+        ctx.make_key("ref_uri"),
+        ctx.make_val("https://example.com/inv/001"),
+    );
 
     let stream_id = ctx.create_stream_with_metadata(Some(meta.clone()));
     let got = ctx.client().get_stream_metadata(&stream_id).unwrap();
@@ -309,12 +304,9 @@ fn test_metadata_aggregate_exactly_at_limit_valid() {
     // 4 entries: key "kXXXXXXX" (8 bytes) + value of 120 bytes = 128 bytes each × 4 = 512 total.
     let mut meta: Map<Bytes, Bytes> = Map::new(&ctx.env);
     for i in 0u8..4 {
-        let key_str = std::format!("key{:05}", i);      // 8 bytes
+        let key_str = std::format!("key{:05}", i); // 8 bytes
         let value = Bytes::from_slice(&ctx.env, &vec![i; 120].as_slice()); // 120 bytes
-        meta.set(
-            Bytes::from_slice(&ctx.env, key_str.as_bytes()),
-            value,
-        );
+        meta.set(Bytes::from_slice(&ctx.env, key_str.as_bytes()), value);
     }
     let stream_id = ctx.create_stream_with_metadata(Some(meta));
     assert!(ctx.client().get_stream_metadata(&stream_id).is_some());
@@ -328,10 +320,7 @@ fn test_metadata_aggregate_exceeds_limit_rejected() {
     for i in 0u8..5 {
         let key_str = std::format!("key{:05}", i); // 8 bytes
         let value = Bytes::from_slice(&ctx.env, &vec![i; 120].as_slice()); // 120 bytes
-        meta.set(
-            Bytes::from_slice(&ctx.env, key_str.as_bytes()),
-            value,
-        );
+        meta.set(Bytes::from_slice(&ctx.env, key_str.as_bytes()), value);
     }
     let result = ctx.client().try_create_stream(
         &ctx.sender,
@@ -347,7 +336,10 @@ fn test_metadata_aggregate_exceeds_limit_rejected() {
     );
     match result {
         Err(Ok(ContractError::MetadataTooLarge)) => {}
-        _ => panic!("Expected MetadataTooLarge for aggregate overflow, got {:?}", result),
+        _ => panic!(
+            "Expected MetadataTooLarge for aggregate overflow, got {:?}",
+            result
+        ),
     }
 }
 
@@ -362,7 +354,8 @@ fn test_metadata_unchanged_after_pause_resume() {
     meta.set(ctx.make_key("ref"), ctx.make_val("PAUSE_TEST"));
     let stream_id = ctx.create_stream_with_metadata(Some(meta.clone()));
 
-    ctx.client().pause_stream(&stream_id, &fluxora_stream::PauseReason::Operational);
+    ctx.client()
+        .pause_stream(&stream_id, &fluxora_stream::PauseReason::Operational);
     ctx.client().resume_stream(&stream_id);
 
     let got = ctx.client().get_stream_metadata(&stream_id).unwrap();
@@ -484,11 +477,23 @@ fn test_create_streams_batch_each_entry_stores_own_metadata() {
     let ids = ctx.client().create_streams(&ctx.sender, &params);
     assert_eq!(ids.len(), 2);
 
-    let got_a = ctx.client().get_stream_metadata(&ids.get(0).unwrap()).unwrap();
-    let got_b = ctx.client().get_stream_metadata(&ids.get(1).unwrap()).unwrap();
+    let got_a = ctx
+        .client()
+        .get_stream_metadata(&ids.get(0).unwrap())
+        .unwrap();
+    let got_b = ctx
+        .client()
+        .get_stream_metadata(&ids.get(1).unwrap())
+        .unwrap();
 
-    assert_eq!(got_a.get(ctx.make_key("stream")).unwrap(), ctx.make_val("A"));
-    assert_eq!(got_b.get(ctx.make_key("stream")).unwrap(), ctx.make_val("B"));
+    assert_eq!(
+        got_a.get(ctx.make_key("stream")).unwrap(),
+        ctx.make_val("A")
+    );
+    assert_eq!(
+        got_b.get(ctx.make_key("stream")).unwrap(),
+        ctx.make_val("B")
+    );
 }
 
 #[test]
@@ -513,7 +518,10 @@ fn test_create_streams_batch_none_metadata_stored_as_none() {
 
     let ids = ctx.client().create_streams(&ctx.sender, &params);
     assert_eq!(ids.len(), 1);
-    assert!(ctx.client().get_stream_metadata(&ids.get(0).unwrap()).is_none());
+    assert!(ctx
+        .client()
+        .get_stream_metadata(&ids.get(0).unwrap())
+        .is_none());
 }
 
 // ---------------------------------------------------------------------------
@@ -546,8 +554,14 @@ fn test_create_streams_relative_with_metadata() {
     let ids = ctx.client().create_streams_relative(&ctx.sender, &params);
     assert_eq!(ids.len(), 1);
 
-    let got = ctx.client().get_stream_metadata(&ids.get(0).unwrap()).unwrap();
-    assert_eq!(got.get(ctx.make_key("src")).unwrap(), ctx.make_val("relative"));
+    let got = ctx
+        .client()
+        .get_stream_metadata(&ids.get(0).unwrap())
+        .unwrap();
+    assert_eq!(
+        got.get(ctx.make_key("src")).unwrap(),
+        ctx.make_val("relative")
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -582,9 +596,7 @@ fn test_create_streams_partial_invalid_metadata_fails_entry() {
         },
     ];
 
-    let results = ctx
-        .client()
-        .create_streams_partial(&ctx.sender, &params);
+    let results = ctx.client().create_streams_partial(&ctx.sender, &params);
 
     assert_eq!(results.len(), 1);
     let r = results.get(0).unwrap();

--- a/contracts/stream/tests/rate_bounds.rs
+++ b/contracts/stream/tests/rate_bounds.rs
@@ -1,5 +1,5 @@
-use soroban_sdk::{testutils::Address as _, Address, Env, String};
 use fluxora_stream::{ContractError, FluxoraStream, StreamStatus};
+use soroban_sdk::{testutils::Address as _, Address, Env, String};
 
 fn setup() -> (Env, FluxoraStreamClient, Address, Address, Address) {
     let env = Env::default();
@@ -49,9 +49,7 @@ fn create_stream_with_rate(
         .unwrap()
 }
 
-
 // Happy path: rate at or above MIN_RATE_PER_SECOND
-
 
 #[test]
 fn test_create_stream_at_min_rate_succeeds() {
@@ -81,9 +79,7 @@ fn test_create_stream_at_large_rate_succeeds() {
     assert_eq!(stream.rate_per_second, rate);
 }
 
-
 // Failure path: rate below MIN_RATE_PER_SECOND
-
 
 #[test]
 fn test_create_stream_at_zero_rate_fails() {
@@ -153,9 +149,7 @@ fn test_create_stream_at_min_rate_boundary_succeeds() {
     assert_eq!(stream_id, 0); // first stream
 }
 
-
 // Batch creation: rate bounds enforced per entry
-
 
 #[test]
 fn test_create_streams_with_mixed_rates_fails_atomically() {
@@ -229,9 +223,7 @@ fn test_create_streams_all_valid_rates_succeeds() {
     assert_eq!(client.get_stream_count(), 2);
 }
 
-
 // Relative time creation: rate bounds enforced
-
 
 #[test]
 fn test_create_stream_relative_below_min_rate_fails() {
@@ -271,7 +263,6 @@ fn test_create_stream_relative_at_min_rate_succeeds() {
     let stream = client.get_stream_state(&stream_id).unwrap();
     assert_eq!(stream.rate_per_second, 100i128);
 }
-
 
 // Template-based creation: rate bounds enforced
 

--- a/contracts/stream/tests/recipient_paged_index.rs
+++ b/contracts/stream/tests/recipient_paged_index.rs
@@ -1,4 +1,4 @@
-﻿extern crate std;
+extern crate std;
 
 use fluxora_stream::{FluxoraStream, FluxoraStreamClient, MAX_RECIPIENT_PAGE_SIZE};
 use soroban_sdk::{
@@ -70,7 +70,7 @@ fn test_recipient_index_migration() {
             &0,
             &None,
             &fluxora_stream::StreamKind::Linear,
-            );
+        );
     }
 
     let streams = ctx.client.get_recipient_streams(&ctx.recipient);
@@ -96,7 +96,7 @@ fn test_recipient_index_migration() {
         &0,
         &None,
         &fluxora_stream::StreamKind::Linear,
-        );
+    );
 
     let streams_final = ctx.client.get_recipient_streams(&ctx.recipient);
     assert_eq!(streams_final.len(), 6);
@@ -121,7 +121,7 @@ fn test_paged_index_pagination() {
             &0,
             &None,
             &fluxora_stream::StreamKind::Linear,
-            );
+        );
     }
 
     // Migrate to paged index
@@ -171,7 +171,7 @@ fn test_remove_from_paged_index() {
         &0,
         &None,
         &fluxora_stream::StreamKind::Linear,
-        );
+    );
     let id2 = ctx.client.create_stream(
         &ctx.sender,
         &ctx.recipient,
@@ -183,7 +183,7 @@ fn test_remove_from_paged_index() {
         &0,
         &None,
         &fluxora_stream::StreamKind::Linear,
-        );
+    );
     let id3 = ctx.client.create_stream(
         &ctx.sender,
         &ctx.recipient,
@@ -195,7 +195,7 @@ fn test_remove_from_paged_index() {
         &0,
         &None,
         &fluxora_stream::StreamKind::Linear,
-        );
+    );
 
     ctx.client.migrate_recipient_index(&ctx.recipient);
 

--- a/contracts/stream/tests/storage_key_compat.rs
+++ b/contracts/stream/tests/storage_key_compat.rs
@@ -49,8 +49,7 @@
 extern crate std;
 
 use fluxora_stream::{
-    Config, DataKey, FluxoraStream, FluxoraStreamClient, Stream, StreamStatus,
-    CONTRACT_VERSION,
+    Config, DataKey, FluxoraStream, FluxoraStreamClient, Stream, StreamStatus, CONTRACT_VERSION,
 };
 use soroban_sdk::{
     testutils::{Address as _, Ledger},
@@ -93,7 +92,14 @@ impl<'a> Ctx<'a> {
 
         client.init(&token_id, &admin);
 
-        Ctx { env, contract_id, client, token_id, admin, sender }
+        Ctx {
+            env,
+            contract_id,
+            client,
+            token_id,
+            admin,
+            sender,
+        }
     }
 
     /// Seed a V5-era `Stream` directly into persistent storage, bypassing the
@@ -163,7 +169,10 @@ fn v5_stream_readable_by_v6_get_stream_state() {
     assert_eq!(state.withdrawn_amount, 0);
     assert_eq!(state.status, StreamStatus::Active);
     // V5 entry has no memo — V6 decoder must return None, not panic.
-    assert!(state.memo.is_none(), "V5 stream must decode with memo == None");
+    assert!(
+        state.memo.is_none(),
+        "V5 stream must decode with memo == None"
+    );
 }
 
 /// V6 `calculate_accrued` works correctly on a V5-era Stream entry.
@@ -181,7 +190,10 @@ fn v5_stream_calculate_accrued_correct() {
 
     let accrued = ctx.client.calculate_accrued(&0u64);
     // rate=1 token/s × 100 s = 100
-    assert_eq!(accrued, 100, "accrual on V5 stream must equal rate × elapsed");
+    assert_eq!(
+        accrued, 100,
+        "accrual on V5 stream must equal rate × elapsed"
+    );
 }
 
 /// V6 `get_withdrawable` works correctly on a V5-era Stream entry.
@@ -272,7 +284,10 @@ fn v5_cancelled_stream_readable_accrual_frozen() {
 
     // Accrual must be frozen at cancelled_at (50 tokens)
     let accrued = ctx.client.calculate_accrued(&0u64);
-    assert_eq!(accrued, 50, "cancelled V5 stream accrual must be frozen at cancelled_at");
+    assert_eq!(
+        accrued, 50,
+        "cancelled V5 stream accrual must be frozen at cancelled_at"
+    );
 }
 
 /// A V5-era Stream with non-zero `checkpointed_amount` decodes correctly.
@@ -346,7 +361,10 @@ fn v5_next_stream_id_readable_by_v6() {
     });
 
     let count = ctx.client.get_stream_count();
-    assert_eq!(count, 3, "V5 NextStreamId must be readable by V6 get_stream_count");
+    assert_eq!(
+        count, 3,
+        "V5 NextStreamId must be readable by V6 get_stream_count"
+    );
 }
 
 /// V5 `GlobalEmergencyPaused` (discriminant 4) is readable by V6.
@@ -449,7 +467,8 @@ fn v5_total_liabilities_readable_by_v6() {
     // TotalLiabilities, so we verify the key is present by reading it directly.
     let cid2 = ctx.contract_id.clone();
     ctx.env.as_contract(&cid2, || {
-        let val: i128 = ctx.env
+        let val: i128 = ctx
+            .env
             .storage()
             .instance()
             .get(&DataKey::TotalLiabilities)
@@ -521,11 +540,15 @@ fn v6_withdraw_nonce_absent_on_v5_instance() {
     let addr = Address::generate(&ctx.env);
     let cid = ctx.contract_id.clone();
     ctx.env.as_contract(&cid, || {
-        let present = ctx.env
+        let present = ctx
+            .env
             .storage()
             .persistent()
             .has(&DataKey::WithdrawNonce(addr.clone()));
-        assert!(!present, "WithdrawNonce must be absent on a V5-seeded instance");
+        assert!(
+            !present,
+            "WithdrawNonce must be absent on a V5-seeded instance"
+        );
     });
 }
 
@@ -538,11 +561,11 @@ fn v6_pause_state_absent_on_v5_instance() {
     let ctx = Ctx::setup();
     let cid = ctx.contract_id.clone();
     ctx.env.as_contract(&cid, || {
-        let present = ctx.env
-            .storage()
-            .instance()
-            .has(&DataKey::PauseState);
-        assert!(!present, "PauseState must be absent on a V5-seeded instance");
+        let present = ctx.env.storage().instance().has(&DataKey::PauseState);
+        assert!(
+            !present,
+            "PauseState must be absent on a V5-seeded instance"
+        );
     });
 }
 
@@ -554,11 +577,11 @@ fn v6_reentrancy_lock_absent_on_v5_instance() {
     let ctx = Ctx::setup();
     let cid = ctx.contract_id.clone();
     ctx.env.as_contract(&cid, || {
-        let present = ctx.env
-            .storage()
-            .instance()
-            .has(&DataKey::ReentrancyLock);
-        assert!(!present, "ReentrancyLock must be absent on a V5-seeded instance");
+        let present = ctx.env.storage().instance().has(&DataKey::ReentrancyLock);
+        assert!(
+            !present,
+            "ReentrancyLock must be absent on a V5-seeded instance"
+        );
     });
 }
 
@@ -572,11 +595,15 @@ fn v6_recipient_stream_page_absent_on_v5_instance() {
     let addr = Address::generate(&ctx.env);
     let cid = ctx.contract_id.clone();
     ctx.env.as_contract(&cid, || {
-        let present = ctx.env
+        let present = ctx
+            .env
             .storage()
             .persistent()
             .has(&DataKey::RecipientStreamPage(addr.clone(), 0u32));
-        assert!(!present, "RecipientStreamPage must be absent on a V5-seeded instance");
+        assert!(
+            !present,
+            "RecipientStreamPage must be absent on a V5-seeded instance"
+        );
     });
 }
 
@@ -587,11 +614,15 @@ fn v6_recipient_stream_page_count_absent_on_v5_instance() {
     let addr = Address::generate(&ctx.env);
     let cid = ctx.contract_id.clone();
     ctx.env.as_contract(&cid, || {
-        let present = ctx.env
+        let present = ctx
+            .env
             .storage()
             .persistent()
             .has(&DataKey::RecipientStreamPageCount(addr.clone()));
-        assert!(!present, "RecipientStreamPageCount must be absent on a V5-seeded instance");
+        assert!(
+            !present,
+            "RecipientStreamPageCount must be absent on a V5-seeded instance"
+        );
     });
 }
 
@@ -601,11 +632,15 @@ fn v6_pending_recipient_update_absent_on_v5_instance() {
     let ctx = Ctx::setup();
     let cid = ctx.contract_id.clone();
     ctx.env.as_contract(&cid, || {
-        let present = ctx.env
+        let present = ctx
+            .env
             .storage()
             .persistent()
             .has(&DataKey::PendingRecipientUpdate(0u64));
-        assert!(!present, "PendingRecipientUpdate must be absent on a V5-seeded instance");
+        assert!(
+            !present,
+            "PendingRecipientUpdate must be absent on a V5-seeded instance"
+        );
     });
 }
 
@@ -634,7 +669,8 @@ fn discriminant_0_config_round_trips() {
                 admin: new_admin.clone(),
             },
         );
-        let cfg: Config = ctx.env
+        let cfg: Config = ctx
+            .env
             .storage()
             .instance()
             .get(&DataKey::Config)
@@ -654,7 +690,8 @@ fn discriminant_1_next_stream_id_round_trips() {
             .storage()
             .instance()
             .set(&DataKey::NextStreamId, &7u64);
-        let val: u64 = ctx.env
+        let val: u64 = ctx
+            .env
             .storage()
             .instance()
             .get(&DataKey::NextStreamId)
@@ -685,7 +722,8 @@ fn discriminant_3_recipient_streams_round_trips() {
 
     let cid = ctx.contract_id.clone();
     ctx.env.as_contract(&cid, || {
-        let ids: soroban_sdk::Vec<u64> = ctx.env
+        let ids: soroban_sdk::Vec<u64> = ctx
+            .env
             .storage()
             .persistent()
             .get(&DataKey::RecipientStreams(recipient.clone()))
@@ -705,7 +743,8 @@ fn discriminant_14_total_liabilities_round_trips() {
             .storage()
             .instance()
             .set(&DataKey::TotalLiabilities, &12345_i128);
-        let val: i128 = ctx.env
+        let val: i128 = ctx
+            .env
             .storage()
             .instance()
             .get(&DataKey::TotalLiabilities)

--- a/contracts/stream/tests/withdrawal_frequency.rs
+++ b/contracts/stream/tests/withdrawal_frequency.rs
@@ -4,8 +4,8 @@ extern crate std;
 use fluxora_stream::{ContractError, FluxoraStream, FluxoraStreamClient};
 use soroban_sdk::{
     testutils::{Address as _, Ledger, LedgerInfo},
-    Address, Env,
     token::Client as TokenClient,
+    Address, Env,
 };
 
 struct TestContext {
@@ -26,7 +26,9 @@ impl TestContext {
         let client = FluxoraStreamClient::new(&env, &contract_id);
 
         let token_admin = Address::generate(&env);
-        let token_id = env.register_stellar_asset_contract_v2(token_admin).address();
+        let token_id = env
+            .register_stellar_asset_contract_v2(token_admin)
+            .address();
         let token = TokenClient::new(&env, &token_id);
 
         let admin = Address::generate(&env);
@@ -273,7 +275,7 @@ fn test_delegated_withdraw_enforces_rate_limit() {
 #[test]
 fn test_batch_withdraw_enforces_rate_limit_per_stream() {
     let ctx = TestContext::setup();
-    
+
     // Create two streams
     let stream_id1 = ctx.create_stream();
     let stream_id2 = ctx.create_stream();
@@ -304,7 +306,7 @@ fn test_batch_withdraw_enforces_rate_limit_per_stream() {
 #[test]
 fn test_batch_withdraw_fails_if_any_stream_violates_rate_limit() {
     let ctx = TestContext::setup();
-    
+
     // Create two streams
     let stream_id1 = ctx.create_stream();
     let stream_id2 = ctx.create_stream();
@@ -325,7 +327,7 @@ fn test_batch_withdraw_fails_if_any_stream_violates_rate_limit() {
     // stream1 just withdrew (0 ledgers ago), stream2 never withdrew (should succeed)
     let stream_ids = soroban_sdk::vec![&ctx.env, stream_id1, stream_id2];
     let result = ctx.client.try_batch_withdraw(&ctx.recipient, &stream_ids);
-    
+
     // Should fail because stream1 violates rate limit
     assert_eq!(result, Err(Ok(ContractError::WithdrawalTooFrequent)));
 }
@@ -355,7 +357,7 @@ fn test_no_state_mutation_on_rate_limit_error() {
 
     // First withdrawal succeeds
     let first_amount = ctx.client.withdraw(&stream_id).unwrap();
-    
+
     // Get stream state after first withdrawal
     let stream_after_first = ctx.client.get_stream_state(&stream_id);
     let withdrawn_after_first = stream_after_first.withdrawn_amount;
@@ -368,7 +370,7 @@ fn test_no_state_mutation_on_rate_limit_error() {
     // Verify no state mutation occurred
     let stream_after_failed = ctx.client.get_stream_state(&stream_id);
     assert_eq!(stream_after_failed.withdrawn_amount, withdrawn_after_first);
-    
+
     let balance_after_failed = ctx.token.balance(&ctx.recipient);
     assert_eq!(balance_after_failed, balance_after_first);
 }
@@ -382,11 +384,11 @@ fn test_underflow_safety_invariant() {
     for _ in 0..5 {
         ctx.advance_ledger(20);
         ctx.client.withdraw(&stream_id).unwrap();
-        
+
         // After each withdrawal, verify invariant: last_withdraw_ledger <= current_ledger
         let stream = ctx.client.get_stream_state(&stream_id);
         let current_ledger = ctx.env.ledger().sequence();
-        
+
         // This assertion verifies the invariant holds
         // If last_withdraw_ledger > current_ledger, the subtraction would underflow
         assert!(stream.last_withdraw_ledger <= current_ledger);
@@ -396,19 +398,22 @@ fn test_underflow_safety_invariant() {
 #[test]
 fn test_zero_withdrawable_does_not_update_last_withdraw_ledger() {
     let ctx = TestContext::setup();
-    
+
     // Create stream with cliff time in the future
-    let stream_id = ctx.client.create_stream(
-        &ctx.sender,
-        &ctx.recipient,
-        &1000,
-        &1,
-        &0,
-        &500, // cliff at 500 seconds
-        &1000,
-        &0,
-        &None,
-    ).unwrap();
+    let stream_id = ctx
+        .client
+        .create_stream(
+            &ctx.sender,
+            &ctx.recipient,
+            &1000,
+            &1,
+            &0,
+            &500, // cliff at 500 seconds
+            &1000,
+            &0,
+            &None,
+        )
+        .unwrap();
 
     // Advance ledgers but not past cliff
     ctx.advance_ledger(50);
@@ -459,7 +464,7 @@ fn test_rate_limit_applies_across_different_withdrawal_methods() {
 #[test]
 fn test_multiple_streams_independent_rate_limits() {
     let ctx = TestContext::setup();
-    
+
     // Create two streams
     let stream_id1 = ctx.create_stream();
     let stream_id2 = ctx.create_stream();


### PR DESCRIPTION
closes #688
## PR title

docs(readme): align entry-point tables and add factory/governance sections

---

## Description

This PR reconciles the stale root `README.md` with the live Soroban smart contract implementations across the workspace. It expands the stream entry-point surface matrix to accurately document newer endpoints, logs absolute caller authorization constraints matching the source code, introduces foundational architectural Overviews for the Factory and Governance modules, and updates localized developer setup criteria.

## Type of change

- [ ] New feature (`feat`)
- [ ] Bug fix (`fix`)
- [ ] Refactor / internal improvement
- [x] Documentation
- [ ] Tests
- [ ] Other:

## Changes made

- **Stream Matrix Overhaul:** Expanded the core function tracking tables to include `delegated_withdraw`, `clone_stream`, `reserve_stream_ids`, `bulk_cancel_streams`, `keeper_cancel`, `trigger_auto_claim`, `register_stream_template`, `sweep_excess`, and paginated views.
- **Security Alignment:** Documented precise `require_auth()` paths matching explicit source targets (e.g., verifying `delegated_withdraw` tracks against `relayer.require_auth()` and `sweep_excess` implements double-auth checking flags).
- **Workspace Module Guides:** Linked dedicated architecture modules pointing to `docs/factory.md` and `docs/governance.md`.
- **WASM Instruction Target:** Inserted global build guidelines highlighting uniform workspace compilation logic (`cargo build --target wasm32-unknown-unknown --workspace`).

## Test plan

- Checked cross-references via manual inspection across all contract methods.
- Executed local tracking scans ensuring no documented endpoint parameters deviate from code states.

## Screenshots / evidence (Grep Audit)

```bash
# Executed tracking audit on stream contracts surface:
bilalishaq@death-note:~/Fluxora-Contracts$ grep -E -n "pub fn|require_auth" contracts/stream/src/lib.rs
1875:    pub fn init(env: Env, token: Address, admin: Address) -> Result<(), ContractError> {
1876:        admin.require_auth();
1988:    pub fn create_stream(
2001:        sender.require_auth();
2822:    pub fn withdraw(env: Env, stream_id: u64) -> Result<i128, ContractError> {
2827:        stream.recipient.require_auth();
3511:    pub fn delegated_withdraw(
3525:        relayer.require_auth();
5814:    pub fn sweep_excess(env: Env, recipient: Address) -> Result<i128, ContractError> {
5817:        admin.require_auth();
5820:        recipient.require_auth();
6331:    pub fn clone_stream(
6352:        source.sender.require_auth();
6467:    pub fn reserve_stream_ids(
6472:        caller.require_auth();
6569:    pub fn bulk_cancel_streams(
6575:        sender.require_auth();