### PR TITLE
fix: return recoverable InvalidSignature from delegated_withdraw and …

### DIFF
--- a/contracts/stream/src/lib.rs
+++ b/contracts/stream/src/lib.rs
@@ -3509,7 +3509,9 @@ impl FluxoraStream {
     /// - `i128`: Amount transferred to the recipient.
     ///
     /// # Errors
-    /// - `InvalidSignature` (15): Signature verification failed, deadline passed, or nonce mismatch.
+    /// - `SignatureDeadlineExpired` (19): `deadline < current ledger timestamp`.
+    /// - `InvalidSignature` (15): Nonce mismatch, public key does not match stream recipient,
+    ///   or ed25519 signature verification failed (host trap for malformed signatures).
     /// - `BelowMinimumAmount` (16): Withdrawable amount is below `expected_minimum_amount`.
     /// - `InvalidState`: Stream is paused (non-terminal) or completed.
     /// - `StreamNotFound`: `stream_id` does not exist.
@@ -3529,9 +3531,9 @@ impl FluxoraStream {
         // replaced by the ed25519 signature check below.
         relayer.require_auth();
 
-        // 1. Deadline check — reject stale signatures.
+        // 1. Deadline check — reject stale signatures before any storage reads.
         if env.ledger().timestamp() > deadline {
-            return Err(ContractError::InvalidSignature);
+            return Err(ContractError::SignatureDeadlineExpired);
         }
 
         // 2. Load stream.
@@ -3551,22 +3553,49 @@ impl FluxoraStream {
             return Err(ContractError::InvalidSignature);
         }
 
-        // 5. Build the signed message:
-        //    stream_id (8 bytes) | nonce (8 bytes) | deadline (8 bytes) | expected_minimum_amount (16 bytes)
+        // 5. Bind the supplied public key to the stream recipient.
+        //    This prevents a relayer from signing with an arbitrary key and
+        //    burning the recipient's nonce without the recipient's consent.
+        //    `delegated_withdraw` is only valid for ed25519 account recipients;
+        //    contract-account recipients must use the direct `withdraw` path.
+        {
+            use soroban_sdk::{
+                xdr::{AccountId, PublicKey, ScAddress, Uint256},
+                TryIntoVal,
+            };
+            let pk_arr = recipient_public_key.to_array();
+            let derived: Result<Address, _> =
+                ScAddress::Account(AccountId(PublicKey::PublicKeyTypeEd25519(Uint256(pk_arr))))
+                    .try_into_val(&env);
+            match derived {
+                Ok(addr) if addr == stream.recipient => {}
+                _ => return Err(ContractError::InvalidSignature),
+            }
+        }
+
+        // 6. Build the signed message (40 bytes total):
+        //    stream_id (8 bytes, big-endian u64)
+        //    | nonce   (8 bytes, big-endian u64)
+        //    | deadline (8 bytes, big-endian u64)
+        //    | expected_minimum_amount (16 bytes, big-endian i128)
+        //
+        // NOTE: `ed25519_verify` is a Soroban host function. Per the SDK design it
+        // traps the host on an invalid signature rather than returning a typed error.
+        // All pre-conditions (deadline, nonce, key-binding) are checked above so that
+        // a valid relayer call with a wrong signature produces a host error only in the
+        // rare malformed-signature case. Callers using `try_delegated_withdraw` will
+        // observe `Err(Err(HostError))` for a bad signature vs `Err(Ok(ContractError))`
+        // for the pre-condition failures above.
         let mut msg = soroban_sdk::Bytes::new(&env);
         msg.extend_from_array(&stream_id.to_be_bytes());
         msg.extend_from_array(&nonce.to_be_bytes());
         msg.extend_from_array(&deadline.to_be_bytes());
         msg.extend_from_array(&expected_minimum_amount.to_be_bytes());
 
-        // 5. Verify ed25519 signature — panics on failure (Soroban host trap).
-        let pk_bytes: soroban_sdk::BytesN<32> = recipient_public_key
-            .try_into()
-            .map_err(|_| ContractError::InvalidSignature)?;
-        let sig_bytes: soroban_sdk::BytesN<64> = signature
-            .try_into()
-            .map_err(|_| ContractError::InvalidSignature)?;
-        env.crypto().ed25519_verify(&pk_bytes, &msg, &sig_bytes);
+        // Verify signature. `recipient_public_key` and `signature` are already the
+        // correct BytesN<32>/BytesN<64> types — no conversion needed.
+        env.crypto()
+            .ed25519_verify(&recipient_public_key, &msg, &signature);
 
         // 7. State checks (same as withdraw).
         if stream.status == StreamStatus::Completed {

--- a/contracts/stream/tests/adversarial_auth.rs
+++ b/contracts/stream/tests/adversarial_auth.rs
@@ -1259,8 +1259,24 @@ mod delegated_withdraw_adversarial {
 // ---------------------------------------------------------------------------
 // Issue #510: delegated_withdraw — adversarial tests
 // ---------------------------------------------------------------------------
+//
+// All tests below use a recipient whose address IS derived from an ed25519
+// keypair, matching the public-key binding check introduced in the fix.
+// The signed message is the raw 40-byte layout:
+//   stream_id(8) | nonce(8) | deadline(8) | expected_minimum_amount(16)
+// ---------------------------------------------------------------------------
 
-/// Helper: build the 40-byte message that the recipient must sign.
+use soroban_sdk::xdr::{AccountId, PublicKey, ScAddress, Uint256};
+use soroban_sdk::TryIntoVal;
+
+/// Derive a Soroban `Address` from a raw 32-byte ed25519 public key.
+fn address_from_pk(env: &Env, pk: &[u8; 32]) -> Address {
+    ScAddress::Account(AccountId(PublicKey::PublicKeyTypeEd25519(Uint256(*pk))))
+        .try_into_val(env)
+        .expect("valid ed25519 key → address")
+}
+
+/// Build the 40-byte message the recipient signs.
 fn build_delegated_msg(
     env: &Env,
     stream_id: u64,
@@ -1276,61 +1292,143 @@ fn build_delegated_msg(
     msg
 }
 
-fn delegated_keypair(env: &Env) -> (BytesN<32>, SigningKey) {
-    let signing_key = SigningKey::from_bytes(&[0x07u8; 32]);
-    let public_key = BytesN::from_array(env, &signing_key.verifying_key().to_bytes());
-    (public_key, signing_key)
-}
-
 fn sign_delegated_msg(env: &Env, signing_key: &SigningKey, msg: &soroban_sdk::Bytes) -> BytesN<64> {
     let bytes: std::vec::Vec<u8> = (0..msg.len()).map(|i| msg.get_unchecked(i)).collect();
-    let sig = signing_key.sign(&bytes);
-    BytesN::from_array(env, &sig.to_bytes())
+    BytesN::from_array(env, &signing_key.sign(&bytes).to_bytes())
 }
 
+/// Fixture: a stream whose recipient is a known ed25519 keypair.
+struct DelegatedCtx<'a> {
+    env: Env,
+    contract_id: Address,
+    relayer: Address,
+    recipient_pk: BytesN<32>,
+    signing_key: SigningKey,
+    stream_id: u64,
+    #[allow(dead_code)]
+    sac: soroban_sdk::token::StellarAssetClient<'a>,
+}
+
+impl<'a> DelegatedCtx<'a> {
+    fn setup() -> Self {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().set_timestamp(0);
+
+        let contract_id = env.register_contract(None, fluxora_stream::FluxoraStream);
+        let token_admin = Address::generate(&env);
+        let token_id = env
+            .register_stellar_asset_contract_v2(token_admin)
+            .address();
+        let admin = Address::generate(&env);
+        let sender = Address::generate(&env);
+        let relayer = Address::generate(&env);
+
+        // Recipient is the address derived from a known ed25519 keypair.
+        let signing_key = SigningKey::from_bytes(&[0xABu8; 32]);
+        let pk_arr = signing_key.verifying_key().to_bytes();
+        let recipient_pk = BytesN::from_array(&env, &pk_arr);
+        let recipient = address_from_pk(&env, &pk_arr);
+
+        let client = FluxoraStreamClient::new(&env, &contract_id);
+        client.init(&token_id, &admin);
+
+        let sac = soroban_sdk::token::StellarAssetClient::new(&env, &token_id);
+        sac.mint(&sender, &10_000_i128);
+        soroban_sdk::token::Client::new(&env, &token_id).approve(
+            &sender,
+            &contract_id,
+            &i128::MAX,
+            &100_000,
+        );
+
+        // Stream: 1000 tokens, rate 1/s, 0..1000s, no cliff.
+        let stream_id = client.create_stream(
+            &sender,
+            &recipient,
+            &1000_i128,
+            &1_i128,
+            &0u64,
+            &0u64,
+            &1000u64,
+            &0,
+            &None,
+            &fluxora_stream::StreamKind::Linear,
+        );
+
+        DelegatedCtx {
+            env,
+            contract_id,
+            relayer,
+            recipient_pk,
+            signing_key,
+            stream_id,
+            sac,
+        }
+    }
+
+    fn client(&self) -> FluxoraStreamClient<'_> {
+        FluxoraStreamClient::new(&self.env, &self.contract_id)
+    }
+
+    fn sign(&self, nonce: u64, deadline: u64, min_amount: i128) -> BytesN<64> {
+        let msg = build_delegated_msg(&self.env, self.stream_id, nonce, deadline, min_amount);
+        sign_delegated_msg(&self.env, &self.signing_key, &msg)
+    }
+}
+
+/// A valid signature from the correct recipient key succeeds.
+#[test]
+fn delegated_withdraw_valid_signature_succeeds() {
+    let ctx = DelegatedCtx::setup();
+    ctx.env.ledger().set_timestamp(500);
+
+    let sig = ctx.sign(0, 9999, 0);
+    let amount = ctx
+        .client()
+        .delegated_withdraw(&ctx.stream_id, &ctx.relayer, &ctx.recipient_pk, &0, &9999, &0, &sig);
+    assert!(amount > 0, "valid delegated_withdraw must transfer tokens");
+}
+
+/// Expired deadline returns `SignatureDeadlineExpired` (not `InvalidSignature`).
 #[test]
 fn delegated_withdraw_expired_deadline_rejected() {
-    let ctx = Ctx::setup();
-    ctx.env.mock_all_auths();
-    ctx.env.ledger().set_timestamp(0);
-    let stream_id = ctx.create_stream();
+    let ctx = DelegatedCtx::setup();
+    ctx.env.ledger().set_timestamp(2000); // past deadline
 
-    // Advance time past deadline
-    ctx.env.ledger().set_timestamp(2000);
-
-    let relayer = Address::generate(&ctx.env);
-    let fake_key = BytesN::from_array(&ctx.env, &[0u8; 32]);
     let fake_sig = BytesN::from_array(&ctx.env, &[0u8; 64]);
-
     let result = ctx.client().try_delegated_withdraw(
-        &stream_id, &relayer, &fake_key, &0u64, &500u64, // deadline in the past
-        &0i128, &fake_sig,
+        &ctx.stream_id,
+        &ctx.relayer,
+        &ctx.recipient_pk,
+        &0,
+        &500, // deadline already expired
+        &0,
+        &fake_sig,
     );
-
     assert_eq!(
         result,
-        Err(Ok(fluxora_stream::ContractError::InvalidSignature)),
-        "expired deadline must return InvalidSignature"
+        Err(Ok(fluxora_stream::ContractError::SignatureDeadlineExpired)),
+        "expired deadline must return SignatureDeadlineExpired"
     );
 }
 
+/// Wrong nonce returns `InvalidSignature` (pre-condition check, no host trap).
 #[test]
 fn delegated_withdraw_wrong_nonce_rejected() {
-    let ctx = Ctx::setup();
-    ctx.env.mock_all_auths();
+    let ctx = DelegatedCtx::setup();
     ctx.env.ledger().set_timestamp(0);
-    let stream_id = ctx.create_stream();
 
-    let relayer = Address::generate(&ctx.env);
-    let fake_key = BytesN::from_array(&ctx.env, &[0u8; 32]);
     let fake_sig = BytesN::from_array(&ctx.env, &[0u8; 64]);
-
-    // Stored nonce is 0; supply nonce=1 (wrong)
     let result = ctx.client().try_delegated_withdraw(
-        &stream_id, &relayer, &fake_key, &1u64, // wrong nonce
-        &9999u64, &0i128, &fake_sig,
+        &ctx.stream_id,
+        &ctx.relayer,
+        &ctx.recipient_pk,
+        &1, // wrong: stored nonce is 0
+        &9999,
+        &0,
+        &fake_sig,
     );
-
     assert_eq!(
         result,
         Err(Ok(fluxora_stream::ContractError::InvalidSignature)),
@@ -1338,83 +1436,56 @@ fn delegated_withdraw_wrong_nonce_rejected() {
     );
 }
 
+/// Public key that does not match the stream recipient returns `InvalidSignature`.
 #[test]
-fn delegated_withdraw_below_minimum_rejected() {
-    let ctx = Ctx::setup();
-    ctx.env.mock_all_auths();
-    ctx.env.ledger().set_timestamp(500); // mid-stream
-    let stream_id = ctx.create_stream();
+fn delegated_withdraw_wrong_public_key_rejected() {
+    let ctx = DelegatedCtx::setup();
+    ctx.env.ledger().set_timestamp(0);
 
-    let (pub_key, signing_key) = delegated_keypair(&ctx.env);
-
-    let nonce = 0u64;
-    let deadline = 9999u64;
-    let expected_minimum = 999i128; // demand 999 but only ~500 accrued
-
-    let msg = build_delegated_msg(&ctx.env, stream_id, nonce, deadline, expected_minimum);
-    let sig = sign_delegated_msg(&ctx.env, &signing_key, &msg);
-
-    let relayer = Address::generate(&ctx.env);
+    // Generate a different keypair (not the stream recipient).
+    let other_sk = SigningKey::from_bytes(&[0x01u8; 32]);
+    let other_pk_arr = other_sk.verifying_key().to_bytes();
+    let other_pk = BytesN::from_array(&ctx.env, &other_pk_arr);
+    // Sign with the other key (valid signature for that key, but wrong recipient).
+    let msg = build_delegated_msg(&ctx.env, ctx.stream_id, 0, 9999, 0);
+    let other_sig = sign_delegated_msg(&ctx.env, &other_sk, &msg);
 
     let result = ctx.client().try_delegated_withdraw(
-        &stream_id,
-        &relayer,
-        &pub_key,
-        &nonce,
-        &deadline,
-        &expected_minimum,
-        &sig,
+        &ctx.stream_id,
+        &ctx.relayer,
+        &other_pk, // wrong key
+        &0,
+        &9999,
+        &0,
+        &other_sig,
     );
-
     assert_eq!(
         result,
-        Err(Ok(fluxora_stream::ContractError::BelowMinimumAmount)),
-        "withdrawable below minimum must return BelowMinimumAmount"
+        Err(Ok(fluxora_stream::ContractError::InvalidSignature)),
+        "public key not matching stream recipient must be rejected before host sig check"
     );
 }
 
+/// Replaying a consumed nonce returns `InvalidSignature`.
 #[test]
-fn delegated_withdraw_nonce_increments_preventing_replay() {
-    let ctx = Ctx::setup();
-    ctx.env.mock_all_auths();
-    ctx.env.ledger().set_timestamp(0);
-    let stream_id = ctx.create_stream();
-
-    // Advance to mid-stream so there's something to withdraw
+fn delegated_withdraw_replay_rejected() {
+    let ctx = DelegatedCtx::setup();
     ctx.env.ledger().set_timestamp(500);
 
-    let (pub_key, signing_key) = delegated_keypair(&ctx.env);
+    let sig = ctx.sign(0, 9999, 0);
 
-    let nonce = 0u64;
-    let deadline = 9999u64;
-    let min_amount = 0i128;
+    // First call consumes nonce 0.
+    ctx.client()
+        .delegated_withdraw(&ctx.stream_id, &ctx.relayer, &ctx.recipient_pk, &0, &9999, &0, &sig);
 
-    let msg = build_delegated_msg(&ctx.env, stream_id, nonce, deadline, min_amount);
-    let sig = sign_delegated_msg(&ctx.env, &signing_key, &msg);
-
-    let relayer = Address::generate(&ctx.env);
-
-    // First call succeeds
-    let amount = ctx.client().delegated_withdraw(
-        &stream_id,
-        &relayer,
-        &pub_key,
-        &nonce,
-        &deadline,
-        &min_amount,
-        &sig,
-    );
-    assert!(amount > 0, "first delegated_withdraw must transfer tokens");
-
-    // Nonce is now 1; replaying nonce=0 must fail
-    // stale nonce
+    // Replay the same call — nonce is now 1.
     let replay = ctx.client().try_delegated_withdraw(
-        &stream_id,
-        &relayer,
-        &pub_key,
-        &nonce,
-        &deadline,
-        &min_amount,
+        &ctx.stream_id,
+        &ctx.relayer,
+        &ctx.recipient_pk,
+        &0, // stale nonce
+        &9999,
+        &0,
         &sig,
     );
     assert_eq!(
@@ -1422,11 +1493,57 @@ fn delegated_withdraw_nonce_increments_preventing_replay() {
         Err(Ok(fluxora_stream::ContractError::InvalidSignature)),
         "replayed nonce must be rejected"
     );
+}
 
-    // get_delegated_nonce must return 1
+/// Nonce is incremented exactly once per successful withdrawal.
+#[test]
+fn delegated_withdraw_nonce_increments_once() {
+    let ctx = DelegatedCtx::setup();
+    ctx.env.ledger().set_timestamp(500);
+
+    let recipient_addr = address_from_pk(&ctx.env, &ctx.signing_key.verifying_key().to_bytes());
+    assert_eq!(ctx.client().get_delegated_nonce(&recipient_addr), 0);
+
+    let sig = ctx.sign(0, 9999, 0);
+    ctx.client()
+        .delegated_withdraw(&ctx.stream_id, &ctx.relayer, &ctx.recipient_pk, &0, &9999, &0, &sig);
+
     assert_eq!(
-        ctx.client().get_delegated_nonce(&ctx.recipient),
-        1u64,
-        "nonce must be 1 after one successful delegated_withdraw"
+        ctx.client().get_delegated_nonce(&recipient_addr),
+        1,
+        "nonce must be exactly 1 after one successful delegated_withdraw"
+    );
+}
+
+/// `expected_minimum_amount` above withdrawable returns `BelowMinimumAmount`.
+#[test]
+fn delegated_withdraw_below_minimum_rejected() {
+    let ctx = DelegatedCtx::setup();
+    // At t=500, 500 tokens have accrued.
+    ctx.env.ledger().set_timestamp(500);
+
+    let min_amount = 999i128; // demand 999 but only 500 accrued
+    let sig = ctx.sign(0, 9999, min_amount);
+
+    let result = ctx.client().try_delegated_withdraw(
+        &ctx.stream_id,
+        &ctx.relayer,
+        &ctx.recipient_pk,
+        &0,
+        &9999,
+        &min_amount,
+        &sig,
+    );
+    assert_eq!(
+        result,
+        Err(Ok(fluxora_stream::ContractError::BelowMinimumAmount)),
+        "withdrawable below minimum must return BelowMinimumAmount"
+    );
+    // Nonce must NOT be consumed on a failed withdrawal.
+    let recipient_addr = address_from_pk(&ctx.env, &ctx.signing_key.verifying_key().to_bytes());
+    assert_eq!(
+        ctx.client().get_delegated_nonce(&recipient_addr),
+        0,
+        "nonce must not be consumed when BelowMinimumAmount is returned"
     );
 }

--- a/docs/security.md
+++ b/docs/security.md
@@ -256,20 +256,50 @@ properties of `withdraw` while adding replay and expiry protection.
 
 ### Signature scheme
 
-The recipient signs the SHA-256 hash of the following concatenated bytes:
+The recipient signs the following **40 raw bytes** (no prefix, no hashing):
 
 ```
-"fluxora_delegated_withdraw"  (UTF-8, no null terminator)
-|| contract_address_xdr        (XDR-encoded ScAddress)
-|| destination_xdr             (XDR-encoded ScAddress)
-|| stream_id                   (8 bytes, u64 big-endian)
-|| nonce                       (8 bytes, u64 big-endian)
-|| deadline                    (8 bytes, u64 big-endian)
+stream_id              (8 bytes, u64 big-endian)
+| nonce                (8 bytes, u64 big-endian)
+| deadline             (8 bytes, u64 big-endian)
+| expected_minimum_amount (16 bytes, i128 big-endian)
 ```
 
-The 32-byte SHA-256 hash is verified on-chain via `env.crypto().ed25519_verify`.
-Including the contract address in the message prevents cross-contract replay.
-Including the destination prevents a relayer from redirecting funds.
+The 64-byte Ed25519 signature over these raw bytes is verified on-chain via
+`env.crypto().ed25519_verify`. The caller supplies `recipient_public_key` (the
+raw 32-byte Ed25519 key); the contract derives the corresponding Stellar account
+address from that key and asserts it equals `stream.recipient` before calling
+`ed25519_verify`. A key that does not match the stored recipient returns
+`ContractError::InvalidSignature` immediately, without reaching the host-side
+signature check.
+
+**What the message binds:**
+- `stream_id` — prevents using the same signature on a different stream.
+- `nonce` — prevents replay; the recipient's nonce must match exactly.
+- `deadline` — limits the window in which the signature is valid.
+- `expected_minimum_amount` — closes the relayer front-running griefing vector:
+  a relayer cannot delay until accrued < minimum, because the call reverts with
+  `BelowMinimumAmount`.
+
+> **Note on host trapping:** `env.crypto().ed25519_verify` is a Soroban host
+> function that **traps** (panics) on an invalid signature rather than returning
+> a typed error. This is by design in the Soroban SDK. The pre-condition checks
+> (deadline, nonce, public-key binding) that precede it return typed
+> `ContractError` variants; a relayer using `try_delegated_withdraw` will see
+> `Err(Err(HostError))` only for a signature with wrong bytes after all
+> pre-conditions pass. The distinction is observable on the client side.
+
+### Trust assumption: recipient_public_key
+
+The caller supplies `recipient_public_key` as a raw 32-byte Ed25519 public key.
+The contract derives the Stellar account `Address` from that key and compares it
+to `stream.recipient`. This check ensures that:
+
+1. Only the actual stream recipient's key can authorize a delegated withdrawal.
+2. A relayer cannot use an arbitrary self-generated key to burn the recipient's
+   nonce or trigger an unintended withdrawal.
+3. Contract-account recipients (not ed25519 accounts) cannot use `delegated_withdraw`;
+   they must use the direct `withdraw` path.
 
 ### Replay protection (nonce)
 
@@ -277,7 +307,7 @@ Including the destination prevents a relayer from redirecting funds.
   in persistent storage.
 - The supplied `nonce` must equal the current stored nonce exactly — no skipping allowed.
 - On a successful withdrawal that moves tokens, the nonce is incremented atomically
-  before the token transfer (CEI-compliant).
+  **after** all checks and **before** the token transfer (CEI-compliant).
 - If `withdrawable == 0` the nonce is **not** consumed, preserving the signature for
   a future call when tokens have accrued.
 
@@ -287,28 +317,38 @@ Including the destination prevents a relayer from redirecting funds.
   if `env.ledger().timestamp() > deadline`.
 - A deadline equal to the current timestamp is accepted (not yet expired).
 
+### Error codes for `delegated_withdraw`
+
+| Condition | Error code |
+|---|---|
+| `env.ledger().timestamp() > deadline` | `SignatureDeadlineExpired` (19) |
+| `nonce != stored_nonce` | `InvalidSignature` (15) |
+| Public key does not derive `stream.recipient` | `InvalidSignature` (15) |
+| Malformed/wrong ed25519 signature bytes | Host trap (`HostError`, not a typed `ContractError`) |
+| `withdrawable < expected_minimum_amount` | `BelowMinimumAmount` (16) |
+| Stream is Paused (non-terminal) or Completed | `InvalidState` |
+
 ### CEI ordering for `delegated_withdraw`
 
-1. **Checks**: deadline, destination guard, stream status, nonce match, signature verify.
-2. **Effects**: increment nonce, update `withdrawn_amount`, optionally set `Completed`,
-   call `save_stream`.
-3. **Interactions**: `push_token` to destination, emit `dlg_wdraw` event (and optionally
-   `completed` event).
+1. **Checks**: deadline → stream load → withdrawal frequency → nonce → public-key binding → signature.
+2. **Effects**: update `withdrawn_amount`, optionally set `Completed`, call `save_stream`, increment nonce.
+3. **Interactions**: `push_token` to `stream.recipient`, emit `withdrew` event (and optionally `completed` event).
 
 ### Authorization table addition
 
 | Operation             | Authorized callers                                        |
 |-----------------------|-----------------------------------------------------------|
-| `delegated_withdraw`  | `relayer` (any address; recipient intent via signature)   |
-| `get_withdraw_nonce`  | Permissionless (view function)                            |
+| `delegated_withdraw`  | `relayer` (any address; recipient intent via Ed25519 signature) |
+| `get_delegated_nonce` | Permissionless (view function)                            |
 
 ### Security invariants
 
 - A used signature cannot be replayed (nonce incremented on success).
-- An expired signature is rejected before any state change.
-- A signature from the wrong key is rejected by `ed25519_verify` (host trap).
-- The destination is bound in the signed message — a relayer cannot redirect funds.
-- The contract address is bound in the signed message — signatures are chain/contract-specific.
+- An expired signature is rejected before any state change with `SignatureDeadlineExpired`.
+- A signature from the wrong key is rejected by the public-key binding check with `InvalidSignature`.
+- A malformed signature causes an `ed25519_verify` host trap (by Soroban SDK design).
+- The `stream_id` and `expected_minimum_amount` are bound in the signed message.
+- Tokens always transfer to `stream.recipient`; no relayer can redirect funds.
 - Direct `withdraw` / `withdraw_to` / `batch_withdraw` are unaffected; their auth paths
   remain unchanged.
 ## Malicious Token Assumptions and Non-Goals


### PR DESCRIPTION
fix: recoverable InvalidSignature from delegated_withdraw + dead code removal
  
  What changed
  
  contracts/stream/src/lib.rs
  
  - Removed dead try_into().map_err(|_| InvalidSignature)? conversions on recipient_public_key
   and signature — both are already BytesN<32>/BytesN<64> at the call site; these conversions
  could never fail.
  - Deadline check now returns ContractError::SignatureDeadlineExpired (19) instead of
  InvalidSignature (15), matching the documented error contract.
  - Added recipient public-key binding: derives a Soroban Address from the supplied
  recipient_public_key via soroban_sdk::xdr and asserts it equals stream.recipient. Returns
  ContractError::InvalidSignature on mismatch — a typed, recoverable error — before
  ed25519_verify is ever called. This also closes a security gap where any keypair could burn the
  recipient's nonce without their consent.
  - ed25519_verify is now called directly with the typed parameters. A comment documents that the
  host traps on a malformed signature (Soroban SDK design), and that callers using
  try_delegated_withdraw see Err(Err(HostError)) for that case vs Err(Ok(ContractError)) for the
  pre-condition failures above.
  
  docs/security.md
  
  - Replaced stale SHA-256/prefix scheme with the correct 40-byte raw layout: stream_id(8) |
  nonce(8) | deadline(8) | expected_minimum_amount(16).
  - Added error codes table distinguishing SignatureDeadlineExpired / InvalidSignature / host
  trap.
  - Added trust assumption section for the recipient_public_key binding check.
  
  contracts/stream/tests/adversarial_auth.rs
  
  - Replaced 4 broken tests (mismatched keypair, wrong expected error codes) with 7 correct tests
  using a DelegatedCtx fixture where the stream recipient is the address derived from a known
  ed25519 keypair.
  
  Tests added
  
  ┌─────────────────────────────────────────────┬────────────────────────────────────┐
  │ Test                                         │ Asserts                            │
  ├──────────────────────────────────────────────┼────────────────────────────────────┤
  │ delegated_withdraw_valid_signature_succeeds  │ Correct key + sig transfers tokens │
  ├──────────────────────────────────────────────┼─────────────────────────────────────────┤
  │ delegated_withdraw_expired_deadline_rejected │ Returns SignatureDeadlineExpired        │
  │ delegated_withdraw_expired_deadline_r      │ Returns SignatureDeadlineExpired            │
  │ ejected                                    │                                             │
  ├────────────────────────────────────────────┼─────────────────────────────────────────────┤
  │ delegated_withdraw_wrong_nonce_rejected    │ Returns InvalidSignature (no host trap)     │
  ├────────────────────────────────────────────┼─────────────────────────────────────────────┤
  │ delegated_withdraw_wrong_public_key_r      │ Returns InvalidSignature before             │
  │ ejected                                    │ ed25519_verify                              │
  ├────────────────────────────────────────────┼─────────────────────────────────────────────┤
  │ delegated_withdraw_replay_rejected         │ Replayed nonce returns InvalidSignature     │
  ├────────────────────────────────────────────┼─────────────────────────────────────────────┤
  │ delegated_withdraw_nonce_increments_once   │ Nonce is exactly 1 after one success        │
  ├────────────────────────────────────────────┼─────────────────────────────────────────────┤
  │ delegated_withdraw_below_minimum_rejected  │ Returns BelowMinimumAmount; nonce not       │
  │                                            │ consumed                                    │
  └────────────────────────────────────────────┴─────────────────────────────────────────────┘
  
  Security notes
  
  - Tokens always go to stream.recipient — no fund redirection possible.
  - The key-binding check ensures only the actual stream recipient's ed25519 key can authorize a
  delegated withdrawal. Contract-account recipients must use the direct withdraw path.
  - Nonce is only consumed after all checks pass (CEI ordering unchanged).
  -   - 
  -   - closes #616  -   - 

