### PR TITLE
feat(factory): add admin pause switch for create_stream

### DIFF
--- a/contracts/factory/src/lib.rs
+++ b/contracts/factory/src/lib.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::too_many_arguments)]
 
 use fluxora_stream::FluxoraStreamClient;
-use soroban_sdk::{contract, contracterror, contractimpl, contracttype, Address, Env};
+use soroban_sdk::{contract, contracterror, contractimpl, contracttype, symbol_short, Address, Env};
 
 #[contracterror]
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -17,6 +17,8 @@ pub enum FactoryError {
     InvalidTimeRange = 7,
     /// The requested cliff must be within the inclusive start/end window.
     InvalidCliff = 8,
+    /// Factory stream creation is currently paused by admin.
+    CreationPaused = 9,
 }
 
 #[contracttype]
@@ -26,6 +28,8 @@ pub enum DataKey {
     MaxDepositCap,
     MinDuration,
     Allowlist(Address),
+    /// Boolean flag: when `true`, `create_stream` rejects all new streams.
+    CreationPaused,
 }
 
 /// Load and authorize the current factory admin.
@@ -80,6 +84,8 @@ impl FluxoraFactory {
         env.storage()
             .instance()
             .set(&DataKey::MinDuration, &min_duration);
+        // CreationPaused defaults to false — no explicit write needed;
+        // `is_factory_paused` falls back to `false` on a missing key.
 
         Ok(())
     }
@@ -136,6 +142,57 @@ impl FluxoraFactory {
         Ok(())
     }
 
+    /// Toggle the factory-level stream creation pause.
+    ///
+    /// When `paused` is `true`, all calls to `create_stream` immediately return
+    /// [`FactoryError::CreationPaused`] — before any policy read — allowing the
+    /// admin to halt new factory-originated streams without dismantling the
+    /// allowlist or other policy state.
+    ///
+    /// # Authorization
+    /// Requires the stored admin's signature. Callers that are not the admin
+    /// will have their transaction rejected by `require_auth`.
+    ///
+    /// # Events
+    /// Emits a `factory_paused` or `factory_resumed` topic depending on the
+    /// new value of `paused`.
+    ///
+    /// # Errors
+    /// - [`FactoryError::NotInitialized`] — factory has not been initialized.
+    pub fn set_factory_paused(env: Env, paused: bool) -> Result<(), FactoryError> {
+        require_admin(&env)?;
+
+        env.storage()
+            .instance()
+            .set(&DataKey::CreationPaused, &paused);
+
+        // Emit a structured event so indexers and monitors can react.
+        if paused {
+            env.events().publish(
+                (symbol_short!("factory"), symbol_short!("paused")),
+                paused,
+            );
+        } else {
+            env.events().publish(
+                (symbol_short!("factory"), symbol_short!("resumed")),
+                paused,
+            );
+        }
+
+        Ok(())
+    }
+
+    /// Return whether factory stream creation is currently paused.
+    ///
+    /// This is a permissionless view — anyone may call it to check the current
+    /// pause state before submitting a `create_stream` transaction.
+    pub fn is_factory_paused(env: Env) -> bool {
+        env.storage()
+            .instance()
+            .get(&DataKey::CreationPaused)
+            .unwrap_or(false)
+    }
+
     /// Return the current factory policy configuration.
     pub fn get_factory_config(env: Env) -> Result<FactoryConfig, FactoryError> {
         Ok(FactoryConfig {
@@ -171,6 +228,15 @@ impl FluxoraFactory {
     }
 
     /// Creates a new stream via the FluxoraStream contract after enforcing treasury policies.
+    ///
+    /// # Guard order (checked strictly in sequence)
+    /// 1. **CreationPaused** — rejects immediately, before any policy read, to
+    ///    avoid leaking allowlist or cap state during an incident.
+    /// 2. Allowlist check
+    /// 3. Deposit cap check
+    /// 4. Time-range invariants
+    /// 5. Minimum-duration check
+    /// 6. Cross-contract stream creation
     #[allow(clippy::too_many_arguments)]
     pub fn create_stream(
         env: Env,
@@ -183,7 +249,19 @@ impl FluxoraFactory {
         end_time: u64,
         withdraw_dust_threshold: i128,
     ) -> Result<u64, FactoryError> {
-        // Enforce policies
+        // ── Guard 1: pause check (before any policy read) ───────────────────
+        // Checked first so that no allowlist or cap state is observable when
+        // the factory is in emergency-pause mode.
+        let paused: bool = env
+            .storage()
+            .instance()
+            .get(&DataKey::CreationPaused)
+            .unwrap_or(false);
+        if paused {
+            return Err(FactoryError::CreationPaused);
+        }
+
+        // ── Guard 2: allowlist ───────────────────────────────────────────────
         let is_allowed: bool = env
             .storage()
             .persistent()
@@ -193,6 +271,7 @@ impl FluxoraFactory {
             return Err(FactoryError::RecipientNotAllowlisted);
         }
 
+        // ── Guard 3: deposit cap ─────────────────────────────────────────────
         let max_deposit: i128 = env
             .storage()
             .instance()
@@ -202,6 +281,7 @@ impl FluxoraFactory {
             return Err(FactoryError::DepositExceedsCap);
         }
 
+        // ── Guard 4: time invariants ─────────────────────────────────────────
         // Mirror FluxoraStream time invariants before the cross-contract call so
         // invalid schedules return typed factory errors instead of downstream panics.
         if start_time >= end_time {
@@ -211,6 +291,7 @@ impl FluxoraFactory {
             return Err(FactoryError::InvalidCliff);
         }
 
+        // ── Guard 5: minimum duration ────────────────────────────────────────
         let min_duration: u64 = env
             .storage()
             .instance()

--- a/contracts/stream/src/lib.rs
+++ b/contracts/stream/src/lib.rs
@@ -6545,15 +6545,15 @@ impl FluxoraStream {
             (res.start_id, res.count, res.consumed, reclaimed),
         );
     }
-    /// Release/ Reclaim expired reservation stream IDs for off-chain pre-computation.
-    ///
+
+    /// Reclaim expired reservation stream IDs for off-chain pre-computation.
     ///
     /// # Parameters
     /// - `holder`: Address that made the reservation
     ///
     /// # Errors
-    /// - `ReservationNotExpirable` (25): `expiry` is None.
-    /// - `ReservationStillActive` (26): `current time > expiry`
+    /// - `ReservationNotExpirable` (25): `expiry` is `None` (reservation has no TTL).
+    /// - `ReservationStillActive` (26): `current time < expiry` (reservation has not yet expired).
     pub fn reclaim_expired_id_reservation(env: Env, holder: Address) -> Result<(), ContractError> {
         let res = load_id_reservation(&env, &holder)
             .ok_or(ContractError::ReservationNotFound)?;

--- a/contracts/stream/tests/factory_policy.rs
+++ b/contracts/stream/tests/factory_policy.rs
@@ -564,3 +564,248 @@ fn test_set_allowlist_remove_enforced() {
     );
     assert_eq!(result, Err(Ok(FactoryError::RecipientNotAllowlisted)));
 }
+
+// ---------------------------------------------------------------------------
+// CreationPaused — pause/kill switch
+// ---------------------------------------------------------------------------
+
+/// `is_factory_paused` returns false by default (never explicitly set after init).
+#[test]
+fn test_is_factory_paused_defaults_to_false() {
+    let ctx = Ctx::setup();
+    assert!(!ctx.factory.is_factory_paused());
+}
+
+/// Admin can pause and the flag is immediately reflected by `is_factory_paused`.
+#[test]
+fn test_set_factory_paused_true_reflected_by_view() {
+    let ctx = Ctx::setup();
+    ctx.factory.set_factory_paused(&true);
+    assert!(ctx.factory.is_factory_paused());
+}
+
+/// Admin can resume after pausing.
+#[test]
+fn test_set_factory_paused_false_reflected_by_view() {
+    let ctx = Ctx::setup();
+    ctx.factory.set_factory_paused(&true);
+    ctx.factory.set_factory_paused(&false);
+    assert!(!ctx.factory.is_factory_paused());
+}
+
+/// Idempotent pause: pausing twice keeps the flag true.
+#[test]
+fn test_set_factory_paused_idempotent_true() {
+    let ctx = Ctx::setup();
+    ctx.factory.set_factory_paused(&true);
+    ctx.factory.set_factory_paused(&true);
+    assert!(ctx.factory.is_factory_paused());
+}
+
+/// Idempotent resume: resuming twice keeps the flag false.
+#[test]
+fn test_set_factory_paused_idempotent_false() {
+    let ctx = Ctx::setup();
+    ctx.factory.set_factory_paused(&false);
+    assert!(!ctx.factory.is_factory_paused());
+}
+
+/// When paused, `create_stream` rejects with `CreationPaused` even for an
+/// allowlisted recipient with a valid deposit and schedule.
+#[test]
+fn test_create_stream_rejected_when_paused() {
+    let ctx = Ctx::setup();
+    let recipient = Address::generate(&ctx.env);
+    ctx.factory.set_allowlist(&recipient, &true);
+    ctx.factory.set_factory_paused(&true);
+    let now = ctx.now();
+
+    let result = ctx.factory.try_create_stream(
+        &ctx.sender,
+        &recipient,
+        &1_000,
+        &1,
+        &now,
+        &now,
+        &(now + 200),
+        &0,
+    );
+    assert_eq!(result, Err(Ok(FactoryError::CreationPaused)));
+}
+
+/// Pause is checked BEFORE the allowlist, so a non-allowlisted recipient while
+/// paused also returns `CreationPaused` (no policy state leak).
+#[test]
+fn test_create_stream_paused_before_allowlist_check() {
+    let ctx = Ctx::setup();
+    // Recipient is NOT allowlisted
+    let recipient = Address::generate(&ctx.env);
+    ctx.factory.set_factory_paused(&true);
+    let now = ctx.now();
+
+    let result = ctx.factory.try_create_stream(
+        &ctx.sender,
+        &recipient,
+        &1_000,
+        &1,
+        &now,
+        &now,
+        &(now + 200),
+        &0,
+    );
+    // Must be CreationPaused, not RecipientNotAllowlisted
+    assert_eq!(result, Err(Ok(FactoryError::CreationPaused)));
+}
+
+/// Pause is checked BEFORE the cap, so an over-cap deposit while paused
+/// returns `CreationPaused`.
+#[test]
+fn test_create_stream_paused_before_cap_check() {
+    let ctx = Ctx::setup();
+    let recipient = Address::generate(&ctx.env);
+    ctx.factory.set_allowlist(&recipient, &true);
+    ctx.factory.set_factory_paused(&true);
+    let now = ctx.now();
+
+    // deposit=99_999 vastly exceeds max_deposit=10_000
+    let result = ctx.factory.try_create_stream(
+        &ctx.sender,
+        &recipient,
+        &99_999,
+        &1,
+        &now,
+        &now,
+        &(now + 200),
+        &0,
+    );
+    assert_eq!(result, Err(Ok(FactoryError::CreationPaused)));
+}
+
+/// After resume, `create_stream` proceeds to normal policy evaluation.
+/// (An allowlisted sender with a valid schedule should NOT get CreationPaused.)
+#[test]
+fn test_create_stream_allowed_after_resume() {
+    let ctx = Ctx::setup();
+    let recipient = Address::generate(&ctx.env);
+    ctx.factory.set_allowlist(&recipient, &true);
+
+    // Pause then resume
+    ctx.factory.set_factory_paused(&true);
+    ctx.factory.set_factory_paused(&false);
+    let now = ctx.now();
+
+    let result = ctx.factory.try_create_stream(
+        &ctx.sender,
+        &recipient,
+        &1_000,
+        &1,
+        &now,
+        &now,
+        &(now + 200),
+        &0,
+    );
+    // CreationPaused must NOT appear; any other error (e.g. stream contract not
+    // initialized) is acceptable here — we only verify the pause is gone.
+    assert_ne!(result, Err(Ok(FactoryError::CreationPaused)));
+}
+
+/// Non-admin cannot toggle the pause flag.
+#[test]
+fn test_set_factory_paused_rejects_non_admin() {
+    let env = Env::default();
+    let factory_id = env.register_contract(None, FluxoraFactory);
+    let factory = FluxoraFactoryClient::new(&env, &factory_id);
+    let admin = Address::generate(&env);
+    let non_admin = Address::generate(&env);
+    let stream_contract = Address::generate(&env);
+
+    env.mock_all_auths_allowing_non_root_auth();
+    factory.init(&admin, &stream_contract, &10_000, &100);
+
+    // Provide auth as non_admin — should panic because require_auth will fail.
+    env.mock_auths(&[MockAuth {
+        address: &non_admin,
+        invoke: &MockAuthInvoke {
+            contract: &factory_id,
+            fn_name: "set_factory_paused",
+            args: (true,).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        factory.set_factory_paused(&true);
+    }));
+    assert!(result.is_err(), "non-admin must not be able to pause factory");
+
+    // Flag must remain false
+    env.mock_all_auths();
+    assert!(!factory.is_factory_paused());
+}
+
+/// `set_factory_paused` before init returns `NotInitialized`.
+#[test]
+fn test_set_factory_paused_before_init_returns_not_initialized() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let factory_id = env.register_contract(None, FluxoraFactory);
+    let factory = FluxoraFactoryClient::new(&env, &factory_id);
+
+    let result = factory.try_set_factory_paused(&true);
+    assert_eq!(result, Err(Ok(FactoryError::NotInitialized)));
+}
+
+/// Toggle cycle: pause → create rejects → resume → create passes policy.
+#[test]
+fn test_pause_resume_toggle_cycle() {
+    let ctx = Ctx::setup();
+    let recipient = Address::generate(&ctx.env);
+    ctx.factory.set_allowlist(&recipient, &true);
+    let now = ctx.now();
+
+    // Round 1 — paused
+    ctx.factory.set_factory_paused(&true);
+    assert_eq!(
+        ctx.factory.try_create_stream(
+            &ctx.sender,
+            &recipient,
+            &1_000,
+            &1,
+            &now,
+            &now,
+            &(now + 200),
+            &0,
+        ),
+        Err(Ok(FactoryError::CreationPaused))
+    );
+
+    // Round 2 — resumed
+    ctx.factory.set_factory_paused(&false);
+    let result = ctx.factory.try_create_stream(
+        &ctx.sender,
+        &recipient,
+        &1_000,
+        &1,
+        &now,
+        &now,
+        &(now + 200),
+        &0,
+    );
+    assert_ne!(result, Err(Ok(FactoryError::CreationPaused)));
+
+    // Round 3 — pause again
+    ctx.factory.set_factory_paused(&true);
+    assert_eq!(
+        ctx.factory.try_create_stream(
+            &ctx.sender,
+            &recipient,
+            &1_000,
+            &1,
+            &now,
+            &now,
+            &(now + 200),
+            &0,
+        ),
+        Err(Ok(FactoryError::CreationPaused))
+    );
+}

--- a/contracts/stream/tests/factory_policy.rs
+++ b/contracts/stream/tests/factory_policy.rs
@@ -736,7 +736,10 @@ fn test_set_factory_paused_rejects_non_admin() {
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         factory.set_factory_paused(&true);
     }));
-    assert!(result.is_err(), "non-admin must not be able to pause factory");
+    assert!(
+        result.is_err(),
+        "non-admin must not be able to pause factory"
+    );
 
     // Flag must remain false
     env.mock_all_auths();

--- a/docs/factory.md
+++ b/docs/factory.md
@@ -154,3 +154,137 @@ This document is aligned with the current implementation as follows:
   parameters and pulling `deposit_amount` from `sender`.
 - `contracts/stream/tests/factory_policy.rs` covers the factory policy gates and
   admin-guarded policy updates that surround this authorization model.
+
+---
+
+## Emergency Pause (Kill Switch)
+
+The factory exposes an admin-controlled pause mechanism that blocks all new stream
+creation without requiring any changes to the allowlist or policy state.
+
+### Motivation
+
+When an incident occurs (e.g., a bug in the underlying stream contract, a policy
+misconfiguration, or an active exploit), the admin previously had no fast path to
+stop new factory-originated streams. The only option was to iteratively remove
+every allowlisted recipient — a destructive, slow operation that leaves the
+incident window open.
+
+The `CreationPaused` flag closes this gap: a single admin transaction halts all
+creation, and a second transaction resumes normal operation once the incident is
+resolved.
+
+### New storage key
+
+| Key | Type | Storage tier | Default |
+|-----|------|-------------|---------|
+| `DataKey::CreationPaused` | `bool` | `instance` | `false` (absent = unpaused) |
+
+The key is omitted from storage on `init`. `is_factory_paused` falls back to
+`false` on a missing entry, so existing deployments are unaffected by the upgrade.
+
+### New entrypoints
+
+#### `set_factory_paused(env, paused: bool) -> Result<(), FactoryError>`
+
+Toggle the creation pause.
+
+- Requires the stored admin's `require_auth`.
+- Returns `FactoryError::NotInitialized` when called before `init`.
+- Emits a `(factory, paused)` event with payload `true` when pausing, or a
+  `(factory, resumed)` event with payload `false` when resuming.
+- Idempotent: calling `set_factory_paused(true)` twice is safe.
+
+#### `is_factory_paused(env) -> bool`
+
+Permissionless view that returns the current value of `CreationPaused`
+(`false` when the key is absent). Intended for UI pre-flight and monitoring.
+
+### Guard order in `create_stream`
+
+The pause guard is inserted as the **first check** — before any policy read:
+
+```
+1. CreationPaused → FactoryError::CreationPaused   (before allowlist / cap reads)
+2. Allowlist check
+3. Deposit cap check
+4. Time-range invariants
+5. Minimum-duration check
+6. sender.require_auth()
+7. Cross-contract stream creation
+```
+
+Checking the pause flag before policy reads prevents leaking allowlist membership
+or cap values to an attacker probing state during an active incident.
+
+### Events
+
+| Topic tuple | Payload | When emitted |
+|-------------|---------|--------------|
+| `(symbol!("factory"), symbol!("paused"))` | `true` | Admin sets `paused = true` |
+| `(symbol!("factory"), symbol!("resumed"))` | `false` | Admin sets `paused = false` |
+
+### Security assumptions
+
+1. **Only the stored admin can toggle the flag.** `require_admin` is the single
+   authorization chokepoint; see `contracts/factory/src/lib.rs`.
+2. **No bypass via direct stream calls.** The pause only applies to
+   `FluxoraFactory::create_stream`. Callers who invoke `FluxoraStream::create_stream`
+   directly bypass all factory policies. Operators must restrict the underlying
+   stream contract as described in the [Bypass Warning](#important-bypass-warning)
+   section above.
+3. **Pause state survives admin rotation.** `DataKey::CreationPaused` is an
+   independent instance entry; rotating the admin via `set_admin` does not reset
+   the pause flag.
+4. **Pause blocks creation, not withdrawal.** Active streams already in flight
+   are unaffected. Recipients can still withdraw from existing streams; senders
+   can still cancel or modify existing streams.
+
+### Operator runbook
+
+**Pause creation during an incident:**
+
+```bash
+# Build and sign the pause transaction
+soroban contract invoke \
+  --id <FACTORY_CONTRACT_ID> \
+  --source <ADMIN_SECRET_KEY> \
+  -- set_factory_paused --paused true
+```
+
+**Verify the flag:**
+
+```bash
+soroban contract invoke \
+  --id <FACTORY_CONTRACT_ID> \
+  --source <ANY_ACCOUNT> \
+  -- is_factory_paused
+# Returns: true
+```
+
+**Resume after the incident is resolved:**
+
+```bash
+soroban contract invoke \
+  --id <FACTORY_CONTRACT_ID> \
+  --source <ADMIN_SECRET_KEY> \
+  -- set_factory_paused --paused false
+```
+
+### Code alignment checklist
+
+- `DataKey::CreationPaused` is declared in `contracts/factory/src/lib.rs`.
+- `set_factory_paused` and `is_factory_paused` are implemented in the same file.
+- `create_stream` checks `CreationPaused` as its **first guard** before any
+  policy read.
+- `contracts/stream/tests/factory_policy.rs` covers:
+  - Default unpause state after `init`
+  - Pause/resume toggle reflected by `is_factory_paused`
+  - Idempotent pause and resume
+  - `create_stream` rejected with `CreationPaused` when paused
+  - Pause checked before allowlist (no state leak)
+  - Pause checked before cap (no state leak)
+  - `create_stream` succeeds (past the pause guard) after resume
+  - Non-admin toggle panics
+  - `set_factory_paused` before `init` returns `NotInitialized`
+  - Full pause → resume → pause toggle cycle

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -573,3 +573,265 @@ class TestEntrypointAllowlistFullCoverage:
         assert "require_not_globally_paused" not in vda.extract_entrypoints(
             "pub fn require_not_globally_paused(env: &Env) {}"
         )
+
+
+# ---------------------------------------------------------------------------
+# validate_gas.py tests
+# ---------------------------------------------------------------------------
+
+import importlib.util
+import json
+import textwrap
+import types
+import unittest.mock as mock
+from pathlib import Path
+
+_GAS_SCRIPT = Path(__file__).resolve().parent.parent / "script" / "validate_gas.py"
+
+
+def _load_gas_module():
+    spec = importlib.util.spec_from_file_location("validate_gas", _GAS_SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+vg = _load_gas_module()
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_BASELINE_BLOCK = textwrap.dedent("""\
+    <!-- GAS_BASELINE_START -->
+    {
+        "create_stream": 1000,
+        "withdraw": 500,
+        "batch_withdraw": {"small": 200, "large": 800}
+    }
+    <!-- GAS_BASELINE_END -->
+""")
+
+_GAS_MD_NO_BLOCK = "# Gas\nNo baseline here.\n"
+
+
+# ---------------------------------------------------------------------------
+# extract_baselines
+# ---------------------------------------------------------------------------
+
+class TestExtractBaselines:
+    def test_parses_valid_block(self, tmp_path):
+        f = tmp_path / "gas.md"
+        f.write_text(_BASELINE_BLOCK, encoding="utf-8")
+        result = vg.extract_baselines(str(f))
+        assert result["create_stream"] == 1000
+        assert result["withdraw"] == 500
+        assert result["batch_withdraw"]["small"] == 200
+
+    def test_raises_on_missing_block(self, tmp_path):
+        f = tmp_path / "gas.md"
+        f.write_text(_GAS_MD_NO_BLOCK, encoding="utf-8")
+        with pytest.raises(ValueError, match="Could not find gas baseline"):
+            vg.extract_baselines(str(f))
+
+    def test_returns_dict(self, tmp_path):
+        f = tmp_path / "gas.md"
+        f.write_text(_BASELINE_BLOCK, encoding="utf-8")
+        assert isinstance(vg.extract_baselines(str(f)), dict)
+
+
+# ---------------------------------------------------------------------------
+# parse_measurements
+# ---------------------------------------------------------------------------
+
+class TestParseMeasurements:
+    def test_parses_single_measurement(self):
+        output = "GAS_MEASUREMENT: create_stream: single: 1050\n"
+        result = vg.parse_measurements(output)
+        assert result == {"create_stream": {"single": 1050}}
+
+    def test_parses_multiple_functions(self):
+        output = (
+            "GAS_MEASUREMENT: create_stream: single: 1050\n"
+            "GAS_MEASUREMENT: withdraw: single: 510\n"
+        )
+        result = vg.parse_measurements(output)
+        assert "create_stream" in result
+        assert "withdraw" in result
+
+    def test_parses_batch_sizes(self):
+        output = (
+            "GAS_MEASUREMENT: batch_withdraw: small: 210\n"
+            "GAS_MEASUREMENT: batch_withdraw: large: 820\n"
+        )
+        result = vg.parse_measurements(output)
+        assert result["batch_withdraw"]["small"] == 210
+        assert result["batch_withdraw"]["large"] == 820
+
+    def test_ignores_non_matching_lines(self):
+        output = "INFO: something else\nno match here\n"
+        assert vg.parse_measurements(output) == {}
+
+    def test_empty_output(self):
+        assert vg.parse_measurements("") == {}
+
+    def test_returns_dict(self):
+        assert isinstance(vg.parse_measurements(""), dict)
+
+
+# ---------------------------------------------------------------------------
+# run_tests
+# ---------------------------------------------------------------------------
+
+class TestRunTests:
+    def test_returns_string(self, monkeypatch):
+        fake_result = types.SimpleNamespace(stdout="GAS_MEASUREMENT: x: single: 1\n")
+        monkeypatch.setattr(
+            vg.subprocess, "run", lambda *a, **kw: fake_result
+        )
+        output = vg.run_tests()
+        assert isinstance(output, str)
+        assert "GAS_MEASUREMENT" in output
+
+    def test_passes_nocapture_flag(self, monkeypatch):
+        captured = {}
+
+        def fake_run(cmd, **kwargs):
+            captured["cmd"] = cmd
+            return types.SimpleNamespace(stdout="")
+
+        monkeypatch.setattr(vg.subprocess, "run", fake_run)
+        vg.run_tests()
+        assert "--nocapture" in captured["cmd"]
+
+    def test_ignores_nonzero_returncode(self, monkeypatch):
+        fake_result = types.SimpleNamespace(stdout="some output")
+        monkeypatch.setattr(
+            vg.subprocess, "run", lambda *a, **kw: fake_result
+        )
+        # Should not raise even if cargo fails
+        result = vg.run_tests()
+        assert result == "some output"
+
+
+# ---------------------------------------------------------------------------
+# main — pass / fail / error paths
+# ---------------------------------------------------------------------------
+
+class TestGasMain:
+    def _patch(self, monkeypatch, tmp_path, measurements, baseline_override=None):
+        """Wire up main() with a temp gas.md and fake subprocess output."""
+        gas_md = tmp_path / "gas.md"
+        gas_md.write_text(_BASELINE_BLOCK, encoding="utf-8")
+
+        raw_output = "\n".join(
+            f"GAS_MEASUREMENT: {fn}: {sz}: {cost}"
+            for fn, sizes in measurements.items()
+            for sz, cost in (sizes.items() if isinstance(sizes, dict) else [("single", sizes)])
+        )
+
+        monkeypatch.setattr(
+            vg.subprocess, "run",
+            lambda *a, **kw: types.SimpleNamespace(stdout=raw_output),
+        )
+        # Override file path used by main() via extract_baselines
+        monkeypatch.setattr(vg, "extract_baselines", lambda _: baseline_override or {
+            "create_stream": 1000,
+            "withdraw": 500,
+            "batch_withdraw": {"small": 200, "large": 800},
+        })
+
+    def test_no_regression_exits_0(self, tmp_path, monkeypatch):
+        self._patch(monkeypatch, tmp_path, {
+            "create_stream": 1000,
+            "withdraw": 500,
+            "batch_withdraw": {"small": 200, "large": 800},
+        })
+        with pytest.raises(SystemExit) as exc:
+            vg.main()
+        assert exc.value.code == 0
+
+    def test_regression_exits_1(self, tmp_path, monkeypatch):
+        # create_stream goes 30% over baseline
+        self._patch(monkeypatch, tmp_path, {
+            "create_stream": 1300,
+            "withdraw": 500,
+        })
+        with pytest.raises(SystemExit) as exc:
+            vg.main()
+        assert exc.value.code == 1
+
+    def test_no_measurements_exits_1(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            vg.subprocess, "run",
+            lambda *a, **kw: types.SimpleNamespace(stdout=""),
+        )
+        monkeypatch.setattr(vg, "extract_baselines", lambda _: {"create_stream": 1000})
+        with pytest.raises(SystemExit) as exc:
+            vg.main()
+        assert exc.value.code == 1
+
+    def test_missing_baseline_key_shows_missing(self, tmp_path, monkeypatch, capsys):
+        # Measured function not in baseline -> printed as MISSING
+        self._patch(monkeypatch, tmp_path, {"unknown_fn": 999},
+                    baseline_override={"create_stream": 1000})
+        with pytest.raises(SystemExit):
+            vg.main()
+        assert "MISSING" in capsys.readouterr().out
+
+    def test_extract_baselines_exception_exits_1(self, tmp_path, monkeypatch):
+        def _raise(_):
+            raise ValueError("bad block")
+
+        monkeypatch.setattr(vg, "extract_baselines", _raise)
+        monkeypatch.setattr(
+            vg.subprocess, "run",
+            lambda *a, **kw: types.SimpleNamespace(stdout=""),
+        )
+        with pytest.raises(SystemExit) as exc:
+            vg.main()
+        assert exc.value.code == 1
+
+    def test_pass_prints_success_message(self, tmp_path, monkeypatch, capsys):
+        self._patch(monkeypatch, tmp_path, {
+            "create_stream": 1000,
+            "withdraw": 500,
+        })
+        with pytest.raises(SystemExit):
+            vg.main()
+        assert "SUCCESS" in capsys.readouterr().out
+
+    def test_fail_prints_failed_message(self, tmp_path, monkeypatch, capsys):
+        self._patch(monkeypatch, tmp_path, {"create_stream": 2000})
+        with pytest.raises(SystemExit):
+            vg.main()
+        assert "FAILED" in capsys.readouterr().out
+
+    def test_batch_withdraw_baseline_lookup(self, tmp_path, monkeypatch):
+        # batch_withdraw sizes are looked up via baselines["batch_withdraw"][size]
+        self._patch(monkeypatch, tmp_path, {
+            "batch_withdraw": {"small": 200, "large": 800},
+        })
+        with pytest.raises(SystemExit) as exc:
+            vg.main()
+        assert exc.value.code == 0
+
+    def test_within_5pct_passes(self, tmp_path, monkeypatch):
+        # 4% increase is within tolerance
+        self._patch(monkeypatch, tmp_path, {"create_stream": 1040})
+        with pytest.raises(SystemExit) as exc:
+            vg.main()
+        assert exc.value.code == 0
+
+    def test_exactly_5pct_passes(self, tmp_path, monkeypatch):
+        # exactly 5% is not strictly > 0.05, so passes
+        self._patch(monkeypatch, tmp_path, {"create_stream": 1050})
+        with pytest.raises(SystemExit) as exc:
+            vg.main()
+        assert exc.value.code == 0
+
+    def test_over_5pct_fails(self, tmp_path, monkeypatch):
+        self._patch(monkeypatch, tmp_path, {"create_stream": 1060})
+        with pytest.raises(SystemExit) as exc:
+            vg.main()
+        assert exc.value.code == 1


### PR DESCRIPTION


Closes #630

Adds a governance-gated kill switch to `FluxoraFactory::create_stream` so the admin
can halt all new factory-originated streams in a single transaction — without
dismantling the allowlist or other policy state.

## Changes

### contracts/factory/src/lib.rs
- `FactoryError::CreationPaused = 9` — new typed error returned when paused
- `DataKey::CreationPaused` — instance storage key (absent = false, no migration needed)
- `set_factory_paused(env, paused: bool)` — admin-only toggle; emits
  `(factory, paused)` or `(factory, resumed)` event
- `is_factory_paused(env) -> bool` — permissionless view for UI pre-flight
- Pause guard inserted as the **first check** in `create_stream`, before any
  policy read, preventing allowlist/cap state from leaking during an incident

### contracts/stream/tests/factory_policy.rs
11 new tests: default state, toggle, idempotency, guard ordering before allowlist
and cap, non-admin rejection, NotInitialized guard, full pause→resume→pause cycle

### docs/factory.md
New Emergency Pause section: motivation, storage key, entrypoint specs, guard order,
event table, security assumptions, operator runbook (soroban CLI commands)

## Security notes
- Pause checked **before** any policy read — no allowlist/cap state observable during an incident
- Only the stored admin can toggle (single `require_admin` chokepoint)
- Pause state survives admin rotation (independent instance entry)
- Pause blocks creation only — active streams, withdrawals, cancellations unaffected
