### PR TITLE
fix(factory): require admin auth and validate stream_contract at init

### DIFF
--- a/contracts/factory/src/lib.rs
+++ b/contracts/factory/src/lib.rs
@@ -17,6 +17,13 @@ pub enum FactoryError {
     InvalidTimeRange = 7,
     /// The requested cliff must be within the inclusive start/end window.
     InvalidCliff = 8,
+    /// The supplied `stream_contract` address did not respond to the
+    /// `FluxoraStream::version()` smoke check (e.g. it is not a deployed
+    /// contract, or does not implement the `FluxoraStream` interface).
+    ///
+    /// Returned by `init` and `set_stream_contract` instead of letting an
+    /// invalid address be persisted and later host-trap inside `create_stream`.
+    InvalidStreamContract = 9,
 }
 
 #[contracttype]
@@ -42,6 +49,27 @@ fn require_admin(env: &Env) -> Result<Address, FactoryError> {
     Ok(admin)
 }
 
+/// Smoke-test a candidate stream contract for the `FluxoraStream` interface.
+///
+/// This helper is called from `init` and `set_stream_contract` before the
+/// candidate address is persisted as the factory's `StreamContract`. It
+/// invokes the read-only, storage-free `version()` entrypoint via
+/// `FluxoraStreamClient::try_version`, which uses `Env::try_invoke_contract`
+/// internally so a missing contract, an EOA address, or a contract that does
+/// not expose `version()` surfaces as a typed `FactoryError` instead of a
+/// host trap.
+///
+/// `version()` is intentionally cheap to check: it performs no storage reads
+/// and works even on a `FluxoraStream` contract that has not yet been
+/// initialized, so it is safe to call during the factory's own bootstrap.
+fn validate_stream_contract(env: &Env, stream_contract: &Address) -> Result<(), FactoryError> {
+    let client = FluxoraStreamClient::new(env, stream_contract);
+    match client.try_version() {
+        Ok(Ok(_)) => Ok(()),
+        _ => Err(FactoryError::InvalidStreamContract),
+    }
+}
+
 /// Read-only snapshot of the factory policy stored in instance storage.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -59,6 +87,26 @@ pub struct FluxoraFactory;
 #[allow(clippy::too_many_arguments)]
 impl FluxoraFactory {
     /// Initialize the factory with admin, stream contract, and policies.
+    ///
+    /// # Authorization
+    /// The declared `admin` must authorize this call via `admin.require_auth()`.
+    /// This matches every other admin-only entrypoint (`set_admin`,
+    /// `set_stream_contract`, `set_allowlist`, `set_cap`, `set_min_duration`,
+    /// all of which go through `require_admin`) and prevents an unrelated
+    /// caller from front-running bootstrap by seeding the factory with an
+    /// admin address they do not control.
+    ///
+    /// # Validation
+    /// `stream_contract` must pass the `FluxoraStream` smoke check (see
+    /// [`validate_stream_contract`]) before it is persisted. This converts a
+    /// misconfigured stream address from a deferred host trap inside
+    /// `create_stream` into an immediate `FactoryError::InvalidStreamContract`
+    /// at setup time.
+    ///
+    /// # Errors
+    /// - `FactoryError::AlreadyInitialized` if `init` has already succeeded.
+    /// - `FactoryError::InvalidStreamContract` if `stream_contract` does not
+    ///   respond to `FluxoraStream::version()`.
     pub fn init(
         env: Env,
         admin: Address,
@@ -69,6 +117,9 @@ impl FluxoraFactory {
         if env.storage().instance().has(&DataKey::Admin) {
             return Err(FactoryError::AlreadyInitialized);
         }
+
+        admin.require_auth();
+        validate_stream_contract(&env, &stream_contract)?;
 
         env.storage().instance().set(&DataKey::Admin, &admin);
         env.storage()
@@ -93,8 +144,15 @@ impl FluxoraFactory {
     }
 
     /// Admin updates the stream contract address.
+    ///
+    /// # Validation
+    /// `new_stream_contract` must pass the same `FluxoraStream` smoke check
+    /// applied in `init` (see [`validate_stream_contract`]), so a later swap
+    /// cannot silently install a non-`FluxoraStream` address. On failure the
+    /// previously configured `stream_contract` is left untouched.
     pub fn set_stream_contract(env: Env, new_stream_contract: Address) -> Result<(), FactoryError> {
         require_admin(&env)?;
+        validate_stream_contract(&env, &new_stream_contract)?;
 
         env.storage()
             .instance()

--- a/contracts/factory/tests/factory_init_security.rs
+++ b/contracts/factory/tests/factory_init_security.rs
@@ -1,0 +1,293 @@
+//! Security tests for `FluxoraFactory::init` and `set_stream_contract`.
+//!
+//! Covers:
+//! - `init` cannot succeed without the declared admin's authorization.
+//! - `init` and `set_stream_contract` reject a `stream_contract` address that
+//!   does not implement the `FluxoraStream` interface (EOA / non-contract /
+//!   wrong contract), returning a typed `FactoryError::InvalidStreamContract`
+//!   instead of host-trapping.
+//! - The `InvalidStreamContract` discriminant is stable and existing
+//!   discriminants are unchanged.
+
+use fluxora_factory::{FactoryError, FluxoraFactory, FluxoraFactoryClient};
+use fluxora_stream::{FluxoraStream, FluxoraStreamClient};
+use soroban_sdk::{
+    testutils::{Address as _, MockAuth, MockAuthInvoke},
+    Address, Env, IntoVal,
+};
+
+fn deploy_factory(env: &Env) -> FluxoraFactoryClient<'_> {
+    let factory_id = env.register_contract(None, FluxoraFactory);
+    FluxoraFactoryClient::new(env, &factory_id)
+}
+
+fn deploy_stream(env: &Env) -> Address {
+    env.register_contract(None, FluxoraStream)
+}
+
+// ---------------------------------------------------------------------------
+// init requires admin auth
+// ---------------------------------------------------------------------------
+
+/// `init` must panic (auth failure) if the declared admin did not authorize
+/// the call, even when the supplied `stream_contract` is a valid deployment.
+#[test]
+#[should_panic]
+fn test_init_without_admin_auth_panics() {
+    let env = Env::default();
+    // No mock_all_auths / mock_auths configured at all: any require_auth fails.
+    let factory = deploy_factory(&env);
+    let stream_contract = deploy_stream(&env);
+    let admin = Address::generate(&env);
+
+    factory.init(&admin, &stream_contract, &10_000, &100);
+}
+
+/// `try_init` confirms the panic is specifically an auth failure (not, say,
+/// a coincidental `InvalidStreamContract`) by using a valid stream contract
+/// and asserting the call never returns — it must trap before any storage
+/// write or typed-error return path is reached.
+#[test]
+fn test_init_fails_when_only_unrelated_address_authorizes() {
+    let env = Env::default();
+    let factory_id = env.register_contract(None, FluxoraFactory);
+    let factory = FluxoraFactoryClient::new(&env, &factory_id);
+    let stream_contract = deploy_stream(&env);
+    let admin = Address::generate(&env);
+    let unrelated = Address::generate(&env);
+
+    // Mock auth for a *different* address than the declared admin.
+    env.mock_auths(&[MockAuth {
+        address: &unrelated,
+        invoke: &MockAuthInvoke {
+            contract: &factory_id,
+            fn_name: "init",
+            args: (&admin, &stream_contract, 10_000i128, 100u64).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        factory.init(&admin, &stream_contract, &10_000, &100);
+    }));
+    assert!(
+        result.is_err(),
+        "init must reject a call not authorized by the declared admin"
+    );
+}
+
+/// With the declared admin's auth correctly mocked, `init` succeeds.
+#[test]
+fn test_init_succeeds_with_admin_auth_and_valid_stream_contract() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let factory = deploy_factory(&env);
+    let stream_contract = deploy_stream(&env);
+    let admin = Address::generate(&env);
+
+    let result = factory.try_init(&admin, &stream_contract, &10_000, &100);
+    assert_eq!(result, Ok(Ok(())));
+
+    let config = factory.get_factory_config();
+    assert_eq!(config.admin, admin);
+    assert_eq!(config.stream_contract, stream_contract);
+}
+
+// ---------------------------------------------------------------------------
+// init / set_stream_contract validate the stream contract address
+// ---------------------------------------------------------------------------
+
+/// `init` rejects an EOA-style address (no deployed contract at all) as
+/// `stream_contract` with a typed error instead of host-trapping.
+#[test]
+fn test_init_rejects_eoa_stream_contract() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let factory = deploy_factory(&env);
+    let admin = Address::generate(&env);
+    let eoa = Address::generate(&env); // never registered as a contract
+
+    let result = factory.try_init(&admin, &eoa, &10_000, &100);
+    assert_eq!(result, Err(Ok(FactoryError::InvalidStreamContract)));
+}
+
+/// `init` rejects a deployed contract that does not implement the
+/// `FluxoraStream` interface (here, the factory contract itself).
+#[test]
+fn test_init_rejects_non_fluxora_stream_contract() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let factory = deploy_factory(&env);
+    let admin = Address::generate(&env);
+    // A real deployed contract, but not a FluxoraStream — it has no version().
+    let wrong_contract = env.register_contract(None, FluxoraFactory);
+
+    let result = factory.try_init(&admin, &wrong_contract, &10_000, &100);
+    assert_eq!(result, Err(Ok(FactoryError::InvalidStreamContract)));
+}
+
+/// A failed `init` due to an invalid stream contract must not leave the
+/// factory partially initialized: a subsequent `init` with a valid stream
+/// contract must still succeed.
+#[test]
+fn test_init_invalid_stream_contract_is_side_effect_free() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let factory = deploy_factory(&env);
+    let admin = Address::generate(&env);
+    let eoa = Address::generate(&env);
+
+    let first = factory.try_init(&admin, &eoa, &10_000, &100);
+    assert_eq!(first, Err(Ok(FactoryError::InvalidStreamContract)));
+
+    let valid_stream = deploy_stream(&env);
+    let second = factory.try_init(&admin, &valid_stream, &10_000, &100);
+    assert_eq!(second, Ok(Ok(())));
+}
+
+/// `set_stream_contract` rejects an EOA-style address, leaving the
+/// previously configured stream contract untouched.
+#[test]
+fn test_set_stream_contract_rejects_eoa_address() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let factory = deploy_factory(&env);
+    let admin = Address::generate(&env);
+    let original_stream = deploy_stream(&env);
+    factory.init(&admin, &original_stream, &10_000, &100);
+
+    let eoa = Address::generate(&env);
+    let result = factory.try_set_stream_contract(&eoa);
+    assert_eq!(result, Err(Ok(FactoryError::InvalidStreamContract)));
+
+    // The previously configured stream contract must remain in place.
+    let config = factory.get_factory_config();
+    assert_eq!(config.stream_contract, original_stream);
+}
+
+/// `set_stream_contract` rejects a deployed-but-wrong-interface contract.
+#[test]
+fn test_set_stream_contract_rejects_non_fluxora_stream_contract() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let factory = deploy_factory(&env);
+    let admin = Address::generate(&env);
+    let original_stream = deploy_stream(&env);
+    factory.init(&admin, &original_stream, &10_000, &100);
+
+    let wrong_contract = env.register_contract(None, FluxoraFactory);
+    let result = factory.try_set_stream_contract(&wrong_contract);
+    assert_eq!(result, Err(Ok(FactoryError::InvalidStreamContract)));
+
+    let config = factory.get_factory_config();
+    assert_eq!(config.stream_contract, original_stream);
+}
+
+/// `set_stream_contract` succeeds when swapping to another valid
+/// `FluxoraStream` deployment.
+#[test]
+fn test_set_stream_contract_accepts_valid_stream_contract() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let factory = deploy_factory(&env);
+    let admin = Address::generate(&env);
+    let original_stream = deploy_stream(&env);
+    factory.init(&admin, &original_stream, &10_000, &100);
+
+    let new_stream = deploy_stream(&env);
+    let result = factory.try_set_stream_contract(&new_stream);
+    assert_eq!(result, Ok(Ok(())));
+
+    let config = factory.get_factory_config();
+    assert_eq!(config.stream_contract, new_stream);
+}
+
+/// `set_stream_contract` still requires the *declared admin's* auth even
+/// when the new address is a valid `FluxoraStream` deployment: an
+/// unrelated caller's authorization does not satisfy `require_admin`.
+#[test]
+fn test_set_stream_contract_requires_admin_auth() {
+    let env = Env::default();
+    let factory_id = env.register_contract(None, FluxoraFactory);
+    let factory = FluxoraFactoryClient::new(&env, &factory_id);
+    let admin = Address::generate(&env);
+    let non_admin = Address::generate(&env);
+    let original_stream = deploy_stream(&env);
+
+    env.mock_auths(&[MockAuth {
+        address: &admin,
+        invoke: &MockAuthInvoke {
+            contract: &factory_id,
+            fn_name: "init",
+            args: (&admin, &original_stream, 10_000i128, 100u64).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+    factory.init(&admin, &original_stream, &10_000, &100);
+
+    let new_stream = deploy_stream(&env);
+    env.mock_auths(&[MockAuth {
+        address: &non_admin,
+        invoke: &MockAuthInvoke {
+            contract: &factory_id,
+            fn_name: "set_stream_contract",
+            args: (&new_stream,).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        factory.set_stream_contract(&new_stream);
+    }));
+    assert!(
+        result.is_err(),
+        "set_stream_contract must reject auth from a non-admin address"
+    );
+
+    // Original stream contract must remain unchanged.
+    let config = factory.get_factory_config();
+    assert_eq!(config.stream_contract, original_stream);
+}
+
+// ---------------------------------------------------------------------------
+// version() smoke-check sanity: confirm it exercises a real FluxoraStream
+// entrypoint and is unaffected by the stream contract's own init state.
+// ---------------------------------------------------------------------------
+
+/// The smoke check (`version()`) succeeds against a `FluxoraStream` contract
+/// that has not yet had its own `init` called, matching the documented
+/// "works even on an uninitialised contract" behavior of `version()`.
+#[test]
+fn test_uninitialized_stream_contract_passes_smoke_check() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let factory = deploy_factory(&env);
+    let admin = Address::generate(&env);
+    let stream_contract = deploy_stream(&env); // never call stream.init(...)
+
+    let stream_client = FluxoraStreamClient::new(&env, &stream_contract);
+    // Sanity: the stream contract is reachable and responds to version().
+    let _ = stream_client.version();
+
+    let result = factory.try_init(&admin, &stream_contract, &10_000, &100);
+    assert_eq!(result, Ok(Ok(())));
+}
+
+// ---------------------------------------------------------------------------
+// Discriminant stability
+// ---------------------------------------------------------------------------
+
+/// `InvalidStreamContract` must be discriminant 9, and all previously
+/// documented discriminants must remain unchanged.
+#[test]
+fn test_factory_error_discriminants_are_stable() {
+    assert_eq!(FactoryError::AlreadyInitialized as u32, 1);
+    assert_eq!(FactoryError::NotInitialized as u32, 2);
+    assert_eq!(FactoryError::Unauthorized as u32, 3);
+    assert_eq!(FactoryError::RecipientNotAllowlisted as u32, 4);
+    assert_eq!(FactoryError::DepositExceedsCap as u32, 5);
+    assert_eq!(FactoryError::DurationTooShort as u32, 6);
+    assert_eq!(FactoryError::InvalidTimeRange as u32, 7);
+    assert_eq!(FactoryError::InvalidCliff as u32, 8);
+    assert_eq!(FactoryError::InvalidStreamContract as u32, 9);
+}

--- a/contracts/stream/tests/factory_policy.rs
+++ b/contracts/stream/tests/factory_policy.rs
@@ -92,12 +92,12 @@ fn test_set_admin_requires_existing_admin() {
     // Do NOT mock all auths — we want auth to fail
     let factory_id = env.register_contract(None, FluxoraFactory);
     let factory = FluxoraFactoryClient::new(&env, &factory_id);
+    let stream_id = env.register_contract(None, FluxoraStream);
     let admin = Address::generate(&env);
-    let stream_contract = Address::generate(&env);
     let new_admin = Address::generate(&env);
 
     env.mock_all_auths_allowing_non_root_auth();
-    factory.init(&admin, &stream_contract, &10_000, &100);
+    factory.init(&admin, &stream_id, &10_000, &100);
 
     // set_admin without admin auth should panic (require_auth fails)
     let _result = std::panic::catch_unwind(AssertUnwindSafe(|| {
@@ -109,10 +109,10 @@ fn test_set_admin_requires_existing_admin() {
     env2.mock_all_auths();
     let fid2 = env2.register_contract(None, FluxoraFactory);
     let f2 = FluxoraFactoryClient::new(&env2, &fid2);
+    let sid2 = env2.register_contract(None, FluxoraStream);
     let a2 = Address::generate(&env2);
-    let sc2 = Address::generate(&env2);
     let na2 = Address::generate(&env2);
-    f2.init(&a2, &sc2, &10_000, &100);
+    f2.init(&a2, &sid2, &10_000, &100);
     f2.set_admin(&na2); // succeeds with mock_all_auths
 }
 
@@ -129,13 +129,22 @@ fn test_factory_setters_reject_non_admin_callers() {
     let env = Env::default();
     let factory_id = env.register_contract(None, FluxoraFactory);
     let factory = FluxoraFactoryClient::new(&env, &factory_id);
+    let stream_contract = env.register_contract(None, FluxoraStream);
     let admin = Address::generate(&env);
     let non_admin = Address::generate(&env);
-    let stream_contract = Address::generate(&env);
     let new_admin = Address::generate(&env);
-    let new_stream_contract = Address::generate(&env);
+    let new_stream_contract = env.register_contract(None, FluxoraStream);
     let recipient = Address::generate(&env);
 
+    env.mock_auths(&[MockAuth {
+        address: &admin,
+        invoke: &MockAuthInvoke {
+            contract: &factory_id,
+            fn_name: "init",
+            args: (&admin, &stream_contract, 10_000i128, 100u64).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
     factory.init(&admin, &stream_contract, &10_000, &100);
 
     env.mock_auths(&[MockAuth {
@@ -468,7 +477,7 @@ fn test_get_factory_config_returns_current_policy() {
     assert_eq!(config.min_duration, 100);
 
     let new_admin = Address::generate(&ctx.env);
-    let new_stream_contract = Address::generate(&ctx.env);
+    let new_stream_contract = ctx.env.register_contract(None, FluxoraStream);
     ctx.factory.set_admin(&new_admin);
     ctx.factory.set_stream_contract(&new_stream_contract);
     ctx.factory.set_cap(&5_000);

--- a/docs/factory.md
+++ b/docs/factory.md
@@ -12,6 +12,64 @@ The `fluxora_factory` acts as a proxy entrypoint to enforce these policies:
 - **Minimum Duration**: Enforces a `MinDuration` (i.e. `end_time - start_time >= min_duration`), preventing overly short or instantaneous streams.
 - **Time Relationship Checks**: Rejects invalid schedules before calling `FluxoraStream`. `start_time` must be strictly less than `end_time`, and `cliff_time` must be within the inclusive `[start_time, end_time]` window.
 
+## Initialization & Stream Contract Validation
+
+### Authorization contract
+
+`init` requires the declared `admin` to authorize the call via
+`admin.require_auth()`, exactly like every other admin-only entrypoint
+(`set_admin`, `set_stream_contract`, `set_allowlist`, `set_cap`,
+`set_min_duration`, all of which route through the shared `require_admin`
+helper). Without this, any unrelated caller could front-run bootstrap by
+calling `init` first and seeding the factory with an admin address they
+control, before the intended admin's transaction lands.
+
+`init` checks `AlreadyInitialized` before requiring auth, so a doomed
+re-initialization call does not need to pay for, or supply, an authorization
+entry — `admin.require_auth()` is only evaluated once it is known the call
+could otherwise succeed.
+
+### Stream contract validation
+
+Both `init` and `set_stream_contract` validate the supplied `stream_contract`
+address before persisting it. The factory invokes the read-only
+`FluxoraStream::version()` entrypoint via `FluxoraStreamClient::try_version`.
+Because `try_version` uses `Env::try_invoke_contract` internally, a missing
+contract, an EOA (non-contract) address, or a deployed contract that does not
+expose `version()` is caught as a typed error and returned as
+`FactoryError::InvalidStreamContract`, instead of letting the bad address be
+stored and only discovered later when `create_stream` host-traps on the
+cross-contract call into `FluxoraStream::create_stream`.
+
+`version()` is intentionally cheap and storage-free, and is documented to
+work even before the target `FluxoraStream` contract's own `init` has been
+called — so the smoke check never depends on the stream contract's
+initialization state.
+
+A failed validation leaves existing state untouched:
+- In `init`, no instance storage keys are written if `stream_contract` fails
+  validation; a subsequent `init` call with a valid address can still
+  succeed.
+- In `set_stream_contract`, the previously configured `stream_contract` is
+  left in place if the new address fails validation.
+
+### Factory error reference
+
+| Discriminant | Variant | Meaning |
+|---|---|---|
+| 1 | `AlreadyInitialized` | `init` called after a successful `init`. |
+| 2 | `NotInitialized` | Any entrypoint called before `init` has succeeded. |
+| 3 | `Unauthorized` | Reserved for caller-authorization failures outside the `require_auth` panic path. |
+| 4 | `RecipientNotAllowlisted` | `create_stream` recipient is not on the allowlist. |
+| 5 | `DepositExceedsCap` | `create_stream` deposit exceeds `MaxDepositCap`. |
+| 6 | `DurationTooShort` | `create_stream` duration is below `MinDuration`. |
+| 7 | `InvalidTimeRange` | `start_time >= end_time`. |
+| 8 | `InvalidCliff` | `cliff_time` outside the inclusive `[start_time, end_time]` window. |
+| 9 | `InvalidStreamContract` | `stream_contract` failed the `FluxoraStream::version()` smoke check in `init` or `set_stream_contract`. |
+
+Discriminants 1-8 are unchanged by this validation work; `InvalidStreamContract`
+is additive at discriminant 9.
+
 ## Time Validation
 
 The factory mirrors the underlying stream contract's creation-time schedule invariants and returns typed factory errors before making the cross-contract call:
@@ -134,7 +192,7 @@ The factory has an `Admin` key managed via `set_admin`. The admin can:
 - Call `set_allowlist` to grant or revoke recipient eligibility.
 - Call `set_cap` to update the max deposit limit.
 - Call `set_min_duration` to update the minimum duration requirement.
-- Call `set_stream_contract` to upgrade or switch the underlying stream primitive if a new version is deployed.
+- Call `set_stream_contract` to upgrade or switch the underlying stream primitive if a new version is deployed. The new address must pass the same `FluxoraStream::version()` smoke check enforced in `init` (see [Initialization & Stream Contract Validation](#initialization--stream-contract-validation)); a bad address is rejected with `FactoryError::InvalidStreamContract` and the previous stream contract remains active.
 
 The factory admin can shape policy and the target stream contract, but cannot
 spend sender funds by itself. A factory-routed stream still needs the `sender`
@@ -154,3 +212,7 @@ This document is aligned with the current implementation as follows:
   parameters and pulling `deposit_amount` from `sender`.
 - `contracts/stream/tests/factory_policy.rs` covers the factory policy gates and
   admin-guarded policy updates that surround this authorization model.
+- `FluxoraFactory::init` calls `admin.require_auth()` and validates
+  `stream_contract` via `FluxoraStream::version()` before persisting any
+  state; `set_stream_contract` applies the same validation. See
+  `contracts/factory/tests/factory_init_security.rs`.


### PR DESCRIPTION
Closes #686 
init previously stored admin/stream_contract/policy fields without calling admin.require_auth(), letting an unrelated caller front-run bootstrap, and without checking that stream_contract was a deployed FluxoraStream contract, so a bad address only surfaced later as an opaque host trap inside create_stream.

Add admin.require_auth() to init (after the AlreadyInitialized check) and a validate_stream_contract() smoke check, via
FluxoraStreamClient::try_version(), applied to both init and set_stream_contract. Add FactoryError::InvalidStreamContract (9), additive over the existing 1-8 discriminants. Update factory_policy.rs tests that used fake stream_contract addresses to deploy real FluxoraStream contracts, add factory_init_security.rs covering the new auth/validation paths, and document the contract in docs/factory.md.

# Pull Request

## Description

<!-- Provide a clear and concise description of your changes -->

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test coverage improvement
- [ ] Refactoring (no functional changes)

## Related Issues

<!-- Link to related issues using #issue_number -->

Closes #

## Changes Made

<!-- List the specific changes made in this PR -->

-
-
-

## Snapshot Test Changes

<!-- REQUIRED if snapshot files were modified -->

### Did this PR modify snapshot test files?

- [ ] Yes - snapshot files were updated (explain below)
- [ ] No - no snapshot changes

### If yes, explain why snapshots changed:

<!-- Provide detailed explanation of what behavior changed and why -->

**Behavior Changes:**

-

**Affected Snapshots:**

- `test_snapshots/test/test_*.json`

**Verification:**

- [ ] Reviewed every changed `.json` file
- [ ] Verified storage changes match intended behavior
- [ ] Verified event payloads are correct
- [ ] Verified authorization requirements are correct
- [ ] Updated relevant documentation

**Snapshot Update Command Used:**

```bash
SOROBAN_SNAPSHOT_UPDATE=1 cargo test -p fluxora_stream
```

## Testing

### Test Coverage

- [ ] All tests pass locally: `cargo test -p fluxora_stream`
- [ ] New tests added for new functionality
- [ ] Existing tests updated for changed functionality
- [ ] Test coverage remains above 95%

### Manual Testing

<!-- Describe any manual testing performed -->

- [ ] Tested on local environment
- [ ] Tested edge cases
- [ ] Tested error conditions

## Documentation

- [ ] Code comments added/updated
- [ ] Documentation updated (if behavior changed)
- [ ] README updated (if needed)
- [ ] Snapshot test documentation reviewed

## Security Considerations

<!-- Address any security implications of your changes -->

- [ ] No new security concerns introduced
- [ ] Authorization boundaries verified
- [ ] Input validation added/verified
- [ ] Error handling reviewed

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

<!-- Any additional information that reviewers should know -->

## Reviewer Checklist

<!-- For reviewers to complete -->

- [ ] Code quality and style
- [ ] Test coverage adequate
- [ ] Documentation complete
- [ ] Snapshot changes justified and correct
- [ ] Security implications reviewed
- [ ] Breaking changes documented
