### PR TITLE
feat(factory): validate stream time bounds

### DIFF
--- a/contracts/factory/src/lib.rs
+++ b/contracts/factory/src/lib.rs
@@ -13,6 +13,10 @@ pub enum FactoryError {
     RecipientNotAllowlisted = 4,
     DepositExceedsCap = 5,
     DurationTooShort = 6,
+    /// The requested stream must end strictly after it starts.
+    InvalidTimeRange = 7,
+    /// The requested cliff must be within the inclusive start/end window.
+    InvalidCliff = 8,
 }
 
 #[contracttype]
@@ -165,12 +169,21 @@ impl FluxoraFactory {
             return Err(FactoryError::DepositExceedsCap);
         }
 
+        // Mirror FluxoraStream time invariants before the cross-contract call so
+        // invalid schedules return typed factory errors instead of downstream panics.
+        if start_time >= end_time {
+            return Err(FactoryError::InvalidTimeRange);
+        }
+        if cliff_time < start_time || cliff_time > end_time {
+            return Err(FactoryError::InvalidCliff);
+        }
+
         let min_duration: u64 = env
             .storage()
             .instance()
             .get(&DataKey::MinDuration)
             .ok_or(FactoryError::NotInitialized)?;
-        let duration = end_time.saturating_sub(start_time);
+        let duration = end_time - start_time;
         if duration < min_duration {
             return Err(FactoryError::DurationTooShort);
         }

--- a/contracts/stream/tests/factory_policy.rs
+++ b/contracts/stream/tests/factory_policy.rs
@@ -231,6 +231,83 @@ fn test_create_stream_duration_at_minimum_ok() {
 }
 
 // ---------------------------------------------------------------------------
+// Time relationship validation
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_create_stream_rejects_end_before_start() {
+    let ctx = Ctx::setup();
+    let recipient = Address::generate(&ctx.env);
+    ctx.factory.set_allowlist(&recipient, &true);
+    let now = ctx.now();
+
+    let result = ctx.factory.try_create_stream(
+        &ctx.sender,
+        &recipient,
+        &1_000,
+        &1,
+        &(now + 200),
+        &(now + 200),
+        &(now + 100),
+        &0,
+    );
+    assert_eq!(result, Err(Ok(FactoryError::InvalidTimeRange)));
+}
+
+#[test]
+fn test_create_stream_rejects_end_equal_start() {
+    let ctx = Ctx::setup();
+    let recipient = Address::generate(&ctx.env);
+    ctx.factory.set_allowlist(&recipient, &true);
+    let now = ctx.now();
+
+    let result =
+        ctx.factory
+            .try_create_stream(&ctx.sender, &recipient, &1_000, &1, &now, &now, &now, &0);
+    assert_eq!(result, Err(Ok(FactoryError::InvalidTimeRange)));
+}
+
+#[test]
+fn test_create_stream_rejects_cliff_before_start() {
+    let ctx = Ctx::setup();
+    let recipient = Address::generate(&ctx.env);
+    ctx.factory.set_allowlist(&recipient, &true);
+    let now = ctx.now();
+
+    let result = ctx.factory.try_create_stream(
+        &ctx.sender,
+        &recipient,
+        &1_000,
+        &1,
+        &(now + 100),
+        &now,
+        &(now + 300),
+        &0,
+    );
+    assert_eq!(result, Err(Ok(FactoryError::InvalidCliff)));
+}
+
+#[test]
+fn test_create_stream_rejects_cliff_after_end() {
+    let ctx = Ctx::setup();
+    let recipient = Address::generate(&ctx.env);
+    ctx.factory.set_allowlist(&recipient, &true);
+    let now = ctx.now();
+
+    let result = ctx.factory.try_create_stream(
+        &ctx.sender,
+        &recipient,
+        &1_000,
+        &1,
+        &now,
+        &(now + 300),
+        &(now + 200),
+        &0,
+    );
+    assert_eq!(result, Err(Ok(FactoryError::InvalidCliff)));
+}
+
+// ---------------------------------------------------------------------------
 // NotInitialized
 // ---------------------------------------------------------------------------
 

--- a/docs/factory.md
+++ b/docs/factory.md
@@ -10,6 +10,19 @@ The `fluxora_factory` acts as a proxy entrypoint to enforce these policies:
 - **Recipient Allowlist**: Streams can only be created for recipients explicitly allowlisted by the admin.
 - **Deposit Caps**: Enforces a `MaxDepositCap` on the total `deposit_amount` of a single stream.
 - **Minimum Duration**: Enforces a `MinDuration` (i.e. `end_time - start_time >= min_duration`), preventing overly short or instantaneous streams.
+- **Time Relationship Checks**: Rejects invalid schedules before calling `FluxoraStream`. `start_time` must be strictly less than `end_time`, and `cliff_time` must be within the inclusive `[start_time, end_time]` window.
+
+## Time Validation
+
+The factory mirrors the underlying stream contract's creation-time schedule invariants and returns typed factory errors before making the cross-contract call:
+
+| Condition | Error |
+|-----------|-------|
+| `start_time >= end_time` | `FactoryError::InvalidTimeRange` |
+| `cliff_time < start_time` | `FactoryError::InvalidCliff` |
+| `cliff_time > end_time` | `FactoryError::InvalidCliff` |
+
+These checks keep invalid treasury requests on the factory error surface instead of relying on downstream stream-contract panics.
 
 ## Important Bypass Warning
 
@@ -21,7 +34,7 @@ The `fluxora_factory` acts as a proxy entrypoint to enforce these policies:
 ## Architecture & CEI
 
 The factory contract follows the Checks-Effects-Interactions (CEI) pattern implicitly:
-1. **Checks**: Validates the recipient against the allowlist, and bounds the deposit and duration against the configured caps.
+1. **Checks**: Validates the recipient against the allowlist, validates the stream time relationship, and bounds the deposit and duration against the configured caps.
 2. **Effects**: No local persistent state changes occur during a successful stream creation.
 3. **Interactions**: Makes a cross-contract call to `FluxoraStream::create_stream`.
 


### PR DESCRIPTION
## Summary
- Adds typed factory-layer schedule validation before forwarding to `FluxoraStream`.
- Rejects `start_time >= end_time` with `FactoryError::InvalidTimeRange`.
- Rejects `cliff_time` outside `[start_time, end_time]` with `FactoryError::InvalidCliff`.
- Replaces the duration `saturating_sub` path with ordinary subtraction after the explicit range guard.
- Documents the factory time checks in `docs/factory.md`.

## Security notes
- Invalid treasury schedules now fail before the cross-contract call, avoiding downstream stream-contract panic handling for these cases.
- The checks mirror the underlying stream contract invariants and do not reject valid schedules where `start_time < end_time` and `cliff_time` is within the inclusive range.

## Tests
- `rustfmt --edition 2021 --check contracts/factory/src/lib.rs contracts/stream/tests/factory_policy.rs`
- `git diff --check`

## Local test blocker
- `cargo test -p fluxora_stream --test factory_policy` could not run to completion in this Windows environment because the MSVC linker is unavailable: `linker link.exe not found`.
- I also tried the local GNU and gnullvm Rust toolchains; GNU reached dependency compilation but `dlltool` failed creating import libraries, and gnullvm reported missing `x86_64-w64-mingw32-clang`.

Closes #655