### PR TITLE
fix(stream): return InvalidSignature for bad delegated withdraw signatures

### DIFF
--- a/contracts/stream/Cargo.toml
+++ b/contracts/stream/Cargo.toml
@@ -19,6 +19,7 @@ testutils = ["soroban-sdk/testutils"]
 
 [dependencies]
 soroban-sdk = "21.7.7"
+ed25519-dalek = { version = "2.1", default-features = false, features = ["fast"] }
 
 [dev-dependencies]
 # Required for simulating ledger environment and testing time dependencies
@@ -30,5 +31,5 @@ fluxora_governance = { path = "../governance", features = ["testutils"] }
 # Property-based testing for accrual math fuzz harness (#292)
 proptest = "1"
 # Required for constructing Ed25519 keypairs in delegated-withdraw tests
-ed25519-dalek = { version = "2.1", features = ["rand_core"] }
+ed25519-dalek = { version = "2.1", default-features = false, features = ["fast", "rand_core"] }
 rand = "0.8"

--- a/contracts/stream/src/lib.rs
+++ b/contracts/stream/src/lib.rs
@@ -193,7 +193,7 @@ pub struct IdReservation {
     pub start_id: u64,
     pub count: u32,
     pub consumed: u32,
-    pub expiry: Option<u64>
+    pub expiry: Option<u64>,
 }
 
 /// Reason for a protocol or stream pause.
@@ -375,7 +375,7 @@ pub enum ContractError {
     PauseReasonTooLong = 23,
     ReservationNotFound = 24,
     ReservationNotExpirable = 25,
-    ReservationStillActive = 26
+    ReservationStillActive = 26,
 }
 
 #[contracttype]
@@ -6503,7 +6503,7 @@ impl FluxoraStream {
         env: Env,
         caller: Address,
         count: u32,
-        expiry: Option<u64>
+        expiry: Option<u64>,
     ) -> Result<soroban_sdk::Vec<u64>, ContractError> {
         caller.require_auth();
 
@@ -6521,7 +6521,7 @@ impl FluxoraStream {
             start_id,
             count,
             consumed: 0,
-            expiry
+            expiry,
         };
         save_id_reservation(&env, &caller, &res);
 
@@ -6540,10 +6540,7 @@ impl FluxoraStream {
     ///
     /// # Security
     /// - Authorization required .
-    pub fn release_id_reservation(
-        env: Env,
-        caller: Address,
-    ) -> Result<(), ContractError> {
+    pub fn release_id_reservation(env: Env, caller: Address) -> Result<(), ContractError> {
         caller.require_auth();
 
         remove_id_reservation(&env, &caller);
@@ -6579,8 +6576,7 @@ impl FluxoraStream {
     /// - `ReservationNotExpirable` (25): `expiry` is None.
     /// - `ReservationStillActive` (26): `current time > expiry`
     pub fn reclaim_expired_id_reservation(env: Env, holder: Address) -> Result<(), ContractError> {
-        let res = load_id_reservation(&env, &holder)
-            .ok_or(ContractError::ReservationNotFound)?;
+        let res = load_id_reservation(&env, &holder).ok_or(ContractError::ReservationNotFound)?;
 
         let expiry = res.expiry.ok_or(ContractError::ReservationNotExpirable)?;
         if env.ledger().timestamp() < expiry {

--- a/contracts/stream/src/lib.rs
+++ b/contracts/stream/src/lib.rs
@@ -6,6 +6,7 @@ mod accrual;
 mod checksum;
 mod token_check;
 
+use ed25519_dalek::{Signature, VerifyingKey};
 use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, token, Address, Env};
 use token_check::verify_token_behavior;
 
@@ -956,6 +957,34 @@ fn current_accrual_timestamp(env: &Env) -> Result<u64, ContractError> {
     env.storage().instance().set(&key, &now);
     bump_instance_ttl(env);
     Ok(now)
+}
+
+fn delegated_withdraw_signed_message(
+    stream_id: u64,
+    nonce: u64,
+    deadline: u64,
+    expected_minimum_amount: i128,
+) -> [u8; 40] {
+    let mut msg = [0u8; 40];
+    msg[0..8].copy_from_slice(&stream_id.to_be_bytes());
+    msg[8..16].copy_from_slice(&nonce.to_be_bytes());
+    msg[16..24].copy_from_slice(&deadline.to_be_bytes());
+    msg[24..40].copy_from_slice(&expected_minimum_amount.to_be_bytes());
+    msg
+}
+
+fn verify_delegated_withdraw_signature(
+    recipient_public_key: &soroban_sdk::BytesN<32>,
+    signature: &soroban_sdk::BytesN<64>,
+    message: &[u8; 40],
+) -> Result<(), ContractError> {
+    let verifying_key = VerifyingKey::from_bytes(&recipient_public_key.to_array())
+        .map_err(|_| ContractError::InvalidSignature)?;
+    let signature = Signature::from_bytes(&signature.to_array());
+
+    verifying_key
+        .verify_strict(message, &signature)
+        .map_err(|_| ContractError::InvalidSignature)
 }
 
 fn acquire_reentrancy_lock(env: &Env) -> Result<(), ContractError> {
@@ -3553,20 +3582,15 @@ impl FluxoraStream {
 
         // 5. Build the signed message:
         //    stream_id (8 bytes) | nonce (8 bytes) | deadline (8 bytes) | expected_minimum_amount (16 bytes)
-        let mut msg = soroban_sdk::Bytes::new(&env);
-        msg.extend_from_array(&stream_id.to_be_bytes());
-        msg.extend_from_array(&nonce.to_be_bytes());
-        msg.extend_from_array(&deadline.to_be_bytes());
-        msg.extend_from_array(&expected_minimum_amount.to_be_bytes());
+        let signed_message =
+            delegated_withdraw_signed_message(stream_id, nonce, deadline, expected_minimum_amount);
 
-        // 5. Verify ed25519 signature — panics on failure (Soroban host trap).
-        let pk_bytes: soroban_sdk::BytesN<32> = recipient_public_key
-            .try_into()
-            .map_err(|_| ContractError::InvalidSignature)?;
-        let sig_bytes: soroban_sdk::BytesN<64> = signature
-            .try_into()
-            .map_err(|_| ContractError::InvalidSignature)?;
-        env.crypto().ed25519_verify(&pk_bytes, &msg, &sig_bytes);
+        // 6. Verify ed25519 signature with a structured error before calling
+        // the host verifier, which traps if verification fails.
+        verify_delegated_withdraw_signature(&recipient_public_key, &signature, &signed_message)?;
+        let msg = soroban_sdk::Bytes::from_array(&env, &signed_message);
+        env.crypto()
+            .ed25519_verify(&recipient_public_key, &msg, &signature);
 
         // 7. State checks (same as withdraw).
         if stream.status == StreamStatus::Completed {

--- a/contracts/stream/tests/adversarial_auth.rs
+++ b/contracts/stream/tests/adversarial_auth.rs
@@ -1289,6 +1289,44 @@ fn sign_delegated_msg(env: &Env, signing_key: &SigningKey, msg: &soroban_sdk::By
 }
 
 #[test]
+fn delegated_withdraw_bad_signature_returns_invalid_signature() {
+    let ctx = Ctx::setup();
+    ctx.env.mock_all_auths();
+    ctx.env.ledger().set_timestamp(0);
+    let stream_id = ctx.create_stream();
+
+    ctx.env.ledger().set_sequence_number(100);
+    ctx.env.ledger().set_timestamp(500);
+
+    let (pub_key, signing_key) = delegated_keypair(&ctx.env);
+    let nonce = 0u64;
+    let deadline = 9999u64;
+    let min_amount = 0i128;
+    let msg = build_delegated_msg(&ctx.env, stream_id, nonce, deadline, min_amount);
+    let valid_sig = sign_delegated_msg(&ctx.env, &signing_key, &msg);
+    let mut bad_sig_bytes = valid_sig.to_array();
+    bad_sig_bytes[0] ^= 0x01;
+    let bad_sig = BytesN::from_array(&ctx.env, &bad_sig_bytes);
+
+    let relayer = Address::generate(&ctx.env);
+    let result = ctx.client().try_delegated_withdraw(
+        &stream_id,
+        &relayer,
+        &pub_key,
+        &nonce,
+        &deadline,
+        &min_amount,
+        &bad_sig,
+    );
+
+    assert_eq!(
+        result,
+        Err(Ok(fluxora_stream::ContractError::InvalidSignature)),
+        "bad ed25519 signatures must return InvalidSignature instead of a host trap"
+    );
+}
+
+#[test]
 fn delegated_withdraw_expired_deadline_rejected() {
     let ctx = Ctx::setup();
     ctx.env.mock_all_auths();

--- a/docs/error.md
+++ b/docs/error.md
@@ -37,6 +37,9 @@ treasury tooling) can use this reference to handle protocol exceptions correctly
 | `TemplateUnauthorized` | 22 | Caller is not authorized to delete a template | `delete_stream_template` |
 | `TokenVerificationFailed` | 23 | Token contract does not expose the expected SEP-41 interface during init | `init` |
 | `PauseReasonTooLong` | 23 | Pause reason string exceeds `MAX_PAUSE_REASON_BYTES` | `pause_protocol` |
+| `ReservationNotFound` | 24 | No active ID reservation exists for the requested holder | `reclaim_expired_id_reservation` |
+| `ReservationNotExpirable` | 25 | ID reservation has no expiry timestamp and cannot be permissionlessly reclaimed | `reclaim_expired_id_reservation` |
+| `ReservationStillActive` | 26 | ID reservation expiry timestamp has not passed yet | `reclaim_expired_id_reservation` |
 
 Non-error enum values used by stream creation and accrual:
 

--- a/docs/events.md
+++ b/docs/events.md
@@ -43,9 +43,10 @@ Notes:
 | AutoClaimSet | `["ac_set", stream_id: u64]` | `AutoClaimSet { stream_id: u64, destination: Address }` | When a recipient configures or changes a permissionless final-claim destination via `set_auto_claim`. |
 | AutoClaimRevoked | `["ac_revoke", stream_id: u64]` | `AutoClaimRevoked { stream_id: u64 }` | When a recipient revokes auto-claim configuration via `revoke_auto_claim`. |
 | AutoClaimTriggered | `["ac_trig", stream_id: u64]` | `AutoClaimTriggered { stream_id: u64, destination: Address, amount: i128 }` | When a third party successfully executes a configured final claim via `trigger_auto_claim`. |
+| ReservationReleased | `["res_rel", holder: Address]` | `(start_id: u64, count: u32, consumed: u32, reclaimed: u32)` | When an expired ID reservation is reclaimed via `reclaim_expired_id_reservation`. `reclaimed` is non-zero only when the unconsumed range is still at the tail of the global counter. |
 | MigrationCheckpoint | `["migrated"]` | `(from_version: u32, to_version: u32, timestamp: u64)` | When `migration_v5_to_v6` is called as an auditable deployment checkpoint. |
 
-**Additional topics (validator):** `cloned`, `kp_cncl`, `gl_pause`, `gl_resume`, `rate_dec`, `tmpl_def`, `hlth_chg`, `ex_swept`, `ac_set`, `ac_revoke`, `ac_trig`, `migrated`.
+**Additional topics (validator):** `cloned`, `kp_cncl`, `gl_pause`, `gl_resume`, `rate_dec`, `tmpl_def`, `hlth_chg`, `ex_swept`, `ac_set`, `ac_revoke`, `ac_trig`, `res_rel`, `migrated`.
 
 ---
 | Event name | Topic(s) | Data (shape & types) | When emitted |

--- a/docs/security.md
+++ b/docs/security.md
@@ -306,7 +306,8 @@ Including the destination prevents a relayer from redirecting funds.
 
 - A used signature cannot be replayed (nonce incremented on success).
 - An expired signature is rejected before any state change.
-- A signature from the wrong key is rejected by `ed25519_verify` (host trap).
+- A signature from the wrong key is rejected with `InvalidSignature` before the
+  host verifier is called.
 - The destination is bound in the signed message — a relayer cannot redirect funds.
 - The contract address is bound in the signed message — signatures are chain/contract-specific.
 - Direct `withdraw` / `withdraw_to` / `batch_withdraw` are unaffected; their auth paths

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -1087,7 +1087,7 @@ Each recipient has a per-address nonce stored in `DataKey::DelegatedWithdrawNonc
 |-----------|-------|
 | `ledger.timestamp() > deadline` | `InvalidSignature` (15) |
 | `nonce != stored_nonce` | `InvalidSignature` (15) |
-| ed25519 signature invalid | host trap (panic) |
+| ed25519 signature invalid | `InvalidSignature` (15) |
 | `withdrawable < expected_minimum_amount` | `BelowMinimumAmount` (16) |
 | Stream paused (non-terminal) | `InvalidState` (2) |
 | Stream completed | `InvalidState` (2) |

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -103,7 +103,7 @@ From **CONTRACT_VERSION 4**, the contract supports distinct streaming styles, go
 
 Off-chain orchestrators and indexers that build payment batches often need to know stream IDs **before** submitting `create_stream` transactions, to pre-populate database records or cross-reference external invoice systems.
 
-`reserve_stream_ids(caller, count)` atomically advances the global ID counter by `count` and returns the reserved range as a `Vec<u64>`.  Subsequent `create_stream` calls by the same `caller` consume IDs from the reservation in order; once exhausted (or if no reservation exists) the live counter is used.
+`reserve_stream_ids(caller, count, expiry)` atomically advances the global ID counter by `count` and returns the reserved range as a `Vec<u64>`.  Subsequent `create_stream` calls by the same `caller` consume IDs from the reservation in order; once exhausted (or if no reservation exists) the live counter is used.
 
 | Constant | Value | Purpose |
 |---|---|---|
@@ -114,7 +114,8 @@ Off-chain orchestrators and indexers that build payment batches often need to kn
 - `count = 0` -> `ReservationCountZero` (17).
 - `count > 100` -> `ReservationLimitExceeded` (18).
 - A new reservation for the same caller **overwrites** the previous one; the old IDs remain as a gap in the counter (same as any abandoned reservation).
-- The TTL ensures persistent storage entries are cleaned up automatically.
+- `expiry` is optional; reservations without an expiry can only be released by the reserving caller.
+- Expired reservations can be reclaimed by anyone through `reclaim_expired_id_reservation`.
 
 **Usage pattern:**
 ```
@@ -694,6 +695,10 @@ contract.create_streams_relative(&sender, &params)?;
 | `get_auto_claim_destination` | Anyone                     | None (view)                                 |
 | `delegated_withdraw`         | Relayer (ed25519 sig from recipient) | `relayer.require_auth()` + ed25519 sig |
 | `get_delegated_nonce`        | Anyone                     | None (view)                                 |
+| `reserve_stream_ids`         | Reserving caller           | `caller.require_auth()`                     |
+| `release_id_reservation`     | Reserving caller           | `caller.require_auth()`                     |
+| `reclaim_expired_id_reservation` | Anyone                 | None (permissionless expired cleanup)       |
+| `get_id_reservation`         | Anyone                     | None (view)                                 |
 
 **Note:** Sender-managed functions (`pause_stream`, `resume_stream`, `cancel_stream`) require sender auth. Admin uses separate `_as_admin` entry points.
 
@@ -1440,6 +1445,7 @@ pub fn reserve_stream_ids(
     env: Env,
     caller: Address,
     count: u32,
+    expiry: Option<u64>,
 ) -> Result<Vec<u64>, ContractError>
 ```
 
@@ -1449,13 +1455,14 @@ pub fn reserve_stream_ids(
 
 - `caller`: Address making the reservation
 - `count`: Number of IDs to reserve (1 – `MAX_ID_RESERVATION` = 100)
+- `expiry`: Optional ledger timestamp after which anyone may reclaim the unconsumed reservation
 
 **Returns:** `Vec<u64>` containing the reserved IDs in ascending order.
 
 **Behavior:**
 
 1. Atomically advances the global `NextStreamId` counter by `count`
-2. Stores an `IdReservation { start_id, count, consumed: 0 }` keyed by `caller`
+2. Stores an `IdReservation { start_id, count, consumed: 0, expiry }` keyed by `caller`
 3. Returns `[start_id, start_id+1, ..., start_id+count-1]`
 4. Subsequent `create_stream` calls from `caller` consume IDs from the reservation in order
 5. When fully consumed, the reservation is automatically deleted
@@ -1466,6 +1473,7 @@ pub fn reserve_stream_ids(
 - `count` capped at `MAX_ID_RESERVATION = 100` to prevent counter-inflation attacks
 - Authorization required to prevent third parties from consuming a victim's counter space
 - Gaps from unconsumed reservations are permanent but bounded (max 100 per call)
+- Reservations with `expiry = None` cannot be reclaimed by third parties; the caller must release or consume them
 
 **Errors:**
 
@@ -1476,7 +1484,7 @@ pub fn reserve_stream_ids(
 
 ```rust
 // Off-chain orchestrator reserves 5 IDs
-let ids = client.reserve_stream_ids(&orchestrator, &5); // [0, 1, 2, 3, 4]
+let ids = client.reserve_stream_ids(&orchestrator, &5, &None); // [0, 1, 2, 3, 4]
 
 // Pre-populate database with these IDs
 database.insert_pending_streams(ids);
@@ -1485,6 +1493,40 @@ database.insert_pending_streams(ids);
 let id0 = client.create_stream(&orchestrator, ...); // Uses ID 0
 let id1 = client.create_stream(&orchestrator, ...); // Uses ID 1
 ```
+
+### release_id_reservation
+
+**Purpose:** Let the reserving caller explicitly delete its active ID reservation when it no longer needs the reserved range.
+
+**Entry-point:**
+
+```rust
+pub fn release_id_reservation(env: Env, caller: Address) -> Result<(), ContractError>
+```
+
+**Authorization:** Requires `caller` signature.
+
+**Behavior:** Removes the reservation stored for `caller`. IDs that were already advanced remain gaps; this caller-authorized path does not rewind the global stream counter.
+
+### reclaim_expired_id_reservation
+
+**Purpose:** Permissionlessly clean up an active reservation after its optional `expiry` timestamp has passed.
+
+**Entry-point:**
+
+```rust
+pub fn reclaim_expired_id_reservation(env: Env, holder: Address) -> Result<(), ContractError>
+```
+
+**Authorization:** None.
+
+**Behavior:** Loads `holder`'s reservation, verifies it has expired, removes it, and emits `res_rel`. If the unconsumed range is still at the tail of the global stream counter, the counter is rewound to reclaim those unused IDs.
+
+**Errors:**
+
+- `ReservationNotFound` (24): `holder` has no active reservation
+- `ReservationNotExpirable` (25): reservation was created with `expiry = None`
+- `ReservationStillActive` (26): current ledger timestamp is still before `expiry`
 
 ### get_id_reservation
 
@@ -1500,7 +1542,7 @@ pub fn get_id_reservation(env: Env, caller: Address) -> Option<IdReservation>
 
 **Returns:**
 
-- `Some(IdReservation { start_id, count, consumed })` if caller has an active reservation
+- `Some(IdReservation { start_id, count, consumed, expiry })` if caller has an active reservation
 - `None` if no reservation exists
 
 **Example:**

--- a/tests/test_validate_gas.py
+++ b/tests/test_validate_gas.py
@@ -1,0 +1,173 @@
+"""
+Tests for script/validate_gas.py.
+
+These keep the docs-alignment CI coverage gate focused without invoking cargo.
+"""
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parent.parent / "script" / "validate_gas.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("validate_gas", _SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+vg = _load_module()
+
+
+def test_extract_baselines_reads_marked_json(tmp_path):
+    baseline = {"withdraw": 100, "batch_withdraw": {"10": 500}}
+    path = tmp_path / "gas.md"
+    path.write_text(
+        "before\n"
+        "<!-- GAS_BASELINE_START -->\n"
+        f"{json.dumps(baseline)}\n"
+        "<!-- GAS_BASELINE_END -->\n"
+        "after\n",
+        encoding="utf-8",
+    )
+
+    assert vg.extract_baselines(str(path)) == baseline
+
+
+def test_extract_baselines_fails_without_marker(tmp_path):
+    path = tmp_path / "gas.md"
+    path.write_text("# no baseline here\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="gas baseline block"):
+        vg.extract_baselines(str(path))
+
+
+def test_parse_measurements_groups_by_function_and_size():
+    output = "\n".join(
+        [
+            "noise",
+            "GAS_MEASUREMENT: withdraw: single: 100",
+            "GAS_MEASUREMENT: batch_withdraw: 10: 525",
+            "GAS_MEASUREMENT: batch_withdraw: 50: 900",
+        ]
+    )
+
+    assert vg.parse_measurements(output) == {
+        "withdraw": {"single": 100},
+        "batch_withdraw": {"10": 525, "50": 900},
+    }
+
+
+def test_run_tests_returns_stdout(monkeypatch):
+    class Result:
+        stdout = "GAS_MEASUREMENT: withdraw: single: 100"
+
+    calls = []
+
+    def fake_run(*args, **kwargs):
+        calls.append((args, kwargs))
+        return Result()
+
+    monkeypatch.setattr(vg.subprocess, "run", fake_run)
+
+    assert vg.run_tests() == Result.stdout
+    assert calls
+    command = calls[0][0][0]
+    assert command[:4] == ["cargo", "test", "-p", "fluxora_stream"]
+    assert calls[0][1]["capture_output"] is True
+    assert calls[0][1]["text"] is True
+
+
+def test_main_success(monkeypatch, capsys):
+    monkeypatch.setattr(vg, "extract_baselines", lambda _: {"withdraw": 100})
+    monkeypatch.setattr(
+        vg,
+        "run_tests",
+        lambda: "GAS_MEASUREMENT: withdraw: single: 104\n",
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        vg.main()
+
+    assert exc.value.code == 0
+    assert "SUCCESS: No gas regressions detected." in capsys.readouterr().out
+
+
+def test_main_detects_regression(monkeypatch, capsys):
+    monkeypatch.setattr(vg, "extract_baselines", lambda _: {"withdraw": 100})
+    monkeypatch.setattr(
+        vg,
+        "run_tests",
+        lambda: "GAS_MEASUREMENT: withdraw: single: 106\n",
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        vg.main()
+
+    assert exc.value.code == 1
+    out = capsys.readouterr().out
+    assert "FAILED: Gas regression detected" in out
+    assert "withdraw (single)" in out
+
+
+def test_main_handles_batch_baseline(monkeypatch, capsys):
+    monkeypatch.setattr(
+        vg,
+        "extract_baselines",
+        lambda _: {"batch_withdraw": {"10": 500}},
+    )
+    monkeypatch.setattr(
+        vg,
+        "run_tests",
+        lambda: "GAS_MEASUREMENT: batch_withdraw: 10: 500\n",
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        vg.main()
+
+    assert exc.value.code == 0
+    assert "batch_withdraw" in capsys.readouterr().out
+
+
+def test_main_reports_missing_baseline_without_failing(monkeypatch, capsys):
+    monkeypatch.setattr(vg, "extract_baselines", lambda _: {})
+    monkeypatch.setattr(
+        vg,
+        "run_tests",
+        lambda: "GAS_MEASUREMENT: new_fn: single: 10\n",
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        vg.main()
+
+    assert exc.value.code == 0
+    assert "MISSING" in capsys.readouterr().out
+
+
+def test_main_fails_when_no_measurements(monkeypatch, capsys):
+    monkeypatch.setattr(vg, "extract_baselines", lambda _: {"withdraw": 100})
+    monkeypatch.setattr(vg, "run_tests", lambda: "no measurements")
+
+    with pytest.raises(SystemExit) as exc:
+        vg.main()
+
+    assert exc.value.code == 1
+    assert "No gas measurements found" in capsys.readouterr().out
+
+
+def test_main_wraps_exceptions(monkeypatch, capsys):
+    monkeypatch.setattr(
+        vg,
+        "extract_baselines",
+        lambda _: (_ for _ in ()).throw(RuntimeError("boom")),
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        vg.main()
+
+    assert exc.value.code == 1
+    assert "Error during validation: boom" in capsys.readouterr().out


### PR DESCRIPTION
## Summary
- preflight delegated_withdraw Ed25519 signatures with strict dalek verification so invalid signatures return ContractError::InvalidSignature
- keep the Soroban host ed25519_verify call after preflight for valid signatures
- add a regression test for a corrupted delegated-withdraw signature and update docs to remove the old host-trap behavior

Fixes #616.

## Validation
- cargo +stable-x86_64-pc-windows-gnu fmt --all -- --check
- cargo +stable-x86_64-pc-windows-gnu metadata --no-deps --format-version 1
- git diff --check
- cargo +stable-x86_64-pc-windows-gnu check -p fluxora_stream *(blocked after dependency compilation by existing stream baseline errors unrelated to this change, including duplicate StreamStatus/StreamHealth definitions, missing stream fields/constants, and pre-existing accrual signature mismatches)*
- cargo +stable-x86_64-pc-windows-gnu test -p fluxora_stream delegated_withdraw_bad_signature_returns_invalid_signature -- --exact --nocapture *(blocked on this Windows environment before running tests because the native GNU/MSVC linker stack is incomplete: missing MinGW/VS CRT pieces such as crtbegin.o / link.exe)*