### PR TITLE
ci: pin rust toolchain version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.94.1
         with:
           components: rustfmt, clippy
 
@@ -89,7 +89,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.94.1
         with:
           targets: wasm32-unknown-unknown
 
@@ -168,7 +168,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.94.1
 
       - name: Cache cargo registry
         uses: actions/cache@v4
@@ -223,7 +223,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.94.1
 
       - name: Cache cargo registry
         uses: actions/cache@v4


### PR DESCRIPTION
## Summary
- replace floating `dtolnay/rust-toolchain@stable` in CI with the repository-pinned `dtolnay/rust-toolchain@1.94.1`
- keep existing lint components (`rustfmt`, `clippy`) and WASM target installation unchanged

Closes #611

## Testing
- `git diff --check`
- `rg -n "dtolnay/rust-toolchain|rust-toolchain@stable|rust-toolchain@1\.94\.1|components:|targets:" .github/workflows/ci.yml rust-toolchain.toml`