### PR TITLE
feat(governance): add get_quorum_info and is_executable read-only views

### DIFF
--- a/contracts/governance/src/lib.rs
+++ b/contracts/governance/src/lib.rs
@@ -605,9 +605,8 @@ impl FluxoraGovernance {
 
         // Verify timelock has elapsed from the moment quorum was reached.
         let now = env.ledger().timestamp();
-        let executable_after =
-            checked_deadline(quorum_info.reached_at, GOVERNANCE_TIMELOCK_SECONDS)?;
-        if now < executable_after {
+        let exec_after = Self::executable_after(&quorum_info)?;
+        if now < exec_after {
             return Err(GovernanceError::TimelockNotElapsed);
         }
 
@@ -720,9 +719,115 @@ impl FluxoraGovernance {
         MAX_PROPOSAL_AGE_SECONDS
     }
 
+    /// Return the stored `QuorumInfo` snapshot for a proposal, or `None` if
+    /// quorum has not yet been reached.
+    ///
+    /// # Parameters
+    /// - `proposal_id`: The proposal to query.
+    ///
+    /// # Returns
+    /// - `Some(QuorumInfo { reached_at, threshold })` if quorum was reached.
+    /// - `None` if quorum has not been reached (no approvals, below threshold,
+    ///   or proposal does not exist).
+    ///
+    /// This is a pure read — no authorization required, no state mutation
+    /// other than the standard TTL bump on the stored `QuorumInfo` entry.
+    pub fn get_quorum_info(env: Env, proposal_id: u32) -> Option<QuorumInfo> {
+        let info: Option<QuorumInfo> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::QuorumReachedAt(proposal_id));
+        if info.is_some() {
+            env.storage().persistent().extend_ttl(
+                &DataKey::QuorumReachedAt(proposal_id),
+                PERSISTENT_LIFETIME_THRESHOLD,
+                PERSISTENT_BUMP_AMOUNT,
+            );
+        }
+        info
+    }
+
+    /// Return `true` if the proposal is in an executable state **right now**.
+    ///
+    /// Mirrors the exact gating order used by [`execute`](Self::execute):
+    ///
+    /// 1. Proposal exists (`ProposalNotFound` otherwise).
+    /// 2. Not cancelled.
+    /// 3. Not already executed.
+    /// 4. Not expired.
+    /// 5. Quorum has been reached (approvals >= threshold snapshot).
+    /// 6. Timelock has elapsed (`now >= executable_after`).
+    ///
+    /// # Parameters
+    /// - `proposal_id`: The proposal to check.
+    ///
+    /// # Returns
+    /// - `Ok(true)` iff all gates pass — the proposal can be executed now.
+    /// - `Ok(false)` if any gate blocks execution (cancelled, executed,
+    ///   expired, quorum not reached, timelock not elapsed).
+    /// - `Err(GovernanceError::ProposalNotFound)` if the ID is unknown.
+    /// - `Err(GovernanceError::ArithmeticOverflow)` if timelock arithmetic
+    ///   overflows (should not happen under normal ledger conditions).
+    ///
+    /// This is a pure read — no authorization required, no state mutation
+    /// beyond the TTL bumps already performed by [`load_proposal`] and
+    /// [`get_quorum_info`].
+    pub fn is_executable(env: Env, proposal_id: u32) -> Result<bool, GovernanceError> {
+        let proposal = load_proposal(&env, proposal_id)?;
+
+        if proposal.cancelled {
+            return Ok(false);
+        }
+        if proposal.executed {
+            return Ok(false);
+        }
+        if env.ledger().timestamp()
+            > checked_deadline(proposal.created_at, MAX_PROPOSAL_AGE_SECONDS)?
+        {
+            return Ok(false);
+        }
+
+        let quorum_info: QuorumInfo = match env
+            .storage()
+            .persistent()
+            .get(&DataKey::QuorumReachedAt(proposal_id))
+        {
+            Some(info) => {
+                env.storage().persistent().extend_ttl(
+                    &DataKey::QuorumReachedAt(proposal_id),
+                    PERSISTENT_LIFETIME_THRESHOLD,
+                    PERSISTENT_BUMP_AMOUNT,
+                );
+                info
+            }
+            None => return Ok(false),
+        };
+
+        if proposal.approvals.len() < quorum_info.threshold {
+            return Ok(false);
+        }
+
+        let now = env.ledger().timestamp();
+        let exec_after = Self::executable_after(&quorum_info)?;
+        if now < exec_after {
+            return Ok(false);
+        }
+
+        Ok(true)
+    }
+
     // -----------------------------------------------------------------------
     // Internal helpers
     // -----------------------------------------------------------------------
+
+    /// Compute the ledger timestamp at which a proposal becomes executable,
+    /// given its `QuorumInfo` snapshot.
+    ///
+    /// Returns `reached_at + GOVERNANCE_TIMELOCK_SECONDS`, or
+    /// `ArithmeticOverflow` if the sum would overflow `u64`.
+    fn executable_after(info: &QuorumInfo) -> Result<u64, GovernanceError> {
+        checked_deadline(info.reached_at, GOVERNANCE_TIMELOCK_SECONDS)
+    }
 
     fn is_signer(signers: &Vec<Address>, addr: &Address) -> bool {
         for i in 0..signers.len() {
@@ -1262,5 +1367,318 @@ mod tests {
         ctx.client.execute(&executor, &id);
         let result = ctx.client.try_execute(&executor, &id);
         assert_eq!(result, Err(Ok(GovernanceError::AlreadyExecuted)));
+    }
+
+    // -----------------------------------------------------------------------
+    // get_quorum_info
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_get_quorum_info_before_quorum() {
+        let ctx = Ctx::setup();
+        let id = ctx
+            .client
+            .propose(&ctx.signer_a, &ctx.dummy_target(), &ctx.calldata("x"));
+        // No approvals yet — quorum not reached.
+        assert!(ctx.client.get_quorum_info(&id).is_none());
+    }
+
+    #[test]
+    fn test_get_quorum_info_below_threshold() {
+        let ctx = Ctx::setup();
+        let id = ctx
+            .client
+            .propose(&ctx.signer_a, &ctx.dummy_target(), &ctx.calldata("x"));
+        ctx.client.approve(&ctx.signer_a, &id);
+        // Only 1 approval — threshold is 2, quorum not reached.
+        assert!(ctx.client.get_quorum_info(&id).is_none());
+    }
+
+    #[test]
+    fn test_get_quorum_info_after_quorum() {
+        let ctx = Ctx::setup();
+        let id = ctx
+            .client
+            .propose(&ctx.signer_a, &ctx.dummy_target(), &ctx.calldata("x"));
+        // First approval — below threshold.
+        ctx.client.approve(&ctx.signer_a, &id);
+        // Second approval — hits threshold, quorum reached at timestamp 1_000_000.
+        ctx.client.approve(&ctx.signer_b, &id);
+
+        let info = ctx.client.get_quorum_info(&id).expect("should have quorum info");
+        assert_eq!(info.reached_at, 1_000_000);
+        assert_eq!(info.threshold, 2);
+    }
+
+    #[test]
+    fn test_get_quorum_info_preserves_snapshot_threshold() {
+        // Verify the snapshot threshold is independent of later threshold changes.
+        let ctx = Ctx::setup();
+        let id = ctx
+            .client
+            .propose(&ctx.signer_a, &ctx.dummy_target(), &ctx.calldata("x"));
+        ctx.client.approve(&ctx.signer_a, &id);
+        ctx.client.approve(&ctx.signer_b, &id);
+
+        let info = ctx.client.get_quorum_info(&id).expect("should have quorum info");
+        assert_eq!(info.threshold, 2);
+
+        // Remove signer_c — threshold stays 2, snapshot should still be 2.
+        ctx.client.remove_signer(&ctx.signer_c);
+        let info = ctx.client.get_quorum_info(&id).expect("should still have quorum info");
+        assert_eq!(info.threshold, 2);
+    }
+
+    #[test]
+    fn test_get_quorum_info_none_for_nonexistent_proposal() {
+        let ctx = Ctx::setup();
+        // A valid ID that was never proposed; no QuorumInfo exists.
+        assert!(ctx.client.get_quorum_info(&999).is_none());
+    }
+
+    #[test]
+    fn test_get_quorum_info_none_after_execute() {
+        let ctx = Ctx::setup();
+        let id = ctx
+            .client
+            .propose(&ctx.signer_a, &ctx.dummy_target(), &ctx.calldata("x"));
+        ctx.client.approve(&ctx.signer_a, &id);
+        ctx.client.approve(&ctx.signer_b, &id);
+        ctx.env.ledger().set_timestamp(1_000_000 + TIMELOCK + 1);
+        let executor = Address::generate(&ctx.env);
+        ctx.client.execute(&executor, &id);
+        // QuorumInfo should still exist (execution does not delete it).
+        let info = ctx.client.get_quorum_info(&id).expect("should still have quorum info after execute");
+        assert_eq!(info.reached_at, 1_000_000);
+        assert_eq!(info.threshold, 2);
+    }
+
+    // -----------------------------------------------------------------------
+    // is_executable
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_is_executable_nonexistent_proposal() {
+        let ctx = Ctx::setup();
+        let result = ctx.client.try_is_executable(&999);
+        assert_eq!(result, Err(Ok(GovernanceError::ProposalNotFound)));
+    }
+
+    #[test]
+    fn test_is_executable_pre_quorum() {
+        let ctx = Ctx::setup();
+        let id = ctx
+            .client
+            .propose(&ctx.signer_a, &ctx.dummy_target(), &ctx.calldata("x"));
+        // No approvals yet.
+        assert_eq!(ctx.client.is_executable(&id), false);
+    }
+
+    #[test]
+    fn test_is_executable_below_threshold() {
+        let ctx = Ctx::setup();
+        let id = ctx
+            .client
+            .propose(&ctx.signer_a, &ctx.dummy_target(), &ctx.calldata("x"));
+        ctx.client.approve(&ctx.signer_a, &id);
+        // Only 1 approval — threshold 2 not met.
+        assert_eq!(ctx.client.is_executable(&id), false);
+    }
+
+    #[test]
+    fn test_is_executable_post_quorum_pre_timelock() {
+        let ctx = Ctx::setup();
+        let id = ctx
+            .client
+            .propose(&ctx.signer_a, &ctx.dummy_target(), &ctx.calldata("x"));
+        ctx.client.approve(&ctx.signer_a, &id);
+        ctx.client.approve(&ctx.signer_b, &id);
+        // Timelock not yet elapsed (current time is still 1_000_000).
+        assert_eq!(ctx.client.is_executable(&id), false);
+    }
+
+    #[test]
+    fn test_is_executable_post_timelock() {
+        let ctx = Ctx::setup();
+        let id = ctx
+            .client
+            .propose(&ctx.signer_a, &ctx.dummy_target(), &ctx.calldata("x"));
+        ctx.client.approve(&ctx.signer_a, &id);
+        ctx.client.approve(&ctx.signer_b, &id);
+        ctx.env.ledger().set_timestamp(1_000_000 + TIMELOCK + 1);
+        assert_eq!(ctx.client.is_executable(&id), true);
+    }
+
+    #[test]
+    fn test_is_executable_cancelled() {
+        let ctx = Ctx::setup();
+        let id = ctx
+            .client
+            .propose(&ctx.signer_a, &ctx.dummy_target(), &ctx.calldata("x"));
+        ctx.client.approve(&ctx.signer_a, &id);
+        ctx.client.approve(&ctx.signer_b, &id);
+        ctx.client.cancel_proposal(&ctx.signer_a, &id);
+        ctx.env.ledger().set_timestamp(1_000_000 + TIMELOCK + 1);
+        assert_eq!(ctx.client.is_executable(&id), false);
+    }
+
+    #[test]
+    fn test_is_executable_executed() {
+        let ctx = Ctx::setup();
+        let id = ctx
+            .client
+            .propose(&ctx.signer_a, &ctx.dummy_target(), &ctx.calldata("x"));
+        ctx.client.approve(&ctx.signer_a, &id);
+        ctx.client.approve(&ctx.signer_b, &id);
+        ctx.env.ledger().set_timestamp(1_000_000 + TIMELOCK + 1);
+        let executor = Address::generate(&ctx.env);
+        ctx.client.execute(&executor, &id);
+        assert_eq!(ctx.client.is_executable(&id), false);
+    }
+
+    #[test]
+    fn test_is_executable_expired() {
+        let ctx = Ctx::setup();
+        let id = ctx
+            .client
+            .propose(&ctx.signer_a, &ctx.dummy_target(), &ctx.calldata("x"));
+        ctx.client.approve(&ctx.signer_a, &id);
+        ctx.client.approve(&ctx.signer_b, &id);
+        ctx.env.ledger().set_timestamp(1_000_000 + MAX_AGE + 1);
+        assert_eq!(ctx.client.is_executable(&id), false);
+    }
+
+    #[test]
+    fn test_is_executable_at_timelock_boundary() {
+        let ctx = Ctx::setup();
+        let id = ctx
+            .client
+            .propose(&ctx.signer_a, &ctx.dummy_target(), &ctx.calldata("x"));
+        ctx.client.approve(&ctx.signer_a, &id);
+        ctx.client.approve(&ctx.signer_b, &id);
+
+        // Exactly at reached_at + TIMELOCK — timelock has elapsed (now >= exec_after).
+        ctx.env.ledger().set_timestamp(1_000_000 + TIMELOCK);
+        assert_eq!(ctx.client.is_executable(&id), true);
+    }
+
+    #[test]
+    fn test_is_executable_one_second_before_timelock() {
+        let ctx = Ctx::setup();
+        let id = ctx
+            .client
+            .propose(&ctx.signer_a, &ctx.dummy_target(), &ctx.calldata("x"));
+        ctx.client.approve(&ctx.signer_a, &id);
+        ctx.client.approve(&ctx.signer_b, &id);
+
+        // One second before the timelock elapses — should NOT be executable.
+        ctx.env.ledger().set_timestamp(1_000_000 + TIMELOCK - 1);
+        assert_eq!(ctx.client.is_executable(&id), false);
+    }
+
+    #[test]
+    fn test_is_executable_at_expiry_boundary() {
+        let ctx = Ctx::setup();
+        let id = ctx
+            .client
+            .propose(&ctx.signer_a, &ctx.dummy_target(), &ctx.calldata("x"));
+        ctx.client.approve(&ctx.signer_a, &id);
+        ctx.client.approve(&ctx.signer_b, &id);
+
+        // Exactly at created_at + MAX_AGE — not past it, so not expired.
+        // Since MAX_AGE >> TIMELOCK, the timelock has also elapsed.
+        ctx.env.ledger().set_timestamp(1_000_000 + MAX_AGE);
+        assert_eq!(ctx.client.is_executable(&id), true);
+    }
+
+    #[test]
+    fn test_is_executable_one_second_before_expiry() {
+        let ctx = Ctx::setup();
+        let id = ctx
+            .client
+            .propose(&ctx.signer_a, &ctx.dummy_target(), &ctx.calldata("x"));
+        ctx.client.approve(&ctx.signer_a, &id);
+        ctx.client.approve(&ctx.signer_b, &id);
+
+        // One second before expiry — still executable if timelock has elapsed.
+        ctx.env.ledger().set_timestamp(1_000_000 + MAX_AGE - 1);
+        assert_eq!(ctx.client.is_executable(&id), true);
+    }
+
+    #[test]
+    fn test_is_executable_one_second_after_expiry() {
+        let ctx = Ctx::setup();
+        let id = ctx
+            .client
+            .propose(&ctx.signer_a, &ctx.dummy_target(), &ctx.calldata("x"));
+        ctx.client.approve(&ctx.signer_a, &id);
+        ctx.client.approve(&ctx.signer_b, &id);
+
+        // One second past expiry — not executable.
+        ctx.env.ledger().set_timestamp(1_000_000 + MAX_AGE + 1);
+        assert_eq!(ctx.client.is_executable(&id), false);
+    }
+
+    #[test]
+    fn test_is_executable_agrees_with_execute_across_states() {
+        let ctx = Ctx::setup();
+
+        // --- Pre-quorum ---
+        let id = ctx
+            .client
+            .propose(&ctx.signer_a, &ctx.dummy_target(), &ctx.calldata("x"));
+        assert_eq!(ctx.client.is_executable(&id), false);
+        let executor = Address::generate(&ctx.env);
+        assert_eq!(
+            ctx.client.try_execute(&executor, &id),
+            Err(Ok(GovernanceError::QuorumNotReached))
+        );
+
+        // --- Post-quorum, pre-timelock ---
+        ctx.client.approve(&ctx.signer_a, &id);
+        ctx.client.approve(&ctx.signer_b, &id);
+        assert_eq!(ctx.client.is_executable(&id), false);
+        assert_eq!(
+            ctx.client.try_execute(&executor, &id),
+            Err(Ok(GovernanceError::TimelockNotElapsed))
+        );
+
+        // --- Post-timelock, executable ---
+        ctx.env.ledger().set_timestamp(1_000_000 + TIMELOCK + 1);
+        assert_eq!(ctx.client.is_executable(&id), true);
+        assert!(ctx.client.try_execute(&executor, &id).is_ok());
+
+        // --- Post-execution ---
+        assert_eq!(ctx.client.is_executable(&id), false);
+        assert_eq!(
+            ctx.client.try_execute(&executor, &id),
+            Err(Ok(GovernanceError::AlreadyExecuted))
+        );
+
+        // --- Cancelled proposal (fresh) ---
+        let id2 = ctx
+            .client
+            .propose(&ctx.signer_a, &ctx.dummy_target(), &ctx.calldata("y"));
+        ctx.client.approve(&ctx.signer_a, &id2);
+        ctx.client.approve(&ctx.signer_b, &id2);
+        ctx.client.cancel_proposal(&ctx.signer_a, &id2);
+        assert_eq!(ctx.client.is_executable(&id2), false);
+        assert_eq!(
+            ctx.client.try_execute(&executor, &id2),
+            Err(Ok(GovernanceError::ProposalCancelled))
+        );
+
+        // --- Expired proposal (fresh) ---
+        let id3 = ctx
+            .client
+            .propose(&ctx.signer_a, &ctx.dummy_target(), &ctx.calldata("z"));
+        ctx.client.approve(&ctx.signer_a, &id3);
+        ctx.client.approve(&ctx.signer_b, &id3);
+        ctx.env.ledger().set_timestamp(1_000_000 + MAX_AGE + TIMELOCK + 100);
+        assert_eq!(ctx.client.is_executable(&id3), false);
+        assert_eq!(
+            ctx.client.try_execute(&executor, &id3),
+            Err(Ok(GovernanceError::ProposalExpired))
+        );
     }
 }

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -172,6 +172,15 @@ Cancels a proposal, marking it as terminal. Emits `ProposalCancelled`.
 - `quorum() -> u32`: returns the configured approval threshold.
 - `timelock_seconds() -> u64`: returns `GOVERNANCE_TIMELOCK_SECONDS`.
 - `max_proposal_age_seconds() -> u64`: returns `MAX_PROPOSAL_AGE_SECONDS`.
+- `get_quorum_info(proposal_id) -> Option<QuorumInfo>`: returns the stored
+  `QuorumInfo { reached_at, threshold }` snapshot if quorum was reached, or
+  `None` if quorum has not yet been reached.  No authorization required.
+- `is_executable(proposal_id) -> bool`: returns `true` iff the proposal
+  exists, is not cancelled/executed/expired, quorum is reached, and
+  `now >= reached_at + GOVERNANCE_TIMELOCK_SECONDS`.  Mirrors the exact
+  gating order used by `execute`.  Returns an error (`ProposalNotFound` or
+  `ArithmeticOverflow`) only when `execute` would also error.  No
+  authorization required.
 
 ## Calldata encoding contract
 
@@ -250,11 +259,12 @@ throughout the timelock window, the contract bumps TTL on every read and
 write that touches the entry:
 
 - **`Proposal(id)`**: bumped via `bump_proposal` in `load_proposal` (read path,
-  called by `get_proposal`, `approve`, `execute`, `cancel_proposal`) and in
-  `save_proposal` (write path, called by `propose`, `approve`,
-  `cancel_proposal`, `execute`).
-- **`QuorumReachedAt(id)`**: bumped once when quorum is first reached inside
-  `approve`, immediately after the `QuorumInfo` write.
+  called by `get_proposal`, `is_executable`, `approve`, `execute`,
+  `cancel_proposal`) and in `save_proposal` (write path, called by `propose`,
+  `approve`, `cancel_proposal`, `execute`).
+- **`QuorumReachedAt(id)`**: bumped when quorum is first reached inside
+  `approve` (write path), and also bumped on read by `get_quorum_info`
+  and `is_executable` (read path).
 
 Constants:
 


### PR DESCRIPTION
Close #685 

PR Description
## Summary

Adds `get_quorum_info` and `is_executable` read-only views to `fluxora_governance` so executors and dashboards can cheaply determine when a multisig proposal becomes executable — no need to probe via `try_execute` or scan event logs.

## Changes

### `contracts/governance/src/lib.rs`

- **`executable_after(info: &QuorumInfo) -> Result<u64, GovernanceError>`** — private helper factoring `reached_at + GOVERNANCE_TIMELOCK_SECONDS`. Both `execute` and `is_executable` call it, guaranteeing identical timelock arithmetic.

- **`get_quorum_info(env, proposal_id) -> Option<QuorumInfo>`** — returns the stored `QuorumInfo { reached_at, threshold }` snapshot if quorum was reached, or `None` otherwise. Bumps TTL on the `QuorumReachedAt` key when present. Pure read, no auth.

- **`is_executable(env, proposal_id) -> Result<bool, GovernanceError>`** — returns `Ok(true)` iff all gates pass, mirroring `execute`'s exact gating order:
  1. Proposal exists (`ProposalNotFound` otherwise)
  2. Not cancelled
  3. Not executed
  4. Not expired
  5. Quorum reached (approvals >= snapshot threshold)
  6. Timelock elapsed (`now >= executable_after`)

  Returns `Ok(false)` for terminal/non-executable states, `Err` only for `ProposalNotFound` or `ArithmeticOverflow`. No auth.

- **Refactored `execute`** to use `executable_after(&quorum_info)` instead of inline `checked_deadline`.

### `docs/governance.md`

- Added `get_quorum_info` and `is_executable` to the query entrypoints section
- Updated TTL policy: `QuorumReachedAt(id)` is now bumped on read by `get_quorum_info` and `is_executable`, not only on write in `approve`

## Tests (18 new, 50 total)

| Test | What it covers |
|---|---|
| `get_quorum_info` | None before quorum, None below threshold, Some after quorum, snapshot threshold preserved after `remove_signer`, None for nonexistent ID, persists after execute |
| `is_executable` | Nonexistent (Err), pre-quorum (false), below-threshold (false), post-quorum/pre-timelock (false), post-timelock (true), cancelled (false), executed (false), expired (false), at timelock boundary (true), 1s before timelock (false), at expiry boundary (true), 1s before expiry (true), 1s after expiry (false) |
| `is_executable_agrees_with_execute_across_states` | Single proposal tracked through pre-quorum → post-quorum → post-timelock → executed + fresh proposals for cancelled and expired; asserts both views agree at every step |

All 50 tests pass.

