### PR TITLE
fix(governance): refresh quorum timestamp TTL

### DIFF
--- a/contracts/governance/src/lib.rs
+++ b/contracts/governance/src/lib.rs
@@ -120,6 +120,11 @@ const INSTANCE_BUMP_AMOUNT: u32 = 120_960;
 const PERSISTENT_LIFETIME_THRESHOLD: u32 = 17_280;
 const PERSISTENT_BUMP_AMOUNT: u32 = 120_960;
 
+/// Number of seconds represented by one ledger under the network cadence used
+/// by the TTL policy. Governance's persistent bump covers 7 days of ledgers,
+/// which is well above the 48 hour timelock.
+pub const GOVERNANCE_TTL_LEDGER_SECONDS: u64 = 5;
+
 // ---------------------------------------------------------------------------
 // Events
 // ---------------------------------------------------------------------------
@@ -197,6 +202,32 @@ fn bump_proposal(env: &Env, id: u32) {
     );
 }
 
+/// Refreshes the quorum timestamp entry when it exists so the timelock record
+/// keeps the same TTL guarantee as the proposal it unlocks.
+fn bump_quorum_reached_at(env: &Env, id: u32) {
+    let key = DataKey::QuorumReachedAt(id);
+    if env.storage().persistent().has(&key) {
+        env.storage().persistent().extend_ttl(
+            &key,
+            PERSISTENT_LIFETIME_THRESHOLD,
+            PERSISTENT_BUMP_AMOUNT,
+        );
+    }
+}
+
+/// Loads the stored quorum snapshot and refreshes its TTL before execution
+/// evaluates the immutable threshold/timelock pair.
+fn load_quorum_info(env: &Env, id: u32) -> Result<QuorumInfo, GovernanceError> {
+    let key = DataKey::QuorumReachedAt(id);
+    let info: QuorumInfo = env
+        .storage()
+        .persistent()
+        .get(&key)
+        .ok_or(GovernanceError::QuorumNotReached)?;
+    bump_quorum_reached_at(env, id);
+    Ok(info)
+}
+
 fn get_admin(env: &Env) -> Result<Address, GovernanceError> {
     bump_instance(env);
     env.storage()
@@ -241,6 +272,7 @@ fn load_proposal(env: &Env, id: u32) -> Result<Proposal, GovernanceError> {
         .get(&DataKey::Proposal(id))
         .ok_or(GovernanceError::ProposalNotFound)?;
     bump_proposal(env, id);
+    bump_quorum_reached_at(env, id);
     Ok(proposal)
 }
 
@@ -513,11 +545,7 @@ impl FluxoraGovernance {
             env.storage()
                 .persistent()
                 .set(&DataKey::QuorumReachedAt(proposal_id), &info);
-            env.storage().persistent().extend_ttl(
-                &DataKey::QuorumReachedAt(proposal_id),
-                PERSISTENT_LIFETIME_THRESHOLD,
-                PERSISTENT_BUMP_AMOUNT,
-            );
+            bump_quorum_reached_at(&env, proposal_id);
 
             env.events().publish(
                 (symbol_short!("quorum"), proposal_id),
@@ -569,11 +597,7 @@ impl FluxoraGovernance {
         // Verify quorum was reached and use the recorded threshold (snapshot at
         // quorum time) so that in-flight proposals are immune to mid-flight
         // threshold changes.
-        let quorum_info: QuorumInfo = env
-            .storage()
-            .persistent()
-            .get(&DataKey::QuorumReachedAt(proposal_id))
-            .ok_or(GovernanceError::QuorumNotReached)?;
+        let quorum_info = load_quorum_info(&env, proposal_id)?;
 
         if proposal.approvals.len() < quorum_info.threshold {
             return Err(GovernanceError::QuorumNotReached);

--- a/contracts/stream/tests/governance_integration.rs
+++ b/contracts/stream/tests/governance_integration.rs
@@ -1,14 +1,19 @@
 extern crate std;
 
-use fluxora_governance::{FluxoraGovernance, FluxoraGovernanceClient, GovernanceError};
+use fluxora_governance::{
+    DataKey, FluxoraGovernance, FluxoraGovernanceClient, GovernanceError,
+    GOVERNANCE_TTL_LEDGER_SECONDS,
+};
 use soroban_sdk::{
-    testutils::{Address as _, Ledger},
+    testutils::{storage::Persistent as _, Address as _, Ledger, LedgerInfo},
     vec, Address, Bytes, Env,
 };
 
 // Mirror constants from governance lib.rs
 const TIMELOCK: u64 = 172_800; // 48 hours
 const MAX_AGE: u64 = 2_592_000; // 30 days
+const PERSISTENT_LIFETIME_THRESHOLD: u32 = 17_280;
+const PERSISTENT_BUMP_AMOUNT: u32 = 120_960;
 
 struct GovCtx<'a> {
     env: Env,
@@ -57,6 +62,30 @@ impl<'a> GovCtx<'a> {
 
     fn calldata(&self, tag: &str) -> Bytes {
         Bytes::from_slice(&self.env, tag.as_bytes())
+    }
+
+    fn advance_ledger(&self, ledgers: u32) {
+        let current = self.env.ledger().sequence();
+        self.env.ledger().set(LedgerInfo {
+            timestamp: self.env.ledger().timestamp()
+                + u64::from(ledgers) * GOVERNANCE_TTL_LEDGER_SECONDS,
+            protocol_version: 20,
+            sequence_number: current + ledgers,
+            network_id: Default::default(),
+            base_reserve: 10,
+            min_temp_entry_ttl: 16,
+            min_persistent_entry_ttl: 16,
+            max_entry_ttl: 6_312_000,
+        });
+    }
+
+    fn quorum_ttl(&self, proposal_id: u32) -> u32 {
+        self.env.as_contract(&self.contract_id, || {
+            self.env
+                .storage()
+                .persistent()
+                .get_ttl(&DataKey::QuorumReachedAt(proposal_id))
+        })
     }
 }
 
@@ -243,6 +272,32 @@ fn test_execute_after_quorum_and_timelock_succeeds() {
 
     // Advance past timelock
     ctx.env.ledger().set_timestamp(1_000_000 + TIMELOCK + 1);
+
+    let executor = Address::generate(&ctx.env);
+    ctx.client.execute(&executor, &id);
+
+    let p = ctx.client.get_proposal(&id);
+    assert!(p.executed);
+}
+
+#[test]
+fn test_quorum_record_ttl_refreshes_when_proposal_is_touched() {
+    let ctx = GovCtx::setup();
+    let id = ctx
+        .client
+        .propose(&ctx.signer_a, &ctx.dummy_target(), &ctx.calldata("x"));
+
+    ctx.client.approve(&ctx.signer_a, &id);
+    ctx.client.approve(&ctx.signer_b, &id);
+
+    assert_eq!(ctx.quorum_ttl(id), PERSISTENT_BUMP_AMOUNT);
+
+    ctx.advance_ledger(PERSISTENT_BUMP_AMOUNT - PERSISTENT_LIFETIME_THRESHOLD + 1);
+    assert!(ctx.quorum_ttl(id) < PERSISTENT_LIFETIME_THRESHOLD);
+
+    let p = ctx.client.get_proposal(&id);
+    assert_eq!(p.approvals.len(), 2);
+    assert_eq!(ctx.quorum_ttl(id), PERSISTENT_BUMP_AMOUNT);
 
     let executor = Address::generate(&ctx.env);
     ctx.client.execute(&executor, &id);

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -92,6 +92,20 @@ Cancelled, expired, and executed proposals cannot receive approvals or be execut
 Additional approvals above quorum do not rewrite `QuorumInfo` and do not restart the
 timelock.
 
+### TTL and timelock durability
+
+`Proposal(id)` and its `QuorumReachedAt(id)` timestamp are both persistent entries. The
+governance contract refreshes the proposal TTL on every proposal read/write and refreshes
+the quorum timestamp TTL whenever a quorum-reached proposal is touched, including
+`get_proposal`, `approve`, `cancel_proposal`, and `execute` paths that load the proposal.
+
+The configured persistent bump is `120,960` ledgers. At the 5-second ledger cadence used by
+the TTL policy, that is 604,800 seconds (7 days), which comfortably exceeds the
+`GOVERNANCE_TIMELOCK_SECONDS` value of 172,800 seconds (48 hours). Refreshing
+`QuorumReachedAt(id)` preserves the original quorum timestamp and threshold snapshot while
+keeping the timelock evidence live long enough for low-traffic governance proposals to be
+executed after the delay.
+
 ## Entrypoints
 
 ### `init(admin, signers, threshold)`


### PR DESCRIPTION
## Summary
- refresh the persistent `QuorumReachedAt(id)` TTL whenever a quorum-reached proposal is loaded
- route execute-time quorum reads through a helper that refreshes the timelock evidence before evaluating it
- add a regression test covering TTL refresh near the threshold and document the 7-day TTL / 48-hour timelock relationship

## Validation
- `cargo +1.94.1-x86_64-pc-windows-msvc fmt --all -- --check`
- `git diff --check`

Attempted targeted Rust test locally:
- `cargo +1.94.1-x86_64-pc-windows-msvc test --test governance_integration test_quorum_record_ttl_refreshes_when_proposal_is_touched -- --exact`

The test run is blocked in this Windows environment before project code links because the MSVC linker / Windows SDK import libraries are not installed (`link.exe` / `kernel32.lib` / related SDK libs missing). I also tried the installed GNU and gnullvm toolchains; those are blocked by local binutils/clang driver availability (`dlltool` CreateProcess failure / `x86_64-w64-mingw32-clang` missing). The committed regression test is included for CI to execute in the repository environment.

## Security notes
- The original quorum timestamp and threshold snapshot are preserved; this does not rewrite quorum state or restart the timelock.
- Missing quorum evidence still fails closed with `QuorumNotReached`.
- The quorum timestamp now receives the same persistent TTL refresh guarantee as the proposal record that depends on it.

Closes #638