### PR TITLE
refactor(factory): centralize admin auth helper

### DIFF
--- a/contracts/factory/src/lib.rs
+++ b/contracts/factory/src/lib.rs
@@ -24,6 +24,20 @@ pub enum DataKey {
     Allowlist(Address),
 }
 
+/// Load and authorize the current factory admin.
+///
+/// This is the single authorization chokepoint for admin-only factory setters.
+/// It preserves the existing `NotInitialized` behavior before attempting auth.
+fn require_admin(env: &Env) -> Result<Address, FactoryError> {
+    let admin: Address = env
+        .storage()
+        .instance()
+        .get(&DataKey::Admin)
+        .ok_or(FactoryError::NotInitialized)?;
+    admin.require_auth();
+    Ok(admin)
+}
+
 #[contract]
 pub struct FluxoraFactory;
 
@@ -58,12 +72,7 @@ impl FluxoraFactory {
 
     /// Admin updates the factory admin.
     pub fn set_admin(env: Env, new_admin: Address) -> Result<(), FactoryError> {
-        let admin: Address = env
-            .storage()
-            .instance()
-            .get(&DataKey::Admin)
-            .ok_or(FactoryError::NotInitialized)?;
-        admin.require_auth();
+        require_admin(&env)?;
 
         env.storage().instance().set(&DataKey::Admin, &new_admin);
         Ok(())
@@ -71,12 +80,7 @@ impl FluxoraFactory {
 
     /// Admin updates the stream contract address.
     pub fn set_stream_contract(env: Env, new_stream_contract: Address) -> Result<(), FactoryError> {
-        let admin: Address = env
-            .storage()
-            .instance()
-            .get(&DataKey::Admin)
-            .ok_or(FactoryError::NotInitialized)?;
-        admin.require_auth();
+        require_admin(&env)?;
 
         env.storage()
             .instance()
@@ -86,12 +90,7 @@ impl FluxoraFactory {
 
     /// Admin adds or removes a recipient from the allowlist.
     pub fn set_allowlist(env: Env, recipient: Address, allowed: bool) -> Result<(), FactoryError> {
-        let admin: Address = env
-            .storage()
-            .instance()
-            .get(&DataKey::Admin)
-            .ok_or(FactoryError::NotInitialized)?;
-        admin.require_auth();
+        require_admin(&env)?;
 
         let key = DataKey::Allowlist(recipient);
         if allowed {
@@ -105,12 +104,7 @@ impl FluxoraFactory {
 
     /// Admin updates the max deposit cap.
     pub fn set_cap(env: Env, max_deposit: i128) -> Result<(), FactoryError> {
-        let admin: Address = env
-            .storage()
-            .instance()
-            .get(&DataKey::Admin)
-            .ok_or(FactoryError::NotInitialized)?;
-        admin.require_auth();
+        require_admin(&env)?;
 
         env.storage()
             .instance()
@@ -120,12 +114,7 @@ impl FluxoraFactory {
 
     /// Admin updates the minimum stream duration.
     pub fn set_min_duration(env: Env, min_duration: u64) -> Result<(), FactoryError> {
-        let admin: Address = env
-            .storage()
-            .instance()
-            .get(&DataKey::Admin)
-            .ok_or(FactoryError::NotInitialized)?;
-        admin.require_auth();
+        require_admin(&env)?;
 
         env.storage()
             .instance()

--- a/contracts/stream/tests/factory_policy.rs
+++ b/contracts/stream/tests/factory_policy.rs
@@ -6,9 +6,9 @@
 use fluxora_factory::{FactoryError, FluxoraFactory, FluxoraFactoryClient};
 use fluxora_stream::{FluxoraStream, FluxoraStreamClient};
 use soroban_sdk::{
-    testutils::Address as _,
+    testutils::{Address as _, MockAuth, MockAuthInvoke},
     token::{Client as TokenClient, StellarAssetClient},
-    Address, Env,
+    Address, Env, IntoVal,
 };
 use std::panic::AssertUnwindSafe;
 
@@ -114,6 +114,84 @@ fn test_set_admin_requires_existing_admin() {
     let na2 = Address::generate(&env2);
     f2.init(&a2, &sc2, &10_000, &100);
     f2.set_admin(&na2); // succeeds with mock_all_auths
+}
+
+#[test]
+fn test_factory_setters_reject_non_admin_callers() {
+    fn expect_rejected<F>(call: F)
+    where
+        F: FnOnce(),
+    {
+        let result = std::panic::catch_unwind(AssertUnwindSafe(call));
+        assert!(result.is_err(), "non-admin setter call must fail auth");
+    }
+
+    let env = Env::default();
+    let factory_id = env.register_contract(None, FluxoraFactory);
+    let factory = FluxoraFactoryClient::new(&env, &factory_id);
+    let admin = Address::generate(&env);
+    let non_admin = Address::generate(&env);
+    let stream_contract = Address::generate(&env);
+    let new_admin = Address::generate(&env);
+    let new_stream_contract = Address::generate(&env);
+    let recipient = Address::generate(&env);
+
+    factory.init(&admin, &stream_contract, &10_000, &100);
+
+    env.mock_auths(&[MockAuth {
+        address: &non_admin,
+        invoke: &MockAuthInvoke {
+            contract: &factory_id,
+            fn_name: "set_admin",
+            args: (&new_admin,).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+    expect_rejected(|| factory.set_admin(&new_admin));
+
+    env.mock_auths(&[MockAuth {
+        address: &non_admin,
+        invoke: &MockAuthInvoke {
+            contract: &factory_id,
+            fn_name: "set_stream_contract",
+            args: (&new_stream_contract,).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+    expect_rejected(|| factory.set_stream_contract(&new_stream_contract));
+
+    env.mock_auths(&[MockAuth {
+        address: &non_admin,
+        invoke: &MockAuthInvoke {
+            contract: &factory_id,
+            fn_name: "set_allowlist",
+            args: (&recipient, true).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+    expect_rejected(|| factory.set_allowlist(&recipient, &true));
+
+    env.mock_auths(&[MockAuth {
+        address: &non_admin,
+        invoke: &MockAuthInvoke {
+            contract: &factory_id,
+            fn_name: "set_cap",
+            args: (5_000i128,).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+    expect_rejected(|| factory.set_cap(&5_000));
+
+    env.mock_auths(&[MockAuth {
+        address: &non_admin,
+        invoke: &MockAuthInvoke {
+            contract: &factory_id,
+            fn_name: "set_min_duration",
+            args: (500u64,).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+    expect_rejected(|| factory.set_min_duration(&500));
 }
 
 // ---------------------------------------------------------------------------
@@ -256,6 +334,36 @@ fn test_factory_not_initialized_returns_error() {
         &0,
     );
     assert_eq!(result, Err(Ok(FactoryError::NotInitialized)));
+}
+
+#[test]
+fn test_factory_setters_before_init_return_not_initialized() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let factory_id = env.register_contract(None, FluxoraFactory);
+    let factory = FluxoraFactoryClient::new(&env, &factory_id);
+    let address = Address::generate(&env);
+
+    assert_eq!(
+        factory.try_set_admin(&address),
+        Err(Ok(FactoryError::NotInitialized))
+    );
+    assert_eq!(
+        factory.try_set_stream_contract(&address),
+        Err(Ok(FactoryError::NotInitialized))
+    );
+    assert_eq!(
+        factory.try_set_allowlist(&address, &true),
+        Err(Ok(FactoryError::NotInitialized))
+    );
+    assert_eq!(
+        factory.try_set_cap(&1_000),
+        Err(Ok(FactoryError::NotInitialized))
+    );
+    assert_eq!(
+        factory.try_set_min_duration(&100),
+        Err(Ok(FactoryError::NotInitialized))
+    );
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Adds a private `require_admin(&Env)` helper in `fluxora_factory`.
- Routes all five admin-only setters through the helper: `set_admin`, `set_stream_contract`, `set_allowlist`, `set_cap`, and `set_min_duration`.
- Preserves the existing `FactoryError::NotInitialized` path before auth is attempted.
- Adds tests covering non-admin rejection across all five setters and the uninitialized error path.

## Security notes
- This keeps the same admin auth requirement while making the authorization boundary easier to audit.
- No storage layout, public ABI, or policy behavior changes are intended.

## Tests
- `rustfmt --edition 2021 --check contracts/factory/src/lib.rs contracts/stream/tests/factory_policy.rs`
- `git diff --check`

## Local test blocker
- `cargo test -p fluxora_stream --test factory_policy` could not run to completion in this Windows environment because the MSVC linker is unavailable: `linker link.exe not found`.

Closes #642