### PR TITLE
docs(factory): document cross-contract authorization model

### DIFF
--- a/docs/factory.md
+++ b/docs/factory.md
@@ -25,7 +25,84 @@ The factory contract follows the Checks-Effects-Interactions (CEI) pattern impli
 2. **Effects**: No local persistent state changes occur during a successful stream creation.
 3. **Interactions**: Makes a cross-contract call to `FluxoraStream::create_stream`.
 
-The sender must authorize the invocation. The factory passes the sender to the stream contract, requiring the sender to also authorize the cross-contract call.
+## Cross-contract authorization model
+
+Factory-routed creation has one client-facing entrypoint, but the sender authorization
+must cover both the wrapper call and the nested stream call:
+
+```mermaid
+flowchart TD
+    client[Client transaction]
+    factory["fluxora_factory.create_stream(sender, recipient, deposit, rate, start, cliff, end, dust_threshold)"]
+    stream["fluxora_stream.create_stream(sender, recipient, deposit, rate, start, cliff, end, dust_threshold, None, Linear)"]
+    token["token.transfer_from(sender -> fluxora_stream, deposit)"]
+
+    client --> factory
+    factory --> stream
+    stream --> token
+```
+
+The required authorization scopes are:
+
+| Signer | Scope | Why it is required |
+| --- | --- | --- |
+| `sender` | `fluxora_factory.create_stream(...)` with the exact wrapper arguments | `FluxoraFactory::create_stream` calls `sender.require_auth()` after policy checks pass. |
+| `sender` | Nested `fluxora_stream.create_stream(...)` with the exact stream arguments the factory forwards | `FluxoraStream::create_stream` also calls `sender.require_auth()` before validating and pulling the deposit. |
+
+This is not two independent user intents. A client should build the Soroban
+authorization tree so the `sender` signs the factory invocation and its
+`fluxora_stream.create_stream` sub-invocation in the same transaction. The nested
+scope is intentionally narrow: it authorizes only the exact stream creation that
+the factory forwards after enforcing recipient, cap, and duration policy.
+
+The stream contract, not the factory, pulls `deposit_amount` from `sender` into
+the stream contract during `fluxora_stream.create_stream`. The factory never
+custodies the sender's tokens and has no standing privilege to spend sender
+funds. If a later transaction tries to reuse the factory or a changed set of
+arguments, the sender must authorize that new invocation tree again.
+
+### Worked client-signing example
+
+Assume a treasury UI wants to create this routed stream:
+
+```text
+sender = G_SENDER
+recipient = G_RECIPIENT
+deposit_amount = 1_000
+rate_per_second = 1
+start_time = 1_800_000_000
+cliff_time = 1_800_000_000
+end_time = 1_800_001_000
+withdraw_dust_threshold = 0
+```
+
+The client prepares a transaction whose root host function invokes
+`fluxora_factory.create_stream` with those values. During simulation/preparation,
+the authorization tree must contain `G_SENDER` for the root factory call and the
+nested `fluxora_stream.create_stream` sub-invocation with:
+
+```text
+memo = None
+kind = Linear
+```
+
+`G_SENDER` signs that prepared authorization tree. The factory admin does not
+sign stream creation unless the admin is also the `sender`. The recipient does
+not sign creation. The recipient signs only later recipient-controlled actions
+such as `withdraw` or `withdraw_to`.
+
+### Single-auth vs dual-scope auth
+
+For UI and wallet copy, describe the flow as "one sender signing session with two
+scopes" rather than "two unrelated signatures":
+
+1. The factory scope lets the sender opt into the treasury policy wrapper.
+2. The stream scope lets the stream contract create the stream and pull exactly
+   the authorized deposit from the sender.
+
+If the client omits either scope, the transaction fails at the corresponding
+`require_auth` call. If the sub-invocation arguments differ from the signed
+arguments, the nested authorization is not valid for that call.
 
 ## Admin Controls
 
@@ -34,3 +111,22 @@ The factory has an `Admin` key managed via `set_admin`. The admin can:
 - Call `set_cap` to update the max deposit limit.
 - Call `set_min_duration` to update the minimum duration requirement.
 - Call `set_stream_contract` to upgrade or switch the underlying stream primitive if a new version is deployed.
+
+The factory admin can shape policy and the target stream contract, but cannot
+spend sender funds by itself. A factory-routed stream still needs the `sender`
+authorization described above, and the underlying stream contract still enforces
+its own authorization table. See the [`docs/security.md` admin powers
+section](security.md#admin-powers) for the protocol-wide admin boundary.
+
+## Code alignment checklist
+
+This document is aligned with the current implementation as follows:
+
+- `FluxoraFactory::create_stream` enforces allowlist, cap, and duration checks
+  before calling `sender.require_auth()`.
+- The factory forwards a linear `FluxoraStream::create_stream` call with
+  `memo = None` and `StreamKind::Linear`.
+- `FluxoraStream::create_stream` calls `sender.require_auth()` before validating
+  parameters and pulling `deposit_amount` from `sender`.
+- `contracts/stream/tests/factory_policy.rs` covers the factory policy gates and
+  admin-guarded policy updates that surround this authorization model.

--- a/docs/security.md
+++ b/docs/security.md
@@ -168,6 +168,22 @@ reentrancy impact — state will already reflect the current operation when the 
 | `set_contract_paused`     | Contract admin                                          |
 | `transfer_sender`         | Current stream sender                                   |
 
+## Admin powers
+
+The stream contract admin can rotate the admin key, set governance-controlled
+limits, pause or resume protocol operations, and use the explicit
+`*_as_admin` stream controls listed in the authorization table above. These
+powers do not replace sender or recipient authorization: stream creation still
+requires the supplied `sender`, withdrawals still require the recipient, and
+top-ups still require the supplied `funder`.
+
+The optional factory wrapper has its own admin for allowlists, deposit caps,
+minimum duration, and the configured stream-contract address. Factory policy
+changes can decide whether a routed creation is accepted, but they do not give
+the factory admin custody of sender funds. See the
+[`fluxora_factory` authorization model](factory.md#cross-contract-authorization-model)
+for the exact factory-to-stream signing tree.
+
 Cancellation-specific boundary checks:
 
 1. Sender path (`cancel_stream`) cannot be executed by recipient or third party.


### PR DESCRIPTION
Closes #648

## Summary
- document the client -> factory.create_stream -> stream.create_stream invocation tree
- spell out the sender authorization scopes for both the wrapper call and nested stream call
- clarify that the factory never custodies sender funds and cannot spend without explicit sender authorization
- add a `docs/security.md` admin-powers anchor and cross-link it from the factory guide

## Verification
- `git diff --check` passed
- Confirmed the documentation against `contracts/factory/src/lib.rs` and `contracts/stream/src/lib.rs`: both factory and stream creation paths call `sender.require_auth()`, and the stream contract pulls `deposit_amount` from `sender`
- `cargo test --test factory_policy` attempted with the pinned Rust 1.94.1 toolchain from `E:\codex-tools`, but this Windows environment is missing native linker components (`link.exe`/Windows SDK libs; GNU path also lacks `dlltool.exe`, gnullvm path lacks `x86_64-w64-mingw32-clang`). No test assertion failures were reached.

## Security notes
- The doc describes one sender signing session with two authorization scopes, not two unrelated intents.
- The nested authorization is limited to the exact stream creation sub-invocation forwarded by the factory.
- Factory admin policy powers are explicitly separated from sender fund movement.