### PR TITLE
fix(governance): check proposal arithmetic overflow

### DIFF
--- a/contracts/governance/src/lib.rs
+++ b/contracts/governance/src/lib.rs
@@ -92,6 +92,10 @@ pub enum GovernanceError {
     QuorumWouldBreak = 16,
     /// Signer is already registered in the co-signer set.
     DuplicateSigner = 17,
+    /// Monotonic proposal ID counter has reached u32::MAX.
+    ProposalIdOverflow = 18,
+    /// Governance timestamp arithmetic overflowed.
+    ArithmeticOverflow = 19,
 }
 
 /// Storage keys for the governance contract.
@@ -226,12 +230,26 @@ fn read_next_proposal_id(env: &Env) -> u32 {
         .unwrap_or(0u32)
 }
 
-fn increment_proposal_id(env: &Env) -> u32 {
+fn increment_proposal_id(env: &Env) -> Result<u32, GovernanceError> {
     let id = read_next_proposal_id(env);
+    let next_id = id
+        .checked_add(1)
+        .ok_or(GovernanceError::ProposalIdOverflow)?;
     env.storage()
         .instance()
-        .set(&DataKey::NextProposalId, &(id + 1));
-    id
+        .set(&DataKey::NextProposalId, &next_id);
+    Ok(id)
+}
+
+fn checked_timestamp_add(timestamp: u64, seconds: u64) -> Result<u64, GovernanceError> {
+    timestamp
+        .checked_add(seconds)
+        .ok_or(GovernanceError::ArithmeticOverflow)
+}
+
+fn is_proposal_expired(env: &Env, proposal: &Proposal) -> Result<bool, GovernanceError> {
+    let expires_at = checked_timestamp_add(proposal.created_at, MAX_PROPOSAL_AGE_SECONDS)?;
+    Ok(env.ledger().timestamp() > expires_at)
 }
 
 fn load_proposal(env: &Env, id: u32) -> Result<Proposal, GovernanceError> {
@@ -383,6 +401,8 @@ impl FluxoraGovernance {
     ///
     /// # Returns
     /// - The proposal ID assigned to the new proposal (monotonically increasing u32).
+    ///   If the counter has reached `u32::MAX`, the call returns
+    ///   `ProposalIdOverflow` rather than host-trapping.
     ///
     /// # Authorization
     /// - Requires `proposer.require_auth()`.
@@ -390,6 +410,7 @@ impl FluxoraGovernance {
     /// # Errors
     /// - `NotASigner`: `proposer` is not in the registered signers list.
     /// - `CalldataTooLarge`: `calldata.len() > MAX_CALLDATA_BYTES`.
+    /// - `ProposalIdOverflow`: the proposal ID counter cannot be advanced.
     pub fn propose(
         env: Env,
         proposer: Address,
@@ -408,7 +429,7 @@ impl FluxoraGovernance {
             return Err(GovernanceError::CalldataTooLarge);
         }
 
-        let id = increment_proposal_id(&env);
+        let id = increment_proposal_id(&env)?;
         let now = env.ledger().timestamp();
 
         let proposal = Proposal {
@@ -453,6 +474,8 @@ impl FluxoraGovernance {
     /// - `ProposalNotFound`: No proposal with this ID.
     /// - `AlreadyExecuted`: Proposal has already been executed.
     /// - `AlreadyApproved`: This signer already approved this proposal.
+    /// - `ArithmeticOverflow`: proposal expiry or executable-after timestamp
+    ///   arithmetic overflowed instead of producing a host trap.
     pub fn approve(env: Env, approver: Address, proposal_id: u32) -> Result<(), GovernanceError> {
         approver.require_auth();
 
@@ -469,7 +492,7 @@ impl FluxoraGovernance {
         if proposal.executed {
             return Err(GovernanceError::AlreadyExecuted);
         }
-        if env.ledger().timestamp() > proposal.created_at + MAX_PROPOSAL_AGE_SECONDS {
+        if is_proposal_expired(&env, &proposal)? {
             return Err(GovernanceError::ProposalExpired);
         }
 
@@ -487,6 +510,25 @@ impl FluxoraGovernance {
         proposal.approvals.push_back(approver.clone());
         let approval_count = proposal.approvals.len();
 
+        // Record the timestamp and effective threshold at which quorum was first
+        // reached.  Using the stored snapshot at execution time protects in-flight
+        // proposals against mid-flight threshold changes by the admin.
+        let threshold = get_threshold(&env)?;
+        let quorum_info = if approval_count == threshold {
+            let now = env.ledger().timestamp();
+            let executable_after = checked_timestamp_add(now, GOVERNANCE_TIMELOCK_SECONDS)?;
+            Some((
+                QuorumInfo {
+                    reached_at: now,
+                    threshold,
+                },
+                now,
+                executable_after,
+            ))
+        } else {
+            None
+        };
+
         save_proposal(&env, proposal_id, &proposal);
         bump_instance(&env);
 
@@ -499,17 +541,9 @@ impl FluxoraGovernance {
             },
         );
 
-        // Record the timestamp and effective threshold at which quorum was first
-        // reached.  Using the stored snapshot at execution time protects in-flight
-        // proposals against mid-flight threshold changes by the admin.
-        let threshold = get_threshold(&env)?;
         if approval_count == threshold {
-            let now = env.ledger().timestamp();
-            let executable_after = now + GOVERNANCE_TIMELOCK_SECONDS;
-            let info = QuorumInfo {
-                reached_at: now,
-                threshold,
-            };
+            let (info, quorum_reached_at, executable_after) =
+                quorum_info.ok_or(GovernanceError::ArithmeticOverflow)?;
             env.storage()
                 .persistent()
                 .set(&DataKey::QuorumReachedAt(proposal_id), &info);
@@ -523,7 +557,7 @@ impl FluxoraGovernance {
                 (symbol_short!("quorum"), proposal_id),
                 QuorumReached {
                     proposal_id,
-                    quorum_reached_at: now,
+                    quorum_reached_at,
                     executable_after,
                 },
             );
@@ -551,6 +585,8 @@ impl FluxoraGovernance {
     /// - `QuorumNotReached`: Approval count < threshold.
     /// - `TimelockNotElapsed`: Less than `GOVERNANCE_TIMELOCK_SECONDS` have passed
     ///   since quorum was reached.
+    /// - `ArithmeticOverflow`: proposal expiry or quorum timelock timestamp
+    ///   arithmetic overflowed instead of producing a host trap.
     pub fn execute(env: Env, executor: Address, proposal_id: u32) -> Result<(), GovernanceError> {
         executor.require_auth();
 
@@ -562,7 +598,7 @@ impl FluxoraGovernance {
         if proposal.executed {
             return Err(GovernanceError::AlreadyExecuted);
         }
-        if env.ledger().timestamp() > proposal.created_at + MAX_PROPOSAL_AGE_SECONDS {
+        if is_proposal_expired(&env, &proposal)? {
             return Err(GovernanceError::ProposalExpired);
         }
 
@@ -581,7 +617,9 @@ impl FluxoraGovernance {
 
         // Verify timelock has elapsed from the moment quorum was reached.
         let now = env.ledger().timestamp();
-        if now < quorum_info.reached_at + GOVERNANCE_TIMELOCK_SECONDS {
+        let executable_after =
+            checked_timestamp_add(quorum_info.reached_at, GOVERNANCE_TIMELOCK_SECONDS)?;
+        if now < executable_after {
             return Err(GovernanceError::TimelockNotElapsed);
         }
 

--- a/contracts/stream/tests/governance_integration.rs
+++ b/contracts/stream/tests/governance_integration.rs
@@ -1,6 +1,8 @@
 extern crate std;
 
-use fluxora_governance::{FluxoraGovernance, FluxoraGovernanceClient, GovernanceError};
+use fluxora_governance::{
+    DataKey, FluxoraGovernance, FluxoraGovernanceClient, GovernanceError, Proposal, QuorumInfo,
+};
 use soroban_sdk::{
     testutils::{Address as _, Ledger},
     vec, Address, Bytes, Env,
@@ -57,6 +59,36 @@ impl<'a> GovCtx<'a> {
 
     fn calldata(&self, tag: &str) -> Bytes {
         Bytes::from_slice(&self.env, tag.as_bytes())
+    }
+
+    fn seed_next_proposal_id(&self, next_id: u32) {
+        let contract_id = self.contract_id.clone();
+        self.env.as_contract(&contract_id, || {
+            self.env
+                .storage()
+                .instance()
+                .set(&DataKey::NextProposalId, &next_id);
+        });
+    }
+
+    fn seed_proposal(&self, proposal_id: u32, proposal: &Proposal) {
+        let contract_id = self.contract_id.clone();
+        self.env.as_contract(&contract_id, || {
+            self.env
+                .storage()
+                .persistent()
+                .set(&DataKey::Proposal(proposal_id), proposal);
+        });
+    }
+
+    fn seed_quorum_info(&self, proposal_id: u32, info: &QuorumInfo) {
+        let contract_id = self.contract_id.clone();
+        self.env.as_contract(&contract_id, || {
+            self.env
+                .storage()
+                .persistent()
+                .set(&DataKey::QuorumReachedAt(proposal_id), info);
+        });
     }
 }
 
@@ -132,6 +164,21 @@ fn test_propose_returns_incremental_ids() {
 }
 
 #[test]
+fn test_propose_returns_structured_error_on_proposal_id_overflow() {
+    let ctx = GovCtx::setup();
+    ctx.seed_next_proposal_id(u32::MAX);
+
+    let result = ctx.client.try_propose(
+        &ctx.signer_a,
+        &ctx.dummy_target(),
+        &ctx.calldata("overflow"),
+    );
+
+    assert_eq!(result, Err(Ok(GovernanceError::ProposalIdOverflow)));
+    assert_eq!(ctx.client.proposal_count(), u32::MAX);
+}
+
+#[test]
 fn test_propose_non_signer_errors() {
     let ctx = GovCtx::setup();
     let outsider = Address::generate(&ctx.env);
@@ -174,6 +221,26 @@ fn test_approve_increments_approval_count() {
     ctx.client.approve(&ctx.signer_b, &id);
     let p = ctx.client.get_proposal(&id);
     assert_eq!(p.approvals.len(), 2);
+}
+
+#[test]
+fn test_approve_returns_structured_error_when_executable_after_overflows() {
+    let ctx = GovCtx::setup();
+    let proposal = Proposal {
+        proposer: ctx.signer_a.clone(),
+        target: ctx.dummy_target(),
+        calldata: ctx.calldata("x"),
+        approvals: vec![&ctx.env, ctx.signer_a.clone()],
+        created_at: u64::MAX - MAX_AGE,
+        executed: false,
+        cancelled: false,
+    };
+    ctx.seed_proposal(42, &proposal);
+    ctx.env.ledger().set_timestamp(u64::MAX - TIMELOCK + 1);
+
+    let result = ctx.client.try_approve(&ctx.signer_b, &42u32);
+
+    assert_eq!(result, Err(Ok(GovernanceError::ArithmeticOverflow)));
 }
 
 #[test]
@@ -714,6 +781,25 @@ fn test_approve_after_expiry_errors() {
 }
 
 #[test]
+fn test_approve_returns_structured_error_when_expiry_overflows() {
+    let ctx = GovCtx::setup();
+    let proposal = Proposal {
+        proposer: ctx.signer_a.clone(),
+        target: ctx.dummy_target(),
+        calldata: ctx.calldata("x"),
+        approvals: vec![&ctx.env],
+        created_at: u64::MAX - MAX_AGE + 1,
+        executed: false,
+        cancelled: false,
+    };
+    ctx.seed_proposal(43, &proposal);
+
+    let result = ctx.client.try_approve(&ctx.signer_b, &43u32);
+
+    assert_eq!(result, Err(Ok(GovernanceError::ArithmeticOverflow)));
+}
+
+#[test]
 fn test_expired_not_executable_even_with_quorum_and_timelock_met() {
     let ctx = GovCtx::setup();
     let id = ctx
@@ -731,6 +817,34 @@ fn test_expired_not_executable_even_with_quorum_and_timelock_met() {
     let executor = Address::generate(&ctx.env);
     let result = ctx.client.try_execute(&executor, &id);
     assert_eq!(result, Err(Ok(GovernanceError::ProposalExpired)));
+}
+
+#[test]
+fn test_execute_returns_structured_error_when_quorum_timelock_overflows() {
+    let ctx = GovCtx::setup();
+    let proposal = Proposal {
+        proposer: ctx.signer_a.clone(),
+        target: ctx.dummy_target(),
+        calldata: ctx.calldata("x"),
+        approvals: vec![&ctx.env, ctx.signer_a.clone(), ctx.signer_b.clone()],
+        created_at: 1_000_000,
+        executed: false,
+        cancelled: false,
+    };
+    ctx.seed_proposal(77, &proposal);
+    ctx.seed_quorum_info(
+        77,
+        &QuorumInfo {
+            reached_at: u64::MAX - TIMELOCK + 1,
+            threshold: 2,
+        },
+    );
+
+    let executor = Address::generate(&ctx.env);
+    let result = ctx.client.try_execute(&executor, &77u32);
+
+    assert_eq!(result, Err(Ok(GovernanceError::ArithmeticOverflow)));
+    assert!(!ctx.client.get_proposal(&77u32).executed);
 }
 
 #[test]

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -130,6 +130,8 @@ Submits a new governance proposal and returns its monotonically increasing ID.
 - `calldata` is stored as opaque bytes for on-chain auditability.
 - `calldata.len()` must be less than or equal to `MAX_CALLDATA_BYTES`.
 - The proposer is not automatically counted as an approver.
+- If the proposal counter has reached `u32::MAX`, proposal creation fails with
+  `ProposalIdOverflow` rather than panicking.
 - Emits `ProposalCreated` with topic `("proposed", proposal_id)`.
 
 ### `approve(approver, proposal_id)`
@@ -142,6 +144,8 @@ Records an approval from a co-signer.
 - Every successful approval emits `ProposalApproved`.
 - When the approval count first reaches the configured threshold, the contract stores
   `QuorumInfo { reached_at, threshold }` and emits `QuorumReached`.
+- Proposal expiry and `executable_after` timestamps use checked arithmetic. Overflow
+  returns `ArithmeticOverflow` before storing quorum state or emitting quorum events.
 
 ### `execute(executor, proposal_id)`
 
@@ -153,6 +157,8 @@ Marks the proposal as executed after quorum and timelock.
 - Execution requires
   `env.ledger().timestamp() >= quorum_info.reached_at + GOVERNANCE_TIMELOCK_SECONDS`.
 - Execution is rejected after cancellation or expiry.
+- Timelock and expiry timestamp arithmetic is checked. Overflow returns
+  `ArithmeticOverflow` rather than panicking.
 - The proposal is marked executed and saved before `ProposalExecuted` is emitted.
 - Emits `ProposalExecuted` with the stored `target` and `calldata`.
 
@@ -265,6 +271,8 @@ handle these discriminants from `contracts/governance/src/lib.rs`:
 | `InvalidThreshold` | 15 | `init` threshold is zero or exceeds signer count | Choose a threshold in the range `1..=signers.len()`. |
 | `QuorumWouldBreak` | 16 | `remove_signer` would leave fewer signers than threshold | Lower the threshold through a governed migration or keep enough signers registered. |
 | `DuplicateSigner` | 17 | `init` or `add_signer` includes an already-registered signer | Remove duplicate entries before submitting. |
+| `ProposalIdOverflow` | 18 | `propose` when `NextProposalId == u32::MAX` | Treat governance as terminal for new proposals and migrate to a fresh governance contract. |
+| `ArithmeticOverflow` | 19 | Proposal expiry or timelock timestamp arithmetic would overflow `u64` | Treat the proposal as invalid in the current ledger-time context and avoid retry loops. |
 
 ## Security considerations
 
@@ -295,6 +303,9 @@ handle these discriminants from `contracts/governance/src/lib.rs`:
 14. **Threshold is snapshotted at quorum time**: execution uses the threshold recorded in
     `QuorumInfo`, so an admin cannot raise or lower the live threshold after quorum to change
     the outcome of an in-flight proposal.
+15. **Governance arithmetic is checked**: proposal IDs and timestamp deadlines return
+    structured errors on overflow, so clients and indexers do not need to recover from opaque
+    host traps.
 
 ## Tests
 
@@ -303,7 +314,9 @@ Integration tests are in `contracts/stream/tests/governance_integration.rs` and 
 - Initialization and constant verification.
 - Duplicate signer rejection during initialization and signer management.
 - Proposal creation and ID assignment.
+- Proposal ID overflow rejection.
 - Approval counting and duplicate rejection.
+- Arithmetic overflow rejection for proposal expiry and quorum executable-after timestamps.
 - Non-signer rejection on both `propose` and `approve`.
 - Quorum enforcement and exact-threshold execution.
 - Timelock enforcement.


### PR DESCRIPTION
## Summary
- replace unchecked governance proposal-id and timestamp arithmetic with structured errors
- add `ProposalIdOverflow` for exhausted `NextProposalId` and `ArithmeticOverflow` for proposal expiry / timelock timestamp overflow
- check quorum executable-after before storing quorum state or emitting quorum events
- add integration coverage for proposal-id overflow, expiry overflow, quorum executable-after overflow, and execute-time timelock overflow
- document the overflow semantics and new error discriminants

Fixes #629.

## Verification
- `cargo +stable-x86_64-pc-windows-gnu check -p fluxora_governance`
- `cargo fmt --all -- --check`
- `git diff --check`
- `rg -n "\+\s*(GOVERNANCE_TIMELOCK_SECONDS|MAX_PROPOSAL_AGE_SECONDS)|NextProposalId.*\+|id \+ 1|quorum_info\.reached_at \+|proposal\.created_at \+" contracts/governance/src/lib.rs` returned no unchecked governance arithmetic matches
- Duplicate check before submission: issue #629 was open, unassigned, had 0 comments, and no matching open PRs for checked governance arithmetic work.

## Local test note
- `cargo test --test governance_integration` could not run to completion in this Windows environment because the MSVC linker `link.exe` is not installed.
- `cargo check -p fluxora_governance --target wasm32-unknown-unknown` is blocked by the MSVC host build-script linker requirement before project code is checked.
- `cargo +stable-x86_64-pc-windows-gnu test --test governance_integration` now finds Rust's bundled `dlltool.exe` but still fails before project tests because `dlltool` exits with a CreateProcess error while creating the `bcryptprimitives.dll` import library.
- GNU/gnullvm fallback toolchains were already blocked in this environment by missing `dlltool.exe` / `x86_64-w64-mingw32-clang` on the previous Contracts PR.

## Security notes
- Overflow paths now return typed governance errors instead of opaque host traps.
- Quorum timestamp overflow is detected before quorum storage or quorum events are written.
- The proposal ID counter remains monotonic and fails closed once it reaches `u32::MAX`.