### PR TITLE
feat(factory): validate policy parameters

### DIFF
--- a/contracts/factory/src/lib.rs
+++ b/contracts/factory/src/lib.rs
@@ -17,7 +17,20 @@ pub enum FactoryError {
     InvalidTimeRange = 7,
     /// The requested cliff must be within the inclusive start/end window.
     InvalidCliff = 8,
+    /// The maximum deposit cap must be strictly positive.
+    InvalidCap = 9,
+    /// The minimum duration must be within the documented factory policy range.
+    InvalidMinDuration = 10,
 }
+
+/// Minimum stream duration accepted by factory policy setters, in seconds.
+pub const MIN_FACTORY_DURATION_SECONDS: u64 = 1;
+
+/// Maximum stream duration accepted by factory policy setters, in seconds.
+///
+/// This ten-year ceiling prevents accidentally storing absurd policy values
+/// that would make factory-routed streams impossible for normal treasury use.
+pub const MAX_FACTORY_DURATION_SECONDS: u64 = 10 * 365 * 24 * 60 * 60;
 
 #[contracttype]
 pub enum DataKey {
@@ -42,6 +55,20 @@ fn require_admin(env: &Env) -> Result<Address, FactoryError> {
     Ok(admin)
 }
 
+fn validate_max_deposit(max_deposit: i128) -> Result<(), FactoryError> {
+    if max_deposit <= 0 {
+        return Err(FactoryError::InvalidCap);
+    }
+    Ok(())
+}
+
+fn validate_min_duration(min_duration: u64) -> Result<(), FactoryError> {
+    if !(MIN_FACTORY_DURATION_SECONDS..=MAX_FACTORY_DURATION_SECONDS).contains(&min_duration) {
+        return Err(FactoryError::InvalidMinDuration);
+    }
+    Ok(())
+}
+
 /// Read-only snapshot of the factory policy stored in instance storage.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -59,6 +86,9 @@ pub struct FluxoraFactory;
 #[allow(clippy::too_many_arguments)]
 impl FluxoraFactory {
     /// Initialize the factory with admin, stream contract, and policies.
+    ///
+    /// `max_deposit` must be greater than zero. `min_duration` must be between
+    /// `MIN_FACTORY_DURATION_SECONDS` and `MAX_FACTORY_DURATION_SECONDS`, inclusive.
     pub fn init(
         env: Env,
         admin: Address,
@@ -69,6 +99,8 @@ impl FluxoraFactory {
         if env.storage().instance().has(&DataKey::Admin) {
             return Err(FactoryError::AlreadyInitialized);
         }
+        validate_max_deposit(max_deposit)?;
+        validate_min_duration(min_duration)?;
 
         env.storage().instance().set(&DataKey::Admin, &admin);
         env.storage()
@@ -117,8 +149,11 @@ impl FluxoraFactory {
     }
 
     /// Admin updates the max deposit cap.
+    ///
+    /// `max_deposit` must be greater than zero.
     pub fn set_cap(env: Env, max_deposit: i128) -> Result<(), FactoryError> {
         require_admin(&env)?;
+        validate_max_deposit(max_deposit)?;
 
         env.storage()
             .instance()
@@ -127,8 +162,12 @@ impl FluxoraFactory {
     }
 
     /// Admin updates the minimum stream duration.
+    ///
+    /// `min_duration` must be between `MIN_FACTORY_DURATION_SECONDS` and
+    /// `MAX_FACTORY_DURATION_SECONDS`, inclusive.
     pub fn set_min_duration(env: Env, min_duration: u64) -> Result<(), FactoryError> {
         require_admin(&env)?;
+        validate_min_duration(min_duration)?;
 
         env.storage()
             .instance()

--- a/contracts/stream/tests/factory_policy.rs
+++ b/contracts/stream/tests/factory_policy.rs
@@ -3,7 +3,10 @@
 //! Covers all six FactoryError variants and verifies that `create_stream` via
 //! the factory correctly delegates to the stream contract after passing all checks.
 
-use fluxora_factory::{FactoryError, FluxoraFactory, FluxoraFactoryClient};
+use fluxora_factory::{
+    FactoryError, FluxoraFactory, FluxoraFactoryClient, MAX_FACTORY_DURATION_SECONDS,
+    MIN_FACTORY_DURATION_SECONDS,
+};
 use fluxora_stream::{FluxoraStream, FluxoraStreamClient};
 use soroban_sdk::{
     testutils::{Address as _, MockAuth, MockAuthInvoke},
@@ -80,6 +83,72 @@ fn test_factory_already_initialized() {
         .factory
         .try_init(&ctx.admin, &Address::generate(&ctx.env), &1_000, &10);
     assert_eq!(result, Err(Ok(FactoryError::AlreadyInitialized)));
+}
+
+#[test]
+fn test_init_rejects_non_positive_cap() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let factory_id = env.register_contract(None, FluxoraFactory);
+    let factory = FluxoraFactoryClient::new(&env, &factory_id);
+    let admin = Address::generate(&env);
+    let stream_contract = Address::generate(&env);
+
+    assert_eq!(
+        factory.try_init(&admin, &stream_contract, &0, &MIN_FACTORY_DURATION_SECONDS),
+        Err(Ok(FactoryError::InvalidCap))
+    );
+    assert_eq!(
+        factory.try_init(&admin, &stream_contract, &-1, &MIN_FACTORY_DURATION_SECONDS),
+        Err(Ok(FactoryError::InvalidCap))
+    );
+    assert_eq!(
+        factory.try_get_factory_config(),
+        Err(Ok(FactoryError::NotInitialized))
+    );
+}
+
+#[test]
+fn test_init_rejects_out_of_range_min_duration() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let factory_id = env.register_contract(None, FluxoraFactory);
+    let factory = FluxoraFactoryClient::new(&env, &factory_id);
+    let admin = Address::generate(&env);
+    let stream_contract = Address::generate(&env);
+
+    assert_eq!(
+        factory.try_init(&admin, &stream_contract, &1, &0),
+        Err(Ok(FactoryError::InvalidMinDuration))
+    );
+    assert_eq!(
+        factory.try_init(
+            &admin,
+            &stream_contract,
+            &1,
+            &(MAX_FACTORY_DURATION_SECONDS + 1)
+        ),
+        Err(Ok(FactoryError::InvalidMinDuration))
+    );
+    assert_eq!(
+        factory.try_get_factory_config(),
+        Err(Ok(FactoryError::NotInitialized))
+    );
+}
+
+#[test]
+fn test_init_accepts_policy_boundaries() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let factory_id = env.register_contract(None, FluxoraFactory);
+    let factory = FluxoraFactoryClient::new(&env, &factory_id);
+    let admin = Address::generate(&env);
+    let stream_contract = Address::generate(&env);
+
+    factory.init(&admin, &stream_contract, &1, &MAX_FACTORY_DURATION_SECONDS);
+    let config = factory.get_factory_config();
+    assert_eq!(config.max_deposit, 1);
+    assert_eq!(config.min_duration, MAX_FACTORY_DURATION_SECONDS);
 }
 
 // ---------------------------------------------------------------------------
@@ -521,6 +590,21 @@ fn test_set_cap_enforced() {
     assert_eq!(result, Err(Ok(FactoryError::DepositExceedsCap)));
 }
 
+#[test]
+fn test_set_cap_rejects_non_positive_values_without_changing_policy() {
+    let ctx = Ctx::setup();
+
+    assert_eq!(
+        ctx.factory.try_set_cap(&0),
+        Err(Ok(FactoryError::InvalidCap))
+    );
+    assert_eq!(
+        ctx.factory.try_set_cap(&-1),
+        Err(Ok(FactoryError::InvalidCap))
+    );
+    assert_eq!(ctx.factory.get_factory_config().max_deposit, 10_000);
+}
+
 /// set_min_duration updates the minimum; subsequent short-duration is rejected.
 #[test]
 fn test_set_min_duration_enforced() {
@@ -541,6 +625,39 @@ fn test_set_min_duration_enforced() {
         &0,
     );
     assert_eq!(result, Err(Ok(FactoryError::DurationTooShort)));
+}
+
+#[test]
+fn test_set_min_duration_rejects_out_of_range_values_without_changing_policy() {
+    let ctx = Ctx::setup();
+
+    assert_eq!(
+        ctx.factory.try_set_min_duration(&0),
+        Err(Ok(FactoryError::InvalidMinDuration))
+    );
+    assert_eq!(
+        ctx.factory
+            .try_set_min_duration(&(MAX_FACTORY_DURATION_SECONDS + 1)),
+        Err(Ok(FactoryError::InvalidMinDuration))
+    );
+    assert_eq!(ctx.factory.get_factory_config().min_duration, 100);
+}
+
+#[test]
+fn test_set_min_duration_accepts_documented_boundaries() {
+    let ctx = Ctx::setup();
+
+    ctx.factory.set_min_duration(&MIN_FACTORY_DURATION_SECONDS);
+    assert_eq!(
+        ctx.factory.get_factory_config().min_duration,
+        MIN_FACTORY_DURATION_SECONDS
+    );
+
+    ctx.factory.set_min_duration(&MAX_FACTORY_DURATION_SECONDS);
+    assert_eq!(
+        ctx.factory.get_factory_config().min_duration,
+        MAX_FACTORY_DURATION_SECONDS
+    );
 }
 
 /// set_allowlist(false) removes a previously-allowed recipient.

--- a/docs/ABI_STABILITY.md
+++ b/docs/ABI_STABILITY.md
@@ -346,6 +346,10 @@ Unauthorized             = 3
 RecipientNotAllowlisted  = 4
 DepositExceedsCap        = 5
 DurationTooShort         = 6
+InvalidTimeRange         = 7
+InvalidCliff             = 8
+InvalidCap               = 9
+InvalidMinDuration       = 10
 ```
 
 ### Factory Entrypoints

--- a/docs/factory.md
+++ b/docs/factory.md
@@ -12,6 +12,20 @@ The `fluxora_factory` acts as a proxy entrypoint to enforce these policies:
 - **Minimum Duration**: Enforces a `MinDuration` (i.e. `end_time - start_time >= min_duration`), preventing overly short or instantaneous streams.
 - **Time Relationship Checks**: Rejects invalid schedules before calling `FluxoraStream`. `start_time` must be strictly less than `end_time`, and `cliff_time` must be within the inclusive `[start_time, end_time]` window.
 
+## Policy Parameter Ranges
+
+The factory validates policy values before storing them in `init`, `set_cap`,
+and `set_min_duration`:
+
+| Policy | Accepted range | Error |
+|--------|----------------|-------|
+| `max_deposit` | `max_deposit > 0` | `FactoryError::InvalidCap` |
+| `min_duration` | `1 <= min_duration <= 315_360_000` seconds (10 years) | `FactoryError::InvalidMinDuration` |
+
+Rejecting invalid values at write time prevents an admin mistake from silently
+bricking factory-routed stream creation with a zero/negative cap or an absurd
+minimum duration.
+
 ## Time Validation
 
 The factory mirrors the underlying stream contract's creation-time schedule invariants and returns typed factory errors before making the cross-contract call:


### PR DESCRIPTION
## Summary
- add append-only `FactoryError::InvalidCap` and `FactoryError::InvalidMinDuration` variants
- validate `max_deposit > 0` in `init` and `set_cap` before policy storage writes
- validate `min_duration` against the documented 1 second to 10 year range in `init` and `set_min_duration`
- cover rejected and accepted boundary policy values in `factory_policy` tests
- document accepted factory policy ranges and update the FactoryError ABI table

## Validation
- `cargo +1.94.1-x86_64-pc-windows-msvc fmt --all -- --check` - passed
- `git diff --check` - passed

## Local environment note
- `cargo +1.94.1-x86_64-pc-windows-msvc test --test factory_policy` was attempted but this Windows environment is missing the MSVC linker (`link.exe`), so build scripts fail before test execution.
- `cargo +1.94.1-x86_64-pc-windows-msvc check -p fluxora_factory` is blocked by the same missing `link.exe` environment issue.

## Security notes
Invalid factory policy is rejected before storage writes, so a zero/negative cap or absurd minimum duration cannot silently brick factory-routed stream creation.

Closes #631