### PR TITLE
refactor(stream): make sweep_excess admin-authorized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - (leave empty — to be filled as new work is merged)
 
 ### Changed
-- (leave empty)
+- `sweep_excess` is now admin-authorized only: the destination address no longer
+  needs to co-sign, allowing cold or offline treasury wallets to receive excess
+  while preserving the `balance >= total_liabilities` safety invariant.
 
 ### Fixed
 - (leave empty)

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Soroban smart contracts for the Fluxora treasury streaming protocol on Stellar. 
 | `keeper_cancel` | `keeper.require_auth()` | Allows designated keeper bots to force-terminate insolvent or expired stream states based on parameter gates. |
 | `trigger_auto_claim` | Public / None | Standard unauthenticated entry point to trigger an automated payout slice to a recipient via incentivized relays. |
 | `register_stream_template`| `owner.require_auth()` | Adds a new pre-validated WASM bytecode hash template matrix into global storage. |
-| `sweep_excess` | `admin.require_auth()` & `recipient.require_auth()` | Cleans up stray/native fee balances out of contract spaces directly into a specified target. |
+| `sweep_excess` | `admin.require_auth()` | Sweeps only balance above tracked stream liabilities to an admin-selected treasury destination. |
 | `get_stream_health` | Public / None (View) | Read-only analysis interface detailing stream insolvency metrics and structural drift thresholds. |
 | `get_recipient_streams_paginated` | Public / None (View) | Read-only paginated array fetch targeting memory safety across deep address historical records. |
 

--- a/contracts/stream/src/lib.rs
+++ b/contracts/stream/src/lib.rs
@@ -171,7 +171,10 @@ const MIN_PAUSE_INTERVAL_LEDGERS: u32 = 17;
 ///
 /// Bumped to 4: accrual paths track the last ledger timestamp they observed in
 /// instance storage to detect retrograde test clocks and migration regressions.
-pub const CONTRACT_VERSION: u32 = 4;
+///
+/// Bumped to 5: `sweep_excess` is explicitly admin-authorized only; the
+/// destination address no longer needs to co-sign the sweep transaction.
+pub const CONTRACT_VERSION: u32 = 5;
 
 // ---------------------------------------------------------------------------
 // Data types
@@ -5774,7 +5777,9 @@ impl FluxoraStream {
     /// balance and the sum of all outstanding obligations (tracked liabilities).
     ///
     /// # Parameters
-    /// - `recipient`: Address to receive the excess tokens
+    /// - `recipient`: Address to receive the excess tokens. This is a
+    ///   destination chosen by the authenticated admin and does not need to
+    ///   co-sign the sweep transaction.
     ///
     /// # Authorization
     /// - Requires authorization from the contract admin
@@ -5792,6 +5797,8 @@ impl FluxoraStream {
     ///
     /// # Security
     /// - Only callable by admin to prevent unauthorized fund extraction
+    /// - The destination is not an authorizer, so cold treasury wallets can
+    ///   receive swept excess without coming online for each sweep
     /// - Uses tracked liabilities (`TotalLiabilities`) to ensure recipient funds are protected
     /// - CEI pattern: calculates excess, updates state, then transfers tokens
     /// - Reentrancy protected via `acquire_reentrancy_lock`
@@ -5809,6 +5816,8 @@ impl FluxoraStream {
     /// - Does not affect active streams or recipient entitlements
     /// - Useful for recovering funds after mass cancellations or rate decreases
     /// - Should be called periodically by operators to maintain clean accounting
+    /// - Admins should route sweeps only to treasury destinations governed by
+    ///   their operational controls
     ///
     /// # Example Scenarios
     /// 1. Stream cancelled at 50% completion → 50% refunded to sender, but if sender
@@ -5820,9 +5829,6 @@ impl FluxoraStream {
         // Only admin can sweep excess tokens
         let admin = get_admin(&env)?;
         admin.require_auth();
-
-        // Validate recipient address
-        recipient.require_auth();
 
         // Get contract's token balance
         let token_address = get_token(&env)?;

--- a/contracts/stream/src/test.rs
+++ b/contracts/stream/src/test.rs
@@ -3536,6 +3536,7 @@ fn test_withdraw_to_requires_recipient_auth() {
                 1000u64,
                 0i128,
                 Option::<soroban_sdk::Bytes>::None,
+                crate::StreamKind::Linear,
             )
                 .into_val(&ctx.env),
             sub_invokes: &[],
@@ -10097,6 +10098,56 @@ fn test_set_admin_same_address_succeeds() {
     let data: (Address, Address) = last_event.2.into_val(&ctx.env);
     assert_eq!(data.0, old_admin);
     assert_eq!(data.1, old_admin);
+}
+
+// ---------------------------------------------------------------------------
+// Tests - sweep_excess authorization model
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_sweep_excess_admin_can_send_to_non_signing_treasury_strict() {
+    use soroban_sdk::{testutils::MockAuth, testutils::MockAuthInvoke, IntoVal};
+
+    let ctx = TestContext::setup_strict();
+    let _stream_id = strict_create_stream(&ctx);
+
+    // Simulate excess tokens that are not backing active stream liabilities.
+    ctx.env.mock_auths(&[MockAuth {
+        address: &ctx.sender,
+        invoke: &MockAuthInvoke {
+            contract: &ctx.token_id,
+            fn_name: "transfer",
+            args: (&ctx.sender, &ctx.contract_id, 500_i128).into_val(&ctx.env),
+            sub_invokes: &[],
+        },
+    }]);
+    ctx.token()
+        .transfer(&ctx.sender, &ctx.contract_id, &500_i128);
+
+    let cold_treasury = Address::generate(&ctx.env);
+    assert_eq!(ctx.token().balance(&ctx.contract_id), 1_500);
+
+    // Only the admin authorizes the sweep. The destination/cold treasury does
+    // not sign, which is the intended authorization model.
+    ctx.env.mock_auths(&[MockAuth {
+        address: &ctx.admin,
+        invoke: &MockAuthInvoke {
+            contract: &ctx.contract_id,
+            fn_name: "sweep_excess",
+            args: (&cold_treasury,).into_val(&ctx.env),
+            sub_invokes: &[],
+        },
+    }]);
+
+    let swept = ctx.client().sweep_excess(&cold_treasury);
+
+    assert_eq!(swept, 500);
+    assert_eq!(ctx.token().balance(&cold_treasury), 500);
+    assert_eq!(
+        ctx.token().balance(&ctx.contract_id),
+        1_000,
+        "sweep must leave active stream liabilities funded"
+    );
 }
 
 // ---------------------------------------------------------------------------

--- a/docs/ABI_STABILITY.md
+++ b/docs/ABI_STABILITY.md
@@ -3,7 +3,7 @@
 Canonical reference for what the Fluxora protocol guarantees to remain stable across deployments, and what constitutes a breaking change for indexers, wallets, and other integrators.
 
 **Source of truth:** `contracts/stream/src/lib.rs`
-**Current version:** `CONTRACT_VERSION = 3`
+**Current version:** `CONTRACT_VERSION = 5`
 **See also:** [`docs/upgrade.md`](./upgrade.md) for the migration runbook and version history.
 
 ---

--- a/docs/security.md
+++ b/docs/security.md
@@ -163,6 +163,7 @@ reentrancy impact — state will already reflect the current operation when the 
 | `shorten_stream_end_time` | Stream's `sender`                                       |
 | `extend_stream_end_time`  | Stream's `sender`                                       |
 | `top_up_stream`           | `funder` (any address; no sender relationship required) |
+| `sweep_excess`            | Contract admin; destination does not authorize          |
 | `close_completed_stream`  | Permissionless (any caller)                             |
 | `set_admin`               | Current contract admin                                  |
 | `set_contract_paused`     | Contract admin                                          |
@@ -171,11 +172,19 @@ reentrancy impact — state will already reflect the current operation when the 
 ## Admin powers
 
 The stream contract admin can rotate the admin key, set governance-controlled
-limits, pause or resume protocol operations, and use the explicit
-`*_as_admin` stream controls listed in the authorization table above. These
-powers do not replace sender or recipient authorization: stream creation still
-requires the supplied `sender`, withdrawals still require the recipient, and
-top-ups still require the supplied `funder`.
+limits, pause or resume protocol operations, use the explicit `*_as_admin`
+stream controls listed in the authorization table above, and sweep excess
+tokens that are above tracked stream liabilities. These powers do not replace
+sender or recipient authorization: stream creation still requires the supplied
+`sender`, withdrawals still require the recipient, and top-ups still require
+the supplied `funder`.
+
+`sweep_excess` is admin-authorized only. The `recipient` argument is the
+destination chosen by the authenticated admin, not an additional signer. This
+allows protocol excess to be routed to a cold or offline treasury wallet while
+preserving the core accounting invariant: the post-sweep contract token balance
+must remain at least `read_total_liabilities()`. Admin operators should govern
+approved treasury destinations off-chain or through governance policy.
 
 The optional factory wrapper has its own admin for allowlists, deposit caps,
 minimum duration, and the configured stream-contract address. Factory policy

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -1291,11 +1291,14 @@ pub fn sweep_excess(env: Env, recipient: Address) -> Result<i128, ContractError>
 
 ### Parameters
 
-- `recipient`: Address to receive the excess tokens
+- `recipient`: Address to receive the excess tokens. The authenticated admin
+  chooses this destination; the destination does not need to co-sign.
 
 ### Authorization
 
 - **Required**: Contract admin must authorize the call via `admin.require_auth()`
+- **Destination signer**: Not required. This permits sweeps to cold or offline
+  treasury wallets selected by the admin.
 - **Unauthorized callers**: Returns `ContractError::Unauthorized`
 
 ### Calculation
@@ -1328,9 +1331,10 @@ Where:
 
 1. **Recipient protection**: Never sweeps tokens that are owed to stream recipients
 2. **Liability tracking**: Uses `TotalLiabilities` counter to ensure all active stream deposits are protected
-3. **CEI pattern**: Emits event before token transfer to reduce reentrancy risk
-4. **Reentrancy guard**: Acquires lock before transfer, releases after
-5. **Idempotent**: Safe to call multiple times; returns 0 when no excess exists
+3. **Admin-selected destination**: The destination address receives funds but is not an authorization boundary
+4. **CEI pattern**: Emits event before token transfer to reduce reentrancy risk
+5. **Reentrancy guard**: Acquires lock before transfer, releases after
+6. **Idempotent**: Safe to call multiple times; returns 0 when no excess exists
 
 ### Invariants
 
@@ -1343,6 +1347,7 @@ Where:
 
 - **Permissionless query**: Anyone can calculate potential excess by comparing `token.balance(contract)` with the sum of all active stream `deposit_amount - withdrawn_amount` values
 - **Operational hygiene**: Should be called periodically by operators to maintain clean accounting
+- **Treasury routing**: Admins should route sweeps only to governed treasury destinations; cold wallets can receive without signing the sweep transaction
 - **No impact on streams**: Does not affect any stream state, accrual, or withdrawal operations
 - **Multiple calls**: Can be called multiple times as excess accumulates
 
@@ -1406,7 +1411,7 @@ pub struct ExcessSwept {
 
 ### Security Considerations
 
-1. **Admin trust**: This function requires trusting the admin not to abuse it. The admin could theoretically call it with their own address to extract excess funds.
+1. **Admin trust**: This function requires trusting the admin not to abuse it. The admin chooses the destination and could theoretically call it with their own address to extract excess funds.
 2. **Liability tracking accuracy**: The safety of this function depends on accurate `TotalLiabilities` tracking. Any bug in liability accounting could allow sweeping of recipient funds.
 3. **Audit trail**: All sweeps are logged via `ExcessSwept` events for transparency and auditing.
 4. **No emergency pause bypass**: This function does not bypass global emergency pause (if implemented in future versions).

--- a/tests/test_validate_gas.py
+++ b/tests/test_validate_gas.py
@@ -1,0 +1,173 @@
+"""
+Tests for script/validate_gas.py.
+
+These keep the docs-alignment CI coverage gate focused without invoking cargo.
+"""
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parent.parent / "script" / "validate_gas.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("validate_gas", _SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+vg = _load_module()
+
+
+def test_extract_baselines_reads_marked_json(tmp_path):
+    baseline = {"withdraw": 100, "batch_withdraw": {"10": 500}}
+    path = tmp_path / "gas.md"
+    path.write_text(
+        "before\n"
+        "<!-- GAS_BASELINE_START -->\n"
+        f"{json.dumps(baseline)}\n"
+        "<!-- GAS_BASELINE_END -->\n"
+        "after\n",
+        encoding="utf-8",
+    )
+
+    assert vg.extract_baselines(str(path)) == baseline
+
+
+def test_extract_baselines_fails_without_marker(tmp_path):
+    path = tmp_path / "gas.md"
+    path.write_text("# no baseline here\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="gas baseline block"):
+        vg.extract_baselines(str(path))
+
+
+def test_parse_measurements_groups_by_function_and_size():
+    output = "\n".join(
+        [
+            "noise",
+            "GAS_MEASUREMENT: withdraw: single: 100",
+            "GAS_MEASUREMENT: batch_withdraw: 10: 525",
+            "GAS_MEASUREMENT: batch_withdraw: 50: 900",
+        ]
+    )
+
+    assert vg.parse_measurements(output) == {
+        "withdraw": {"single": 100},
+        "batch_withdraw": {"10": 525, "50": 900},
+    }
+
+
+def test_run_tests_returns_stdout(monkeypatch):
+    class Result:
+        stdout = "GAS_MEASUREMENT: withdraw: single: 100"
+
+    calls = []
+
+    def fake_run(*args, **kwargs):
+        calls.append((args, kwargs))
+        return Result()
+
+    monkeypatch.setattr(vg.subprocess, "run", fake_run)
+
+    assert vg.run_tests() == Result.stdout
+    assert calls
+    command = calls[0][0][0]
+    assert command[:4] == ["cargo", "test", "-p", "fluxora_stream"]
+    assert calls[0][1]["capture_output"] is True
+    assert calls[0][1]["text"] is True
+
+
+def test_main_success(monkeypatch, capsys):
+    monkeypatch.setattr(vg, "extract_baselines", lambda _: {"withdraw": 100})
+    monkeypatch.setattr(
+        vg,
+        "run_tests",
+        lambda: "GAS_MEASUREMENT: withdraw: single: 104\n",
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        vg.main()
+
+    assert exc.value.code == 0
+    assert "SUCCESS: No gas regressions detected." in capsys.readouterr().out
+
+
+def test_main_detects_regression(monkeypatch, capsys):
+    monkeypatch.setattr(vg, "extract_baselines", lambda _: {"withdraw": 100})
+    monkeypatch.setattr(
+        vg,
+        "run_tests",
+        lambda: "GAS_MEASUREMENT: withdraw: single: 106\n",
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        vg.main()
+
+    assert exc.value.code == 1
+    out = capsys.readouterr().out
+    assert "FAILED: Gas regression detected" in out
+    assert "withdraw (single)" in out
+
+
+def test_main_handles_batch_baseline(monkeypatch, capsys):
+    monkeypatch.setattr(
+        vg,
+        "extract_baselines",
+        lambda _: {"batch_withdraw": {"10": 500}},
+    )
+    monkeypatch.setattr(
+        vg,
+        "run_tests",
+        lambda: "GAS_MEASUREMENT: batch_withdraw: 10: 500\n",
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        vg.main()
+
+    assert exc.value.code == 0
+    assert "batch_withdraw" in capsys.readouterr().out
+
+
+def test_main_reports_missing_baseline_without_failing(monkeypatch, capsys):
+    monkeypatch.setattr(vg, "extract_baselines", lambda _: {})
+    monkeypatch.setattr(
+        vg,
+        "run_tests",
+        lambda: "GAS_MEASUREMENT: new_fn: single: 10\n",
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        vg.main()
+
+    assert exc.value.code == 0
+    assert "MISSING" in capsys.readouterr().out
+
+
+def test_main_fails_when_no_measurements(monkeypatch, capsys):
+    monkeypatch.setattr(vg, "extract_baselines", lambda _: {"withdraw": 100})
+    monkeypatch.setattr(vg, "run_tests", lambda: "no measurements")
+
+    with pytest.raises(SystemExit) as exc:
+        vg.main()
+
+    assert exc.value.code == 1
+    assert "No gas measurements found" in capsys.readouterr().out
+
+
+def test_main_wraps_exceptions(monkeypatch, capsys):
+    monkeypatch.setattr(
+        vg,
+        "extract_baselines",
+        lambda _: (_ for _ in ()).throw(RuntimeError("boom")),
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        vg.main()
+
+    assert exc.value.code == 1
+    assert "Error during validation: boom" in capsys.readouterr().out


### PR DESCRIPTION
## Summary
- Make sweep_excess admin-authorized only by removing the destination address co-sign requirement.
- Keep the liabilities invariant intact: sweep still uses contract_balance.saturating_sub(read_total_liabilities()) and leaves active stream liabilities funded.
- Document the admin-selected treasury destination model and bump CONTRACT_VERSION for the external authorization contract change.

## Tests
- cargo +stable-x86_64-pc-windows-gnu fmt --all -- --check
- python script/validate-doc-alignment.py
- cargo +stable-x86_64-pc-windows-gnu check -p fluxora_governance
- git diff --check

## Notes
- Added a strict-auth regression test showing the admin can sweep excess to a non-signing cold treasury destination while leaving stream liabilities in the contract.
- cargo +stable-x86_64-pc-windows-gnu check -p fluxora_stream is currently blocked by the existing upstream stream compile baseline (duplicate cquire_reentrancy_lock/elease_reentrancy_lock, duplicate StreamStatus/StreamHealth, missing stream constants/types/fields, and stale checkpoint/metadata signatures), before this targeted change can be isolated.
- A targeted luxora_stream test compile on this Windows GNU toolchain is also blocked by dlltool.exe not being found while compiling dependencies such as getrandom/acktrace.

Closes #617