### PR TITLE
ci: enforce wasm size budgets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,6 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    needs: lint
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -105,10 +104,10 @@ jobs:
             ${{ runner.os }}-cargo-build-
 
       - name: Build release (native)
-        run: cargo build --release -p fluxora_stream
+        run: cargo build --release -p fluxora_stream -p fluxora_factory -p fluxora_governance
 
       - name: Build WASM
-        run: cargo build --release -p fluxora_stream --target wasm32-unknown-unknown
+        run: cargo build --release --target wasm32-unknown-unknown -p fluxora_stream -p fluxora_factory -p fluxora_governance
 
       - name: Install Stellar CLI (pinned)
         run: |
@@ -125,15 +124,34 @@ jobs:
 
       - name: Optimize WASM
         run: |
-          stellar contract optimize --wasm target/wasm32-unknown-unknown/release/fluxora_stream.wasm
+          set +e
+          for contract in fluxora_stream fluxora_factory fluxora_governance; do
+            wasm="target/wasm32-unknown-unknown/release/${contract}.wasm"
+            if [ ! -f "$wasm" ]; then
+              echo "::warning::Skipping ${contract} optimization; ${wasm} was not built"
+              continue
+            fi
+
+            echo "Optimizing ${wasm}"
+            stellar contract optimize --wasm "$wasm"
+            status=$?
+            if [ "$status" -ne 0 ]; then
+              echo "::warning::stellar contract optimize failed for ${contract} with exit code ${status}; raw WASM will still be size-checked"
+            fi
+          done
         continue-on-error: true
 
       - name: Compute WASM SHA256 hash
         run: |
-          sha256sum target/wasm32-unknown-unknown/release/fluxora_stream.wasm > target/wasm32-unknown-unknown/release/fluxora_stream.wasm.sha256
-          if [ -f target/wasm32-unknown-unknown/release/fluxora_stream.optimized.wasm ]; then
-            sha256sum target/wasm32-unknown-unknown/release/fluxora_stream.optimized.wasm > target/wasm32-unknown-unknown/release/fluxora_stream.optimized.wasm.sha256
-          fi
+          set -euo pipefail
+          for wasm in target/wasm32-unknown-unknown/release/fluxora_{stream,factory,governance}{,.optimized}.wasm; do
+            if [ -f "$wasm" ]; then
+              sha256sum "$wasm" > "${wasm}.sha256"
+            fi
+          done
+
+      - name: Check WASM size budgets
+        run: bash script/check-wasm-size-budget.sh --no-build
 
       - name: Verify WASM build reproducibility
         run: bash script/verify-wasm-checksum.sh --no-build
@@ -142,20 +160,19 @@ jobs:
       - name: Upload WASM hash artifact
         uses: actions/upload-artifact@v4
         with:
-          name: fluxora_stream-wasm-hash
+          name: fluxora-contracts-wasm-hash
           path: |
-            target/wasm32-unknown-unknown/release/fluxora_stream.wasm.sha256
-            target/wasm32-unknown-unknown/release/fluxora_stream.optimized.wasm.sha256
+            target/wasm32-unknown-unknown/release/fluxora_*.wasm.sha256
           retention-days: 30
           if-no-files-found: warn
 
       - name: Upload WASM artifact
         uses: actions/upload-artifact@v4
         with:
-          name: fluxora_stream-wasm
+          name: fluxora-contracts-wasm
           path: |
-            target/wasm32-unknown-unknown/release/fluxora_stream.wasm
-            target/wasm32-unknown-unknown/release/fluxora_stream.optimized.wasm
+            target/wasm32-unknown-unknown/release/fluxora_*.wasm
+            target/wasm32-unknown-unknown/release/wasm-size-report.md
           retention-days: 30
           if-no-files-found: warn
 
@@ -331,7 +348,7 @@ jobs:
       - name: Download WASM artifact
         uses: actions/download-artifact@v4
         with:
-          name: fluxora_stream-wasm
+          name: fluxora-contracts-wasm
           path: ./artifacts
 
       - name: Install Stellar CLI (pinned)
@@ -394,7 +411,7 @@ jobs:
       - name: Download WASM artifact
         uses: actions/download-artifact@v4
         with:
-          name: fluxora_stream-wasm
+          name: fluxora-contracts-wasm
           path: ./artifacts
 
       - name: Install Stellar CLI (pinned)

--- a/docs/gas.md
+++ b/docs/gas.md
@@ -47,3 +47,38 @@ The following table provides the CPU instruction counts for core operations.
 <!-- GAS_BASELINE_END -->
 
 *Note: Baselines are currently initialized to 0 and should be updated after the first successful run of `script/validate_gas.py` once the contract compiles.*
+
+## WASM Size Budgets
+
+Fluxora CI builds every deployable contract as release WASM with the
+`wasm32-unknown-unknown` target, optionally runs `stellar contract optimize`,
+and then enforces a per-contract byte budget with
+`script/check-wasm-size-budget.sh`. The check fails if any required raw WASM
+artifact is missing or if either the raw or optimized artifact exceeds the
+documented budget.
+
+| Contract | Budget bytes | Budget rationale |
+|----------|--------------|------------------|
+| `fluxora_stream` | 262,144 | Largest contract; caps growth at the 256 KiB review threshold while the current stream source is still being consolidated. |
+| `fluxora_factory` | 98,304 | Thin treasury policy wrapper; allows policy and event growth without approaching stream size. |
+| `fluxora_governance` | 65,536 | Timelock and signer-management contract; local `wasm32` build measured 35,666 bytes before the stream package stopped the workspace build. |
+
+The CI report is written to
+`target/wasm32-unknown-unknown/release/wasm-size-report.md` and uploaded with
+the WASM artifacts. If a contract intentionally grows beyond its budget, update
+this table in the same PR as the budget change and explain the additional
+deployment cost or liveness trade-off.
+
+Local commands:
+
+```bash
+cargo build --release --target wasm32-unknown-unknown \
+  -p fluxora_stream -p fluxora_factory -p fluxora_governance
+bash script/check-wasm-size-budget.sh --no-build
+```
+
+The default budgets can be overridden for exploratory local runs with
+`FLUXORA_STREAM_WASM_BUDGET_BYTES`,
+`FLUXORA_FACTORY_WASM_BUDGET_BYTES`, and
+`FLUXORA_GOVERNANCE_WASM_BUDGET_BYTES`. Do not rely on overrides in CI unless
+the documented table is updated to match.

--- a/script/check-wasm-size-budget.sh
+++ b/script/check-wasm-size-budget.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# check-wasm-size-budget.sh
+#
+# Builds (unless --no-build is passed) and checks release WASM artifacts against
+# per-contract byte budgets. CI appends the measured sizes to the job summary so
+# reviewers can see the current raw and optimized artifact sizes on every run.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+RELEASE_DIR="${REPO_ROOT}/target/wasm32-unknown-unknown/release"
+REPORT_FILE="${RELEASE_DIR}/wasm-size-report.md"
+BUILD=true
+
+# Budgets are intentionally explicit per contract. They should be raised only
+# with a matching documentation update that explains the new size baseline.
+: "${FLUXORA_STREAM_WASM_BUDGET_BYTES:=262144}"
+: "${FLUXORA_FACTORY_WASM_BUDGET_BYTES:=98304}"
+: "${FLUXORA_GOVERNANCE_WASM_BUDGET_BYTES:=65536}"
+
+CONTRACTS=(
+  "fluxora_stream:${FLUXORA_STREAM_WASM_BUDGET_BYTES}"
+  "fluxora_factory:${FLUXORA_FACTORY_WASM_BUDGET_BYTES}"
+  "fluxora_governance:${FLUXORA_GOVERNANCE_WASM_BUDGET_BYTES}"
+)
+
+usage() {
+  cat <<'EOF'
+Usage: bash script/check-wasm-size-budget.sh [--no-build] [--release-dir DIR] [--report-file FILE]
+
+Options:
+  --no-build          Check existing release WASM files without invoking cargo.
+  --release-dir DIR   Directory containing fluxora_*.wasm artifacts.
+  --report-file FILE  Markdown report path. Defaults under the release dir.
+EOF
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --no-build)
+      BUILD=false
+      shift
+      ;;
+    --release-dir)
+      RELEASE_DIR="$2"
+      REPORT_FILE="${RELEASE_DIR}/wasm-size-report.md"
+      shift 2
+      ;;
+    --report-file)
+      REPORT_FILE="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+for tool in awk wc; do
+  if ! command -v "$tool" >/dev/null 2>&1; then
+    echo "ERROR: required tool '$tool' not found in PATH" >&2
+    exit 1
+  fi
+done
+
+if [ "$BUILD" = true ]; then
+  if ! command -v cargo >/dev/null 2>&1; then
+    echo "ERROR: cargo not found; pass --no-build to check existing artifacts." >&2
+    exit 1
+  fi
+
+  echo "Building release WASM artifacts for size-budget checks..."
+  cargo build --release --target wasm32-unknown-unknown \
+    --manifest-path "${REPO_ROOT}/Cargo.toml" \
+    -p fluxora_stream \
+    -p fluxora_factory \
+    -p fluxora_governance
+fi
+
+file_size_bytes() {
+  local file="$1"
+
+  if stat -c '%s' "$file" >/dev/null 2>&1; then
+    stat -c '%s' "$file"
+    return
+  fi
+
+  wc -c < "$file" | awk '{print $1}'
+}
+
+check_artifact() {
+  local contract="$1"
+  local kind="$2"
+  local file="$3"
+  local budget="$4"
+
+  if [ ! -f "$file" ]; then
+    echo "MISSING ${contract} ${kind} artifact: ${file}"
+    printf '| `%s` | %s | missing | %s | FAIL |\n' "$contract" "$kind" "$budget" >> "$REPORT_FILE"
+    FAILURES=$((FAILURES + 1))
+    return
+  fi
+
+  local size
+  size="$(file_size_bytes "$file")"
+
+  if [ "$size" -le "$budget" ]; then
+    echo "PASS ${contract} ${kind}: ${size} bytes <= ${budget}"
+    printf '| `%s` | %s | %s | %s | PASS |\n' "$contract" "$kind" "$size" "$budget" >> "$REPORT_FILE"
+  else
+    echo "FAIL ${contract} ${kind}: ${size} bytes > ${budget}"
+    printf '| `%s` | %s | %s | %s | FAIL |\n' "$contract" "$kind" "$size" "$budget" >> "$REPORT_FILE"
+    FAILURES=$((FAILURES + 1))
+  fi
+}
+
+mkdir -p "$(dirname "$REPORT_FILE")"
+{
+  echo "# WASM Size Budget Report"
+  echo ""
+  echo "| Contract | Artifact | Size bytes | Budget bytes | Status |"
+  echo "|----------|----------|------------|--------------|--------|"
+} > "$REPORT_FILE"
+
+FAILURES=0
+
+for entry in "${CONTRACTS[@]}"; do
+  contract="${entry%%:*}"
+  budget="${entry##*:}"
+  raw_file="${RELEASE_DIR}/${contract}.wasm"
+  optimized_file="${RELEASE_DIR}/${contract}.optimized.wasm"
+
+  check_artifact "$contract" "raw" "$raw_file" "$budget"
+
+  if [ -f "$optimized_file" ]; then
+    check_artifact "$contract" "optimized" "$optimized_file" "$budget"
+  else
+    echo "SKIP ${contract} optimized: ${optimized_file} not present"
+    printf '| `%s` | optimized | not present | %s | SKIP |\n' "$contract" "$budget" >> "$REPORT_FILE"
+  fi
+done
+
+echo ""
+cat "$REPORT_FILE"
+
+if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+  {
+    echo ""
+    cat "$REPORT_FILE"
+  } >> "$GITHUB_STEP_SUMMARY"
+fi
+
+if [ "$FAILURES" -gt 0 ]; then
+  echo "FAIL: ${FAILURES} WASM size-budget check(s) failed." >&2
+  exit 1
+fi
+
+echo "PASS: all WASM artifacts are within their documented budgets."

--- a/tests/test_wasm_size_budget.py
+++ b/tests/test_wasm_size_budget.py
@@ -1,0 +1,124 @@
+"""
+Tests for script/check-wasm-size-budget.sh.
+
+The functional checks run only when bash is available. GitHub Actions Ubuntu
+runners execute them; Windows development machines without bash still get the
+static coverage.
+"""
+
+from __future__ import annotations
+
+import os
+import platform
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = REPO_ROOT / "script" / "check-wasm-size-budget.sh"
+
+
+def test_budget_script_covers_all_workspace_contracts():
+    text = SCRIPT.read_text(encoding="utf-8")
+
+    for contract in ("fluxora_stream", "fluxora_factory", "fluxora_governance"):
+        assert contract in text
+        assert f"-p {contract}" in text
+
+
+def test_budget_script_exposes_per_contract_budget_overrides():
+    text = SCRIPT.read_text(encoding="utf-8")
+
+    assert "FLUXORA_STREAM_WASM_BUDGET_BYTES" in text
+    assert "FLUXORA_FACTORY_WASM_BUDGET_BYTES" in text
+    assert "FLUXORA_GOVERNANCE_WASM_BUDGET_BYTES" in text
+
+
+def test_budget_script_reports_missing_required_raw_artifacts():
+    text = SCRIPT.read_text(encoding="utf-8")
+
+    assert "MISSING ${contract} ${kind} artifact" in text
+    assert "optimized | not present" in text
+
+
+def _run_budget_script(release_dir: Path, report_file: Path, env: dict[str, str]):
+    bash = shutil.which("bash")
+    if bash is None:
+        pytest.skip("bash is not available on this machine")
+    if platform.system() == "Windows" and "WindowsApps" in bash:
+        pytest.skip("WSL bash cannot consume raw Windows paths in this test")
+
+    return subprocess.run(
+        [
+            bash,
+            str(SCRIPT),
+            "--no-build",
+            "--release-dir",
+            str(release_dir),
+            "--report-file",
+            str(report_file),
+        ],
+        cwd=REPO_ROOT,
+        env={**os.environ, **env},
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+
+
+def _write_wasm_artifacts(release_dir: Path, stream_size: int = 10):
+    release_dir.mkdir(parents=True)
+    sizes = {
+        "fluxora_stream.wasm": stream_size,
+        "fluxora_factory.wasm": 8,
+        "fluxora_governance.wasm": 6,
+    }
+    for name, size in sizes.items():
+        (release_dir / name).write_bytes(b"x" * size)
+
+
+def test_budget_script_passes_when_artifacts_fit_budget(tmp_path: Path):
+    release_dir = tmp_path / "release"
+    report = tmp_path / "report.md"
+    _write_wasm_artifacts(release_dir)
+
+    result = _run_budget_script(
+        release_dir,
+        report,
+        {
+            "FLUXORA_STREAM_WASM_BUDGET_BYTES": "20",
+            "FLUXORA_FACTORY_WASM_BUDGET_BYTES": "20",
+            "FLUXORA_GOVERNANCE_WASM_BUDGET_BYTES": "20",
+        },
+    )
+
+    assert result.returncode == 0, result.stderr
+    report_text = report.read_text(encoding="utf-8")
+    assert "| `fluxora_stream` | raw | 10 | 20 | PASS |" in report_text
+    assert "| `fluxora_factory` | optimized | not present | 20 | SKIP |" in report_text
+
+
+def test_budget_script_fails_when_any_artifact_exceeds_budget(tmp_path: Path):
+    release_dir = tmp_path / "release"
+    report = tmp_path / "report.md"
+    _write_wasm_artifacts(release_dir, stream_size=12)
+
+    result = _run_budget_script(
+        release_dir,
+        report,
+        {
+            "FLUXORA_STREAM_WASM_BUDGET_BYTES": "10",
+            "FLUXORA_FACTORY_WASM_BUDGET_BYTES": "20",
+            "FLUXORA_GOVERNANCE_WASM_BUDGET_BYTES": "20",
+        },
+    )
+
+    assert result.returncode == 1
+    assert "FAIL fluxora_stream raw: 12 bytes > 10" in result.stdout
+    assert "| `fluxora_stream` | raw | 12 | 10 | FAIL |" in report.read_text(
+        encoding="utf-8"
+    )


### PR DESCRIPTION
Closes #650.

## Summary
- build release native and wasm artifacts for `fluxora_stream`, `fluxora_factory`, and `fluxora_governance` in CI
- add `script/check-wasm-size-budget.sh` to enforce documented raw/optimized WASM byte budgets and publish a markdown size report
- upload all contract WASM/hash artifacts under a shared artifact name and update deployment downloads accordingly
- document the budget table and local check workflow in `docs/gas.md`
- add pytest coverage for the size-budget script contract list, budget overrides, and pass/fail behavior on POSIX bash runners

## Verification
- `python -m pytest tests/test_validator.py tests/test_wasm_size_budget.py -q` -> 72 passed, 2 skipped on local Windows/WSL-path runner
- `bash -n script/check-wasm-size-budget.sh`
- `cargo fmt --all -- --check`
- `cargo +stable-x86_64-pc-windows-gnu check -p fluxora_governance`
- `cargo +stable-x86_64-pc-windows-gnu build --release --target wasm32-unknown-unknown -p fluxora_governance`
- `git diff --check`

## Notes
- Local full `cargo build --release --target wasm32-unknown-unknown -p fluxora_stream -p fluxora_factory -p fluxora_governance` is currently blocked by existing `fluxora_stream` compile errors on `main` (duplicate definitions and missing symbols before this PR's changes). The CI build step now targets all three contracts and the size-budget gate will run once the workspace build reaches artifact generation.
- The local partial WASM build measured `fluxora_governance.wasm` at 35,666 bytes, below the documented 65,536-byte budget.