### PR TITLE
refactor(governance): index signer and approval membership

### DIFF
--- a/contracts/governance/src/lib.rs
+++ b/contracts/governance/src/lib.rs
@@ -2,7 +2,8 @@
 #![allow(clippy::too_many_arguments)]
 
 use soroban_sdk::{
-    contract, contracterror, contractimpl, contracttype, symbol_short, Address, Bytes, Env, Vec,
+    contract, contracterror, contractimpl, contracttype, symbol_short, Address, Bytes, Env, Map,
+    Vec,
 };
 
 // ---------------------------------------------------------------------------
@@ -109,6 +110,10 @@ pub enum DataKey {
     Proposal(u32),
     /// Ledger timestamp at which a proposal first reached quorum (persistent).
     QuorumReachedAt(u32),
+    /// Map-backed membership index for registered co-signers (instance storage).
+    SignerIndex,
+    /// Per-proposal approval membership index (persistent storage, keyed by ID).
+    ProposalApprovals(u32),
 }
 
 // ---------------------------------------------------------------------------
@@ -212,6 +217,40 @@ fn get_signers(env: &Env) -> Result<Vec<Address>, GovernanceError> {
         .ok_or(GovernanceError::NotInitialized)
 }
 
+fn build_signer_index(
+    env: &Env,
+    signers: &Vec<Address>,
+) -> Result<Map<Address, bool>, GovernanceError> {
+    let mut index = Map::new(env);
+    for i in 0..signers.len() {
+        if let Some(signer) = signers.get(i) {
+            if index.contains_key(signer.clone()) {
+                return Err(GovernanceError::DuplicateSigner);
+            }
+            index.set(signer, true);
+        }
+    }
+    Ok(index)
+}
+
+fn get_signer_index(env: &Env) -> Result<Map<Address, bool>, GovernanceError> {
+    bump_instance(env);
+    if let Some(index) = env.storage().instance().get(&DataKey::SignerIndex) {
+        return Ok(index);
+    }
+
+    let signers = get_signers(env)?;
+    let index = build_signer_index(env, &signers)?;
+    env.storage().instance().set(&DataKey::SignerIndex, &index);
+    Ok(index)
+}
+
+fn save_signers_with_index(env: &Env, signers: &Vec<Address>, index: &Map<Address, bool>) {
+    env.storage().instance().set(&DataKey::Signers, signers);
+    env.storage().instance().set(&DataKey::SignerIndex, index);
+    bump_instance(env);
+}
+
 fn get_threshold(env: &Env) -> Result<u32, GovernanceError> {
     env.storage()
         .instance()
@@ -251,6 +290,44 @@ fn save_proposal(env: &Env, id: u32, proposal: &Proposal) {
     bump_proposal(env, id);
 }
 
+fn get_approval_index(env: &Env, id: u32, proposal: &Proposal) -> Map<Address, bool> {
+    if let Some(index) = env
+        .storage()
+        .persistent()
+        .get(&DataKey::ProposalApprovals(id))
+    {
+        bump_approval_index(env, id);
+        return index;
+    }
+
+    let mut index = Map::new(env);
+    for i in 0..proposal.approvals.len() {
+        if let Some(approver) = proposal.approvals.get(i) {
+            index.set(approver, true);
+        }
+    }
+    env.storage()
+        .persistent()
+        .set(&DataKey::ProposalApprovals(id), &index);
+    bump_approval_index(env, id);
+    index
+}
+
+fn save_approval_index(env: &Env, id: u32, index: &Map<Address, bool>) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::ProposalApprovals(id), index);
+    bump_approval_index(env, id);
+}
+
+fn bump_approval_index(env: &Env, id: u32) {
+    env.storage().persistent().extend_ttl(
+        &DataKey::ProposalApprovals(id),
+        PERSISTENT_LIFETIME_THRESHOLD,
+        PERSISTENT_BUMP_AMOUNT,
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Contract
 // ---------------------------------------------------------------------------
@@ -287,13 +364,16 @@ impl FluxoraGovernance {
         if signers.len() > MAX_SIGNERS {
             return Err(GovernanceError::TooManySigners);
         }
-        Self::require_unique_signers(&signers)?;
+        let signer_index = build_signer_index(&env, &signers)?;
         if threshold == 0 || threshold > signers.len() {
             return Err(GovernanceError::InvalidThreshold);
         }
 
         env.storage().instance().set(&DataKey::Admin, &admin);
         env.storage().instance().set(&DataKey::Signers, &signers);
+        env.storage()
+            .instance()
+            .set(&DataKey::SignerIndex, &signer_index);
         env.storage()
             .instance()
             .set(&DataKey::Threshold, &threshold);
@@ -329,15 +409,16 @@ impl FluxoraGovernance {
     pub fn add_signer(env: Env, signer: Address) -> Result<(), GovernanceError> {
         get_admin(&env)?.require_auth();
         let mut signers = get_signers(&env)?;
-        if Self::is_signer(&signers, &signer) {
+        let mut signer_index = get_signer_index(&env)?;
+        if signer_index.contains_key(signer.clone()) {
             return Err(GovernanceError::DuplicateSigner);
         }
         if signers.len() >= MAX_SIGNERS {
             return Err(GovernanceError::TooManySigners);
         }
-        signers.push_back(signer);
-        env.storage().instance().set(&DataKey::Signers, &signers);
-        bump_instance(&env);
+        signers.push_back(signer.clone());
+        signer_index.set(signer, true);
+        save_signers_with_index(&env, &signers, &signer_index);
         Ok(())
     }
 
@@ -351,6 +432,11 @@ impl FluxoraGovernance {
     ///   threshold, making future proposals permanently unexecutable.
     pub fn remove_signer(env: Env, signer: Address) -> Result<(), GovernanceError> {
         get_admin(&env)?.require_auth();
+        let mut signer_index = get_signer_index(&env)?;
+        if !signer_index.contains_key(signer.clone()) {
+            return Ok(());
+        }
+
         let mut signers = get_signers(&env)?;
         let mut idx: Option<u32> = None;
         for i in 0..signers.len() {
@@ -365,8 +451,8 @@ impl FluxoraGovernance {
                 return Err(GovernanceError::QuorumWouldBreak);
             }
             signers.remove(i);
-            env.storage().instance().set(&DataKey::Signers, &signers);
-            bump_instance(&env);
+            signer_index.remove(signer);
+            save_signers_with_index(&env, &signers, &signer_index);
         }
         Ok(())
     }
@@ -399,8 +485,8 @@ impl FluxoraGovernance {
         proposer.require_auth();
 
         // Verify proposer is a registered signer.
-        let signers = get_signers(&env)?;
-        if !Self::is_signer(&signers, &proposer) {
+        let signer_index = get_signer_index(&env)?;
+        if !signer_index.contains_key(proposer.clone()) {
             return Err(GovernanceError::NotASigner);
         }
 
@@ -456,8 +542,8 @@ impl FluxoraGovernance {
     pub fn approve(env: Env, approver: Address, proposal_id: u32) -> Result<(), GovernanceError> {
         approver.require_auth();
 
-        let signers = get_signers(&env)?;
-        if !Self::is_signer(&signers, &approver) {
+        let signer_index = get_signer_index(&env)?;
+        if !signer_index.contains_key(approver.clone()) {
             return Err(GovernanceError::NotASigner);
         }
 
@@ -473,21 +559,18 @@ impl FluxoraGovernance {
             return Err(GovernanceError::ProposalExpired);
         }
 
-        // Prevent duplicate approvals.
-        for i in 0..proposal.approvals.len() {
-            if proposal
-                .approvals
-                .get(i)
-                .is_some_and(|existing| existing == approver)
-            {
-                return Err(GovernanceError::AlreadyApproved);
-            }
+        // Prevent duplicate approvals using the per-proposal membership index.
+        let mut approval_index = get_approval_index(&env, proposal_id, &proposal);
+        if approval_index.contains_key(approver.clone()) {
+            return Err(GovernanceError::AlreadyApproved);
         }
 
         proposal.approvals.push_back(approver.clone());
+        approval_index.set(approver.clone(), true);
         let approval_count = proposal.approvals.len();
 
         save_proposal(&env, proposal_id, &proposal);
+        save_approval_index(&env, proposal_id, &approval_index);
         bump_instance(&env);
 
         env.events().publish(
@@ -697,29 +780,6 @@ impl FluxoraGovernance {
     // -----------------------------------------------------------------------
     // Internal helpers
     // -----------------------------------------------------------------------
-
-    fn is_signer(signers: &Vec<Address>, addr: &Address) -> bool {
-        for i in 0..signers.len() {
-            if signers.get(i).is_some_and(|signer| &signer == addr) {
-                return true;
-            }
-        }
-        false
-    }
-
-    fn require_unique_signers(signers: &Vec<Address>) -> Result<(), GovernanceError> {
-        for i in 0..signers.len() {
-            let Some(signer) = signers.get(i) else {
-                continue;
-            };
-            for j in (i + 1)..signers.len() {
-                if signers.get(j).is_some_and(|candidate| candidate == signer) {
-                    return Err(GovernanceError::DuplicateSigner);
-                }
-            }
-        }
-        Ok(())
-    }
 }
 
 // ---------------------------------------------------------------------------

--- a/contracts/stream/tests/governance_integration.rs
+++ b/contracts/stream/tests/governance_integration.rs
@@ -69,6 +69,9 @@ fn test_init_stores_signers() {
     let ctx = GovCtx::setup();
     let signers = ctx.client.get_signers();
     assert_eq!(signers.len(), 3);
+    assert_eq!(signers.get(0), Some(ctx.signer_a.clone()));
+    assert_eq!(signers.get(1), Some(ctx.signer_b.clone()));
+    assert_eq!(signers.get(2), Some(ctx.signer_c.clone()));
 }
 
 #[test]
@@ -186,6 +189,10 @@ fn test_approve_duplicate_errors() {
     ctx.client.approve(&ctx.signer_a, &id);
     let result = ctx.client.try_approve(&ctx.signer_a, &id);
     assert_eq!(result, Err(Ok(GovernanceError::AlreadyApproved)));
+
+    let proposal = ctx.client.get_proposal(&id);
+    assert_eq!(proposal.approvals.len(), 1);
+    assert_eq!(proposal.approvals.get(0), Some(ctx.signer_a.clone()));
 }
 
 #[test]
@@ -335,6 +342,35 @@ fn test_add_remove_signer() {
     ctx.client.remove_signer(&new_signer);
     let signers = ctx.client.get_signers();
     assert_eq!(signers.len(), 3);
+}
+
+#[test]
+fn test_signer_index_updates_after_remove_and_readd() {
+    let ctx = GovCtx::setup();
+    let rotating_signer = Address::generate(&ctx.env);
+
+    ctx.client.add_signer(&rotating_signer);
+    ctx.client.remove_signer(&rotating_signer);
+
+    let result = ctx.client.try_propose(
+        &rotating_signer,
+        &ctx.dummy_target(),
+        &ctx.calldata("removed"),
+    );
+    assert_eq!(result, Err(Ok(GovernanceError::NotASigner)));
+
+    ctx.client.add_signer(&rotating_signer);
+    let signers = ctx.client.get_signers();
+    assert_eq!(signers.len(), 4);
+    assert_eq!(signers.get(3), Some(rotating_signer.clone()));
+
+    let proposal_id = ctx.client.propose(
+        &rotating_signer,
+        &ctx.dummy_target(),
+        &ctx.calldata("readded"),
+    );
+    let proposal = ctx.client.get_proposal(&proposal_id);
+    assert_eq!(proposal.proposer, rotating_signer);
 }
 
 #[test]

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -56,6 +56,17 @@ addresses with `DuplicateSigner`, so quorum calculations are based on unique key
 proposer is not automatically counted as an approver; they must submit a separate `approve`
 call if their signature should count toward quorum.
 
+The contract stores co-signers in two synchronized structures:
+
+- `Signers`: the ordered `Vec<Address>` returned by `get_signers` for backward-compatible
+  enumeration.
+- `SignerIndex`: a `Map<Address, bool>` used by hot membership checks in `propose`,
+  `approve`, and duplicate-signer validation.
+
+`init`, `add_signer`, and `remove_signer` update both structures in the same successful
+entrypoint. If upgraded state is missing `SignerIndex`, the index is rebuilt from the
+ordered vector before it is used.
+
 ## Proposal lifecycle
 
 ```text
@@ -138,6 +149,8 @@ Records an approval from a co-signer.
 
 - `approver` must authorize the call and be a registered co-signer.
 - Each signer may approve at most once per proposal.
+- Duplicate approval detection uses `ProposalApprovals(proposal_id)`, a persistent
+  `Map<Address, bool>` kept in sync with the ordered `Proposal.approvals` vector.
 - Approvals are rejected after execution, cancellation, or expiry.
 - Every successful approval emits `ProposalApproved`.
 - When the approval count first reaches the configured threshold, the contract stores
@@ -236,9 +249,11 @@ All storage keys are defined in `DataKey`:
 |---|---|---|
 | `Admin` | Instance | `Address` |
 | `Signers` | Instance | `Vec<Address>` |
+| `SignerIndex` | Instance | `Map<Address, bool>` |
 | `Threshold` | Instance | `u32` |
 | `NextProposalId` | Instance | `u32` |
 | `Proposal(u32)` | Persistent | `Proposal` (includes `created_at`, `executed`, and `cancelled`) |
+| `ProposalApprovals(u32)` | Persistent | `Map<Address, bool>` |
 | `QuorumReachedAt(u32)` | Persistent | `QuorumInfo { reached_at: u64, threshold: u32 }` |
 
 ## GovernanceError codes
@@ -295,6 +310,9 @@ handle these discriminants from `contracts/governance/src/lib.rs`:
 14. **Threshold is snapshotted at quorum time**: execution uses the threshold recorded in
     `QuorumInfo`, so an admin cannot raise or lower the live threshold after quorum to change
     the outcome of an in-flight proposal.
+15. **Signer indexes mirror canonical vectors**: `SignerIndex` and `ProposalApprovals` are
+    updated together with the ordered signer and approval vectors, so indexed membership
+    checks cannot authorize an address that is absent from canonical state.
 
 ## Tests
 
@@ -304,6 +322,7 @@ Integration tests are in `contracts/stream/tests/governance_integration.rs` and 
 - Duplicate signer rejection during initialization and signer management.
 - Proposal creation and ID assignment.
 - Approval counting and duplicate rejection.
+- Signer membership index consistency after add, remove, and re-add.
 - Non-signer rejection on both `propose` and `approve`.
 - Quorum enforcement and exact-threshold execution.
 - Timelock enforcement.


### PR DESCRIPTION
## Summary
- Closes #641.
- Adds a `SignerIndex` map alongside the ordered signer vector so hot signer membership checks no longer scan `Signers`.
- Adds a per-proposal `ProposalApprovals` map so duplicate approval detection is indexed while preserving the ordered `Proposal.approvals` vector for compatibility.
- Keeps `get_signers` ordering stable and documents the dual-structure invariant plus storage layout.

## Tests and validation
- `cargo +stable-x86_64-pc-windows-gnu fmt --all -- --check`
- `cargo +stable-x86_64-pc-windows-gnu check -p fluxora_governance`
- `cargo +stable-x86_64-pc-windows-gnu build --release --target wasm32-unknown-unknown -p fluxora_governance`
- `git diff --check`

## Local blockers / baseline notes
- `cargo +stable-x86_64-pc-windows-gnu test -p fluxora_stream --test governance_integration test_signer_index_updates_after_remove_and_readd -- --exact` was blocked before project tests by the local Windows GNU `dlltool.exe: CreateProcess` import-library failure in dependencies such as `getrandom` / `backtrace`.
- `cargo +stable-x86_64-pc-windows-gnu check -p fluxora_stream --test governance_integration` reaches the current upstream `fluxora_stream` compile baseline and fails on existing duplicate/missing stream definitions unrelated to this governance-only change.
- `cargo +stable-x86_64-pc-windows-gnu clippy -p fluxora_governance -- -D warnings` could not run because `cargo-clippy.exe` is not installed for the local GNU toolchain.

## Security notes
- `init`, `add_signer`, and `remove_signer` update the signer vector and index together.
- If upgraded state lacks `SignerIndex`, it is rebuilt from the canonical ordered vector before use.
- Successful approvals update `Proposal.approvals` and `ProposalApprovals` together, so duplicate approval checks stay aligned with canonical proposal state.

Head commit: `7c8426927d914cd10d51893593a43fa4ff57920c`