### PR TITLE
feat(factory): expose policy config views

### DIFF
--- a/contracts/factory/src/lib.rs
+++ b/contracts/factory/src/lib.rs
@@ -24,6 +24,16 @@ pub enum DataKey {
     Allowlist(Address),
 }
 
+/// Read-only snapshot of the factory policy stored in instance storage.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct FactoryConfig {
+    pub admin: Address,
+    pub stream_contract: Address,
+    pub max_deposit: i128,
+    pub min_duration: u64,
+}
+
 #[contract]
 pub struct FluxoraFactory;
 
@@ -131,6 +141,40 @@ impl FluxoraFactory {
             .instance()
             .set(&DataKey::MinDuration, &min_duration);
         Ok(())
+    }
+
+    /// Return the current factory policy configuration.
+    pub fn get_factory_config(env: Env) -> Result<FactoryConfig, FactoryError> {
+        Ok(FactoryConfig {
+            admin: env
+                .storage()
+                .instance()
+                .get(&DataKey::Admin)
+                .ok_or(FactoryError::NotInitialized)?,
+            stream_contract: env
+                .storage()
+                .instance()
+                .get(&DataKey::StreamContract)
+                .ok_or(FactoryError::NotInitialized)?,
+            max_deposit: env
+                .storage()
+                .instance()
+                .get(&DataKey::MaxDepositCap)
+                .ok_or(FactoryError::NotInitialized)?,
+            min_duration: env
+                .storage()
+                .instance()
+                .get(&DataKey::MinDuration)
+                .ok_or(FactoryError::NotInitialized)?,
+        })
+    }
+
+    /// Return whether `recipient` is currently allowlisted for factory-created streams.
+    pub fn is_allowlisted(env: Env, recipient: Address) -> bool {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Allowlist(recipient))
+            .unwrap_or(false)
     }
 
     /// Creates a new stream via the FluxoraStream contract after enforcing treasury policies.

--- a/contracts/stream/tests/factory_policy.rs
+++ b/contracts/stream/tests/factory_policy.rs
@@ -258,6 +258,58 @@ fn test_factory_not_initialized_returns_error() {
     assert_eq!(result, Err(Ok(FactoryError::NotInitialized)));
 }
 
+#[test]
+fn test_get_factory_config_before_init_returns_not_initialized() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let factory_id = env.register_contract(None, FluxoraFactory);
+    let factory = FluxoraFactoryClient::new(&env, &factory_id);
+
+    let result = factory.try_get_factory_config();
+    assert_eq!(result, Err(Ok(FactoryError::NotInitialized)));
+}
+
+// ---------------------------------------------------------------------------
+// Read-only policy views
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_get_factory_config_returns_current_policy() {
+    let ctx = Ctx::setup();
+
+    let config = ctx.factory.get_factory_config();
+    assert_eq!(config.admin, ctx.admin);
+    assert_eq!(config.max_deposit, 10_000);
+    assert_eq!(config.min_duration, 100);
+
+    let new_admin = Address::generate(&ctx.env);
+    let new_stream_contract = Address::generate(&ctx.env);
+    ctx.factory.set_admin(&new_admin);
+    ctx.factory.set_stream_contract(&new_stream_contract);
+    ctx.factory.set_cap(&5_000);
+    ctx.factory.set_min_duration(&500);
+
+    let updated = ctx.factory.get_factory_config();
+    assert_eq!(updated.admin, new_admin);
+    assert_eq!(updated.stream_contract, new_stream_contract);
+    assert_eq!(updated.max_deposit, 5_000);
+    assert_eq!(updated.min_duration, 500);
+}
+
+#[test]
+fn test_is_allowlisted_reflects_allowlist_state() {
+    let ctx = Ctx::setup();
+    let recipient = Address::generate(&ctx.env);
+
+    assert!(!ctx.factory.is_allowlisted(&recipient));
+
+    ctx.factory.set_allowlist(&recipient, &true);
+    assert!(ctx.factory.is_allowlisted(&recipient));
+
+    ctx.factory.set_allowlist(&recipient, &false);
+    assert!(!ctx.factory.is_allowlisted(&recipient));
+}
+
 // ---------------------------------------------------------------------------
 // Policy update guards
 // ---------------------------------------------------------------------------

--- a/docs/factory.md
+++ b/docs/factory.md
@@ -11,6 +11,17 @@ The `fluxora_factory` acts as a proxy entrypoint to enforce these policies:
 - **Deposit Caps**: Enforces a `MaxDepositCap` on the total `deposit_amount` of a single stream.
 - **Minimum Duration**: Enforces a `MinDuration` (i.e. `end_time - start_time >= min_duration`), preventing overly short or instantaneous streams.
 
+## Read-Only Views
+
+The factory exposes read-only views so UIs, operators, and indexers can inspect policy before routing treasury activity through the wrapper.
+
+| View | Returns | Notes |
+|------|---------|-------|
+| `get_factory_config()` | `FactoryConfig { admin, stream_contract, max_deposit, min_duration }` | Reads all instance policy fields. Returns `FactoryError::NotInitialized` before `init`. |
+| `is_allowlisted(recipient)` | `bool` | Returns `true` only when the recipient currently has an allowlist entry. Missing entries return `false`. |
+
+These views are permissionless and do not mutate factory state.
+
 ## Important Bypass Warning
 
 > [!WARNING]


### PR DESCRIPTION
## Summary
- Adds a `FactoryConfig` contract type for the factory policy snapshot.
- Adds `get_factory_config()` returning admin, stream contract, max deposit, and minimum duration.
- Adds `is_allowlisted(recipient)` returning the current allowlist state.
- Documents the new read-only views in `docs/factory.md`.

## Security notes
- Both views are read-only and permissionless.
- `get_factory_config()` returns `FactoryError::NotInitialized` before `init` so callers do not receive partial policy data.
- `is_allowlisted()` defaults to `false` for missing recipient entries.

## Tests
- `rustfmt --edition 2021 --check contracts/factory/src/lib.rs contracts/stream/tests/factory_policy.rs`
- `git diff --check`

## Local test blocker
- `cargo test -p fluxora_stream --test factory_policy` could not run to completion in this Windows environment because the MSVC linker is unavailable: `linker link.exe not found`.

Closes #639