### PR TITLE
fix(governance): reject duplicate signers

### DIFF
--- a/contracts/governance/src/lib.rs
+++ b/contracts/governance/src/lib.rs
@@ -75,6 +75,8 @@ pub enum GovernanceError {
     CalldataTooLarge = 10,
     /// Signer list exceeds MAX_SIGNERS.
     TooManySigners = 11,
+    /// Signer is already registered in the co-signer set.
+    DuplicateSigner = 12,
 }
 
 /// Storage keys for the governance contract.
@@ -219,11 +221,12 @@ impl FluxoraGovernance {
     /// # Parameters
     /// - `admin`: Address that can add/remove signers and reset governance state.
     /// - `signers`: Initial list of co-signers eligible to approve proposals.
-    ///   Must not exceed `MAX_SIGNERS`.
+    ///   Must not exceed `MAX_SIGNERS` and must not contain duplicates.
     ///
     /// # Errors
     /// - `AlreadyInitialized`: Contract has already been initialised.
     /// - `TooManySigners`: Provided signer list exceeds `MAX_SIGNERS`.
+    /// - `DuplicateSigner`: Provided signer list contains the same address twice.
     pub fn init(
         env: Env,
         admin: Address,
@@ -235,6 +238,7 @@ impl FluxoraGovernance {
         if signers.len() > MAX_SIGNERS {
             return Err(GovernanceError::TooManySigners);
         }
+        Self::require_unique_signers(&signers)?;
 
         env.storage().instance().set(&DataKey::Admin, &admin);
         env.storage().instance().set(&DataKey::Signers, &signers);
@@ -257,14 +261,20 @@ impl FluxoraGovernance {
 
     /// Add a co-signer to the governance set.
     ///
+    /// The signer set is unique: an address may occupy at most one co-signer slot.
+    ///
     /// # Authorization
     /// - Requires admin signature.
     ///
     /// # Errors
     /// - `TooManySigners`: Adding this signer would exceed `MAX_SIGNERS`.
+    /// - `DuplicateSigner`: `signer` is already registered.
     pub fn add_signer(env: Env, signer: Address) -> Result<(), GovernanceError> {
         get_admin(&env)?.require_auth();
         let mut signers = get_signers(&env)?;
+        if Self::is_signer(&signers, &signer) {
+            return Err(GovernanceError::DuplicateSigner);
+        }
         if signers.len() >= MAX_SIGNERS {
             return Err(GovernanceError::TooManySigners);
         }
@@ -545,5 +555,17 @@ impl FluxoraGovernance {
             }
         }
         false
+    }
+
+    fn require_unique_signers(signers: &Vec<Address>) -> Result<(), GovernanceError> {
+        for i in 0..signers.len() {
+            let signer = signers.get(i).unwrap();
+            for j in (i + 1)..signers.len() {
+                if signers.get(j).unwrap() == signer {
+                    return Err(GovernanceError::DuplicateSigner);
+                }
+            }
+        }
+        Ok(())
     }
 }

--- a/contracts/stream/tests/governance_integration.rs
+++ b/contracts/stream/tests/governance_integration.rs
@@ -80,6 +80,23 @@ fn test_init_twice_errors() {
 }
 
 #[test]
+fn test_init_duplicate_signers_errors() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, FluxoraGovernance);
+    let client = FluxoraGovernanceClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let signer = Address::generate(&env);
+    let result = client.try_init(
+        &admin,
+        &vec![&env, signer.clone(), signer],
+    );
+
+    assert_eq!(result, Err(Ok(GovernanceError::DuplicateSigner)));
+}
+
+#[test]
 fn test_quorum_and_timelock_constants() {
     let ctx = GovCtx::setup();
     assert_eq!(ctx.client.quorum(), 2);
@@ -302,6 +319,14 @@ fn test_add_remove_signer() {
     ctx.client.remove_signer(&new_signer);
     let signers = ctx.client.get_signers();
     assert_eq!(signers.len(), 3);
+}
+
+#[test]
+fn test_add_duplicate_signer_errors() {
+    let ctx = GovCtx::setup();
+    let result = ctx.client.try_add_signer(&ctx.signer_a);
+
+    assert_eq!(result, Err(Ok(GovernanceError::DuplicateSigner)));
 }
 
 #[test]

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -32,6 +32,9 @@ A fixed set of addresses registered by the admin. Co-signers can:
 - Submit proposals (`propose`).
 - Approve existing proposals (`approve`).
 
+Each co-signer address may appear only once. `init` and `add_signer` reject duplicate
+addresses with `DuplicateSigner` so quorum calculations are based on unique keys.
+
 ## Lifecycle of a proposal
 
 ```
@@ -126,13 +129,14 @@ All storage keys are defined in `DataKey`:
 
 1. **No self-approval shortcut**: The proposer must call `approve` separately.
 2. **Duplicate approval prevention**: Each signer may approve at most once per proposal.
-3. **Timelock protects against rushed execution**: Even with instant quorum, changes
+3. **Duplicate signer prevention**: A co-signer address can only occupy one signer slot.
+4. **Timelock protects against rushed execution**: Even with instant quorum, changes
    cannot take effect for at least `GOVERNANCE_TIMELOCK_SECONDS` (48 h).
-4. **Executed proposals are immutable**: Once `executed = true`, no further approvals or
+5. **Executed proposals are immutable**: Once `executed = true`, no further approvals or
    re-execution are possible.
-5. **Admin cannot bypass the process**: The admin can only add/remove signers and rotate
+6. **Admin cannot bypass the process**: The admin can only add/remove signers and rotate
    the admin key; parameter changes still require quorum.
-6. **CEI ordering in `execute`**: The proposal is marked as executed and state is written
+7. **CEI ordering in `execute`**: The proposal is marked as executed and state is written
    before the `ProposalExecuted` event, preventing re-entrancy from the event handler.
 
 ## Tests
@@ -140,6 +144,7 @@ All storage keys are defined in `DataKey`:
 Integration tests are in `contracts/stream/tests/governance_integration.rs` and cover:
 
 - Initialization and constant verification
+- Duplicate signer rejection during initialization and signer management
 - Proposal creation and ID assignment
 - Approval counting and duplicate rejection
 - Non-signer rejection on both propose and approve


### PR DESCRIPTION
## Summary
- add `GovernanceError::DuplicateSigner` with a fresh append-only discriminant
- reject duplicate co-signers during `init` and `add_signer`
- cover duplicate init/add cases in the existing governance integration tests and document the invariant

Closes #634

## Testing
- `git diff --check`
- `cargo test -p fluxora_stream --test governance_integration` *(blocked locally: Windows MSVC target cannot find `link.exe` before project tests compile)*
- `rustfmt --edition 2021 --check contracts/governance/src/lib.rs contracts/stream/tests/governance_integration.rs` *(reports pre-existing formatting drift in these files under the pinned 1.94.1 rustfmt)*