### PR TITLE
feat(governance): expose proposal count view

### DIFF
--- a/contracts/governance/src/lib.rs
+++ b/contracts/governance/src/lib.rs
@@ -519,6 +519,15 @@ impl FluxoraGovernance {
         load_proposal(&env, proposal_id)
     }
 
+    /// Return the number of proposals created so far.
+    ///
+    /// Proposal IDs are assigned densely starting at 0, so this is also the
+    /// exclusive upper bound for enumerating proposals by ID.
+    pub fn proposal_count(env: Env) -> u32 {
+        bump_instance(&env);
+        read_next_proposal_id(&env)
+    }
+
     /// Return the list of registered co-signers.
     pub fn get_signers(env: Env) -> Result<Vec<Address>, GovernanceError> {
         get_signers(&env)

--- a/contracts/stream/tests/governance_integration.rs
+++ b/contracts/stream/tests/governance_integration.rs
@@ -95,11 +95,19 @@ fn test_propose_returns_incremental_ids() {
     let ctx = GovCtx::setup();
     let target = ctx.dummy_target();
 
-    let id0 = ctx.client.propose(&ctx.signer_a, &target, &ctx.calldata("call0"));
-    let id1 = ctx.client.propose(&ctx.signer_b, &target, &ctx.calldata("call1"));
+    assert_eq!(ctx.client.proposal_count(), 0);
 
+    let id0 = ctx.client.propose(&ctx.signer_a, &target, &ctx.calldata("call0"));
     assert_eq!(id0, 0);
+    assert_eq!(ctx.client.proposal_count(), 1);
+
+    let id1 = ctx.client.propose(&ctx.signer_b, &target, &ctx.calldata("call1"));
     assert_eq!(id1, 1);
+    assert_eq!(ctx.client.proposal_count(), 2);
+
+    let id2 = ctx.client.propose(&ctx.signer_c, &target, &ctx.calldata("call2"));
+    assert_eq!(id2, 2);
+    assert_eq!(ctx.client.proposal_count(), 3);
 }
 
 #[test]

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -86,6 +86,12 @@ Marks the proposal as executed and emits `ProposalExecuted`.
 - The `ProposalExecuted` event contains `target` and `calldata` so that off-chain
   bots or authorised executors can apply the change to the factory.
 
+### `proposal_count() -> u32`
+
+Returns the number of proposals created so far. Proposal IDs are assigned densely
+from `0`, so off-chain indexers can enumerate proposals by scanning
+`0..proposal_count()` and calling `get_proposal(proposal_id)` for each ID.
+
 ## Integration with the factory
 
 The `FluxoraFactory` contract stores `max_deposit`, `min_duration`, and the allowlist as


### PR DESCRIPTION
## Summary
- add `proposal_count()` to return the maintained next proposal id / total proposal count
- extend governance integration coverage to assert dense proposal IDs `0, 1, 2` and count updates after each proposal
- document enumerating proposals via `0..proposal_count()` plus `get_proposal(id)`

Closes #658

## Testing
- `git diff --check`
- `cargo test -p fluxora_governance` *(blocked locally: Windows MSVC target cannot find `link.exe` before project tests compile)*
- `cargo fmt --all -- --check` *(blocked by pre-existing parse errors in `contracts/stream/src/test.rs` on `&None,,`; also reports existing formatting drift in governance files)*