### PR TITLE
feat(governance): emit membership change events

### DIFF
--- a/contracts/governance/src/lib.rs
+++ b/contracts/governance/src/lib.rs
@@ -179,6 +179,28 @@ pub struct ProposalExecuted {
     pub calldata: Bytes,
 }
 
+/// Emitted when the admin adds a co-signer to the governance set.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct SignerAdded {
+    pub signer: Address,
+}
+
+/// Emitted when the admin removes a co-signer from the governance set.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct SignerRemoved {
+    pub signer: Address,
+}
+
+/// Emitted when the governance admin address is rotated.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct AdminChanged {
+    pub old_admin: Address,
+    pub new_admin: Address,
+}
+
 // ---------------------------------------------------------------------------
 // Storage helpers
 // ---------------------------------------------------------------------------
@@ -310,9 +332,17 @@ impl FluxoraGovernance {
     /// # Authorization
     /// - Requires admin signature.
     pub fn set_admin(env: Env, new_admin: Address) -> Result<(), GovernanceError> {
-        get_admin(&env)?.require_auth();
+        let old_admin = get_admin(&env)?;
+        old_admin.require_auth();
         env.storage().instance().set(&DataKey::Admin, &new_admin);
         bump_instance(&env);
+        env.events().publish(
+            (symbol_short!("admin_chg"),),
+            AdminChanged {
+                old_admin,
+                new_admin,
+            },
+        );
         Ok(())
     }
 
@@ -335,9 +365,11 @@ impl FluxoraGovernance {
         if signers.len() >= MAX_SIGNERS {
             return Err(GovernanceError::TooManySigners);
         }
-        signers.push_back(signer);
+        signers.push_back(signer.clone());
         env.storage().instance().set(&DataKey::Signers, &signers);
         bump_instance(&env);
+        env.events()
+            .publish((symbol_short!("sign_add"),), SignerAdded { signer });
         Ok(())
     }
 
@@ -367,6 +399,8 @@ impl FluxoraGovernance {
             signers.remove(i);
             env.storage().instance().set(&DataKey::Signers, &signers);
             bump_instance(&env);
+            env.events()
+                .publish((symbol_short!("sign_rm"),), SignerRemoved { signer });
         }
         Ok(())
     }

--- a/contracts/stream/tests/governance_integration.rs
+++ b/contracts/stream/tests/governance_integration.rs
@@ -1,9 +1,13 @@
 extern crate std;
 
-use fluxora_governance::{FluxoraGovernance, FluxoraGovernanceClient, GovernanceError};
+use fluxora_governance::{
+    AdminChanged, FluxoraGovernance, FluxoraGovernanceClient, GovernanceError, SignerAdded,
+    SignerRemoved,
+};
 use soroban_sdk::{
+    symbol_short,
     testutils::{Address as _, Ledger},
-    vec, Address, Bytes, Env,
+    vec, Address, Bytes, Env, Symbol, TryFromVal,
 };
 
 // Mirror constants from governance lib.rs
@@ -335,6 +339,76 @@ fn test_add_remove_signer() {
     ctx.client.remove_signer(&new_signer);
     let signers = ctx.client.get_signers();
     assert_eq!(signers.len(), 3);
+}
+
+#[test]
+fn test_add_signer_emits_structured_event() {
+    let ctx = GovCtx::setup();
+    let new_signer = Address::generate(&ctx.env);
+    let events_before = ctx.env.events().all().len();
+
+    ctx.client.add_signer(&new_signer);
+
+    let events = ctx.env.events().all();
+    assert_eq!(events.len(), events_before + 1);
+    let event = events.last().expect("signer add event");
+    assert_eq!(event.0, ctx.contract_id);
+    assert_eq!(event.1.len(), 1);
+    assert_eq!(
+        Symbol::try_from_val(&ctx.env, &event.1.get(0).unwrap()).unwrap(),
+        symbol_short!("sign_add")
+    );
+    let payload = SignerAdded::try_from_val(&ctx.env, &event.2).expect("SignerAdded event payload");
+    assert_eq!(payload.signer, new_signer);
+}
+
+#[test]
+fn test_remove_signer_emits_structured_event_only_when_removed() {
+    let ctx = GovCtx::setup();
+    let events_before = ctx.env.events().all().len();
+
+    ctx.client.remove_signer(&ctx.signer_c);
+
+    let events = ctx.env.events().all();
+    assert_eq!(events.len(), events_before + 1);
+    let event = events.last().expect("signer remove event");
+    assert_eq!(event.0, ctx.contract_id);
+    assert_eq!(event.1.len(), 1);
+    assert_eq!(
+        Symbol::try_from_val(&ctx.env, &event.1.get(0).unwrap()).unwrap(),
+        symbol_short!("sign_rm")
+    );
+    let payload =
+        SignerRemoved::try_from_val(&ctx.env, &event.2).expect("SignerRemoved event payload");
+    assert_eq!(payload.signer, ctx.signer_c);
+
+    let stranger = Address::generate(&ctx.env);
+    let events_before_noop = ctx.env.events().all().len();
+    ctx.client.remove_signer(&stranger);
+    assert_eq!(ctx.env.events().all().len(), events_before_noop);
+}
+
+#[test]
+fn test_set_admin_emits_structured_event() {
+    let ctx = GovCtx::setup();
+    let new_admin = Address::generate(&ctx.env);
+    let events_before = ctx.env.events().all().len();
+
+    ctx.client.set_admin(&new_admin);
+
+    let events = ctx.env.events().all();
+    assert_eq!(events.len(), events_before + 1);
+    let event = events.last().expect("admin changed event");
+    assert_eq!(event.0, ctx.contract_id);
+    assert_eq!(event.1.len(), 1);
+    assert_eq!(
+        Symbol::try_from_val(&ctx.env, &event.1.get(0).unwrap()).unwrap(),
+        symbol_short!("admin_chg")
+    );
+    let payload =
+        AdminChanged::try_from_val(&ctx.env, &event.2).expect("AdminChanged event payload");
+    assert_eq!(payload.old_admin, ctx.admin);
+    assert_eq!(payload.new_admin, new_admin);
 }
 
 #[test]

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -107,12 +107,15 @@ Initializes the contract. It can only be called once.
 
 Rotates the admin address. The current admin must authorize the call.
 
+- Emits `AdminChanged` with topic `("admin_chg")` after the admin storage entry is updated.
+
 ### `add_signer(signer)`
 
 Adds a co-signer to the governance set. The admin must authorize the call.
 
 - Fails with `DuplicateSigner` if the address is already registered.
 - Fails with `TooManySigners` if adding the signer would exceed `MAX_SIGNERS`.
+- Emits `SignerAdded` with topic `("sign_add")` after the signer set is updated.
 
 ### `remove_signer(signer)`
 
@@ -120,7 +123,8 @@ Removes a co-signer from the governance set. The admin must authorize the call.
 
 - Fails with `QuorumWouldBreak` if removal would leave fewer signers than the current
   threshold.
-- Removing a non-existent signer is a no-op.
+- Removing a non-existent signer is a no-op and emits no event.
+- Emits `SignerRemoved` with topic `("sign_rm")` after an existing signer is removed.
 
 ### `propose(proposer, target, calldata) -> u32`
 
@@ -215,10 +219,13 @@ example by importing `FluxoraFactoryClient` and matching on a known operation ta
 ## Events
 
 For stream-level events, see [`events.md`](events.md). Governance emits the following
-proposal events:
+proposal and membership events:
 
 | Event | Topic | Payload | Emitted when |
 |---|---|---|---|
+| `SignerAdded` | `("sign_add")` | `SignerAdded { signer }` | `add_signer` stores a new co-signer |
+| `SignerRemoved` | `("sign_rm")` | `SignerRemoved { signer }` | `remove_signer` removes an existing co-signer |
+| `AdminChanged` | `("admin_chg")` | `AdminChanged { old_admin, new_admin }` | `set_admin` rotates the admin address |
 | `ProposalCreated` | `("proposed", proposal_id)` | `ProposalCreated { proposal_id, proposer, target }` | `propose` stores a new proposal |
 | `ProposalApproved` | `("approved", proposal_id)` | `ProposalApproved { proposal_id, approver, approval_count }` | `approve` records a unique signer approval |
 | `QuorumReached` | `("quorum", proposal_id)` | `QuorumReached { proposal_id, quorum_reached_at, executable_after }` | Approval count first equals the configured threshold |
@@ -227,6 +234,8 @@ proposal events:
 
 `QuorumReached` is emitted only once per proposal because the contract stores `QuorumInfo`
 only when `approval_count == threshold`.
+Signer and admin events are emitted after the corresponding storage mutation succeeds.
+`remove_signer` emits no event when the supplied address is not in the signer set.
 
 ## Storage layout
 


### PR DESCRIPTION
## Summary
- add structured governance membership/admin events for signer additions, signer removals, and admin rotation
- emit the events after the corresponding storage mutation succeeds, while keeping missing-signer removal as a no-op with no event
- cover the event topics and payloads in governance integration tests and document the new event schema

Fixes #637.

## Verification
- `cargo +stable-x86_64-pc-windows-gnu check -p fluxora_governance`
- `cargo fmt --all -- --check`
- `git diff --check`
- Duplicate check before submission: issue #637 was open, unassigned, had 0 comments, and no matching open PRs for the governance membership event work.

## Local test note
- `cargo test --test governance_integration` could not run to completion in this Windows environment because the MSVC linker `link.exe` is not installed.
- `cargo +stable-x86_64-pc-windows-gnu test --test governance_integration` now finds Rust's bundled `dlltool.exe` but still fails before project tests because `dlltool` exits with a CreateProcess error while creating Windows import libraries.
- gnullvm fallback `cargo +stable-x86_64-pc-windows-gnullvm test --test governance_integration` is blocked by missing `x86_64-w64-mingw32-clang`.

## Security notes
- Events are emitted only after the signer/admin storage update succeeds, so indexers see the committed state transition.
- `remove_signer` for an absent address remains a no-op and emits no spurious audit event.
- Event payloads contain only governance addresses already visible through contract state.