### PR TITLE
fix(governance): check proposal arithmetic overflow

### DIFF
--- a/contracts/governance/src/lib.rs
+++ b/contracts/governance/src/lib.rs
@@ -92,6 +92,8 @@ pub enum GovernanceError {
     QuorumWouldBreak = 16,
     /// Signer is already registered in the co-signer set.
     DuplicateSigner = 17,
+    /// Governance arithmetic would overflow instead of producing a valid deadline or ID.
+    ArithmeticOverflow = 18,
 }
 
 /// Storage keys for the governance contract.
@@ -226,12 +228,21 @@ fn read_next_proposal_id(env: &Env) -> u32 {
         .unwrap_or(0u32)
 }
 
-fn increment_proposal_id(env: &Env) -> u32 {
+fn checked_deadline(start: u64, seconds: u64) -> Result<u64, GovernanceError> {
+    start
+        .checked_add(seconds)
+        .ok_or(GovernanceError::ArithmeticOverflow)
+}
+
+fn increment_proposal_id(env: &Env) -> Result<u32, GovernanceError> {
     let id = read_next_proposal_id(env);
+    let next = id
+        .checked_add(1)
+        .ok_or(GovernanceError::ArithmeticOverflow)?;
     env.storage()
         .instance()
-        .set(&DataKey::NextProposalId, &(id + 1));
-    id
+        .set(&DataKey::NextProposalId, &next);
+    Ok(id)
 }
 
 fn load_proposal(env: &Env, id: u32) -> Result<Proposal, GovernanceError> {
@@ -390,6 +401,7 @@ impl FluxoraGovernance {
     /// # Errors
     /// - `NotASigner`: `proposer` is not in the registered signers list.
     /// - `CalldataTooLarge`: `calldata.len() > MAX_CALLDATA_BYTES`.
+    /// - `ArithmeticOverflow`: proposal ID counter has reached `u32::MAX`.
     pub fn propose(
         env: Env,
         proposer: Address,
@@ -408,7 +420,7 @@ impl FluxoraGovernance {
             return Err(GovernanceError::CalldataTooLarge);
         }
 
-        let id = increment_proposal_id(&env);
+        let id = increment_proposal_id(&env)?;
         let now = env.ledger().timestamp();
 
         let proposal = Proposal {
@@ -453,6 +465,7 @@ impl FluxoraGovernance {
     /// - `ProposalNotFound`: No proposal with this ID.
     /// - `AlreadyExecuted`: Proposal has already been executed.
     /// - `AlreadyApproved`: This signer already approved this proposal.
+    /// - `ArithmeticOverflow`: proposal age or quorum timelock deadline cannot be represented.
     pub fn approve(env: Env, approver: Address, proposal_id: u32) -> Result<(), GovernanceError> {
         approver.require_auth();
 
@@ -469,7 +482,9 @@ impl FluxoraGovernance {
         if proposal.executed {
             return Err(GovernanceError::AlreadyExecuted);
         }
-        if env.ledger().timestamp() > proposal.created_at + MAX_PROPOSAL_AGE_SECONDS {
+        if env.ledger().timestamp()
+            > checked_deadline(proposal.created_at, MAX_PROPOSAL_AGE_SECONDS)?
+        {
             return Err(GovernanceError::ProposalExpired);
         }
 
@@ -487,6 +502,15 @@ impl FluxoraGovernance {
         proposal.approvals.push_back(approver.clone());
         let approval_count = proposal.approvals.len();
 
+        let threshold = get_threshold(&env)?;
+        let quorum_reached = if approval_count == threshold {
+            let now = env.ledger().timestamp();
+            let executable_after = checked_deadline(now, GOVERNANCE_TIMELOCK_SECONDS)?;
+            Some((now, executable_after))
+        } else {
+            None
+        };
+
         save_proposal(&env, proposal_id, &proposal);
         bump_instance(&env);
 
@@ -502,10 +526,7 @@ impl FluxoraGovernance {
         // Record the timestamp and effective threshold at which quorum was first
         // reached.  Using the stored snapshot at execution time protects in-flight
         // proposals against mid-flight threshold changes by the admin.
-        let threshold = get_threshold(&env)?;
-        if approval_count == threshold {
-            let now = env.ledger().timestamp();
-            let executable_after = now + GOVERNANCE_TIMELOCK_SECONDS;
+        if let Some((now, executable_after)) = quorum_reached {
             let info = QuorumInfo {
                 reached_at: now,
                 threshold,
@@ -551,6 +572,7 @@ impl FluxoraGovernance {
     /// - `QuorumNotReached`: Approval count < threshold.
     /// - `TimelockNotElapsed`: Less than `GOVERNANCE_TIMELOCK_SECONDS` have passed
     ///   since quorum was reached.
+    /// - `ArithmeticOverflow`: proposal age or quorum timelock deadline cannot be represented.
     pub fn execute(env: Env, executor: Address, proposal_id: u32) -> Result<(), GovernanceError> {
         executor.require_auth();
 
@@ -562,7 +584,9 @@ impl FluxoraGovernance {
         if proposal.executed {
             return Err(GovernanceError::AlreadyExecuted);
         }
-        if env.ledger().timestamp() > proposal.created_at + MAX_PROPOSAL_AGE_SECONDS {
+        if env.ledger().timestamp()
+            > checked_deadline(proposal.created_at, MAX_PROPOSAL_AGE_SECONDS)?
+        {
             return Err(GovernanceError::ProposalExpired);
         }
 
@@ -581,7 +605,9 @@ impl FluxoraGovernance {
 
         // Verify timelock has elapsed from the moment quorum was reached.
         let now = env.ledger().timestamp();
-        if now < quorum_info.reached_at + GOVERNANCE_TIMELOCK_SECONDS {
+        let executable_after =
+            checked_deadline(quorum_info.reached_at, GOVERNANCE_TIMELOCK_SECONDS)?;
+        if now < executable_after {
             return Err(GovernanceError::TimelockNotElapsed);
         }
 
@@ -931,6 +957,76 @@ mod tests {
         assert!(!p.executed);
         assert!(!p.cancelled);
         assert_eq!(p.approvals.len(), 0);
+    }
+
+    #[test]
+    fn test_propose_returns_structured_error_when_proposal_id_counter_overflows() {
+        let ctx = Ctx::setup();
+        ctx.env.as_contract(&ctx.contract_id, || {
+            ctx.env
+                .storage()
+                .instance()
+                .set(&DataKey::NextProposalId, &u32::MAX);
+        });
+
+        let result = ctx.client.try_propose(
+            &ctx.signer_a,
+            &ctx.dummy_target(),
+            &ctx.calldata("overflow"),
+        );
+
+        assert_eq!(result, Err(Ok(GovernanceError::ArithmeticOverflow)));
+        ctx.env.as_contract(&ctx.contract_id, || {
+            assert_eq!(read_next_proposal_id(&ctx.env), u32::MAX);
+        });
+    }
+
+    #[test]
+    fn test_approve_returns_structured_error_when_quorum_timelock_overflows() {
+        let ctx = Ctx::setup();
+        ctx.env.ledger().set_timestamp(u64::MAX - MAX_AGE);
+        let id = ctx.client.propose(
+            &ctx.signer_a,
+            &ctx.dummy_target(),
+            &ctx.calldata("timelock"),
+        );
+
+        ctx.client.approve(&ctx.signer_a, &id);
+        ctx.env.ledger().set_timestamp(u64::MAX - TIMELOCK + 1);
+
+        let result = ctx.client.try_approve(&ctx.signer_b, &id);
+
+        assert_eq!(result, Err(Ok(GovernanceError::ArithmeticOverflow)));
+    }
+
+    #[test]
+    fn test_execute_returns_structured_error_when_quorum_timelock_overflows() {
+        let ctx = Ctx::setup();
+        ctx.env.ledger().set_timestamp(u64::MAX - MAX_AGE);
+        let id = ctx.client.propose(
+            &ctx.signer_a,
+            &ctx.dummy_target(),
+            &ctx.calldata("timelock"),
+        );
+        let mut proposal = ctx.client.get_proposal(&id);
+        proposal.approvals.push_back(ctx.signer_a.clone());
+        proposal.approvals.push_back(ctx.signer_b.clone());
+        ctx.env.as_contract(&ctx.contract_id, || {
+            save_proposal(&ctx.env, id, &proposal);
+            ctx.env.storage().persistent().set(
+                &DataKey::QuorumReachedAt(id),
+                &QuorumInfo {
+                    reached_at: u64::MAX - TIMELOCK + 1,
+                    threshold: 2,
+                },
+            );
+        });
+        ctx.env.ledger().set_timestamp(u64::MAX - 100);
+        let executor = Address::generate(&ctx.env);
+
+        let result = ctx.client.try_execute(&executor, &id);
+
+        assert_eq!(result, Err(Ok(GovernanceError::ArithmeticOverflow)));
     }
 
     // -----------------------------------------------------------------------

--- a/contracts/stream/src/lib.rs
+++ b/contracts/stream/src/lib.rs
@@ -192,7 +192,7 @@ pub struct IdReservation {
     pub start_id: u64,
     pub count: u32,
     pub consumed: u32,
-    pub expiry: Option<u64>
+    pub expiry: Option<u64>,
 }
 
 /// Reason for a protocol or stream pause.
@@ -374,7 +374,7 @@ pub enum ContractError {
     PauseReasonTooLong = 23,
     ReservationNotFound = 24,
     ReservationNotExpirable = 25,
-    ReservationStillActive = 26
+    ReservationStillActive = 26,
 }
 
 #[contracttype]
@@ -6479,7 +6479,7 @@ impl FluxoraStream {
         env: Env,
         caller: Address,
         count: u32,
-        expiry: Option<u64>
+        expiry: Option<u64>,
     ) -> Result<soroban_sdk::Vec<u64>, ContractError> {
         caller.require_auth();
 
@@ -6497,7 +6497,7 @@ impl FluxoraStream {
             start_id,
             count,
             consumed: 0,
-            expiry
+            expiry,
         };
         save_id_reservation(&env, &caller, &res);
 
@@ -6516,10 +6516,7 @@ impl FluxoraStream {
     ///
     /// # Security
     /// - Authorization required .
-    pub fn release_id_reservation(
-        env: Env,
-        caller: Address,
-    ) -> Result<(), ContractError> {
+    pub fn release_id_reservation(env: Env, caller: Address) -> Result<(), ContractError> {
         caller.require_auth();
 
         remove_id_reservation(&env, &caller);
@@ -6555,8 +6552,7 @@ impl FluxoraStream {
     /// - `ReservationNotExpirable` (25): `expiry` is None.
     /// - `ReservationStillActive` (26): `current time > expiry`
     pub fn reclaim_expired_id_reservation(env: Env, holder: Address) -> Result<(), ContractError> {
-        let res = load_id_reservation(&env, &holder)
-            .ok_or(ContractError::ReservationNotFound)?;
+        let res = load_id_reservation(&env, &holder).ok_or(ContractError::ReservationNotFound)?;
 
         let expiry = res.expiry.ok_or(ContractError::ReservationNotExpirable)?;
         if env.ledger().timestamp() < expiry {


### PR DESCRIPTION
## Summary

Closes #629.

This PR replaces unchecked governance arithmetic with structured error returns so proposal ID exhaustion and timelock/deadline overflow do not host-trap.

Changes:
- adds `GovernanceError::ArithmeticOverflow` with a fresh discriminant
- checks the proposal ID counter before writing `NextProposalId`
- checks proposal-age deadlines and quorum timelock deadlines before comparing or emitting them
- avoids persisting the quorum-reaching approval when the executable-after timestamp cannot be represented
- documents the new overflow behavior on `propose`, `approve`, and `execute`
- adds boundary tests for `u32::MAX` proposal IDs and near-`u64::MAX` timelock timestamps

## TDD evidence

Red first:
- `cargo test -p fluxora_governance arithmetic_overflows --lib` initially failed because `GovernanceError::ArithmeticOverflow` did not exist.

Green:
- after the implementation, `cargo test -p fluxora_governance overflows --lib` passed the 3 new overflow tests.

## Validation

- `cargo test -p fluxora_governance` (30 passed)
- `cargo fmt --manifest-path contracts/governance/Cargo.toml -- --check`
- `cargo clippy -p fluxora_governance --all-targets -- -D warnings`
- `cargo build -p fluxora_governance`
- `git diff --check`

## Security notes

The affected paths now return a typed `GovernanceError::ArithmeticOverflow` instead of relying on native `+` behavior. This keeps client/indexer recovery on the contract's documented error channel and prevents opaque host traps in the proposal counter and governance timelock paths.
