### PR TITLE
feat(governance): add get_admin and get_threshold views

### DIFF
--- a/contracts/governance/src/lib.rs
+++ b/contracts/governance/src/lib.rs
@@ -832,7 +832,26 @@ impl FluxoraGovernance {
         get_signers(&env)
     }
 
+    /// Return the admin address.
+    ///
+    /// Returns `GovernanceError::NotInitialized` if `init` has not been called.
+    pub fn get_admin(env: Env) -> Result<Address, GovernanceError> {
+        get_admin(&env)
+    }
+
+    /// Return the configured approval threshold.
+    ///
+    /// Returns `GovernanceError::NotInitialized` if `init` has not been called.
+    /// For a non-erroring convenience wrapper that returns `0` when
+    /// uninitialized, see [`quorum`](Self::quorum).
+    pub fn get_threshold(env: Env) -> Result<u32, GovernanceError> {
+        get_threshold(&env)
+    }
+
     /// Return the effective approval threshold.
+    ///
+    /// Convenience alias for [`get_threshold`](Self::get_threshold) that
+    /// returns `0` instead of an error when the contract is not initialized.
     pub fn quorum(env: Env) -> u32 {
         get_threshold(&env).unwrap_or(0)
     }
@@ -1043,6 +1062,42 @@ mod tests {
     fn test_max_proposal_age_constant() {
         let ctx = Ctx::setup();
         assert_eq!(ctx.client.max_proposal_age_seconds(), MAX_AGE);
+    }
+
+    // -----------------------------------------------------------------------
+    // get_admin / get_threshold views
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_get_admin_after_init() {
+        let ctx = Ctx::setup();
+        let admin = ctx.client.get_admin();
+        assert_eq!(admin, ctx.admin);
+    }
+
+    #[test]
+    fn test_get_admin_pre_init() {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, FluxoraGovernance);
+        let client = FluxoraGovernanceClient::new(&env, &contract_id);
+        let result = client.try_get_admin();
+        assert_eq!(result, Err(Ok(GovernanceError::NotInitialized)));
+    }
+
+    #[test]
+    fn test_get_threshold_after_init() {
+        let ctx = Ctx::setup();
+        let threshold = ctx.client.get_threshold();
+        assert_eq!(threshold, 2);
+    }
+
+    #[test]
+    fn test_get_threshold_pre_init() {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, FluxoraGovernance);
+        let client = FluxoraGovernanceClient::new(&env, &contract_id);
+        let result = client.try_get_threshold();
+        assert_eq!(result, Err(Ok(GovernanceError::NotInitialized)));
     }
 
     // -----------------------------------------------------------------------

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -174,7 +174,14 @@ Cancels a proposal, marking it as terminal. Emits `ProposalCancelled`.
 - `get_proposal(proposal_id) -> Proposal`: reads the stored proposal.
 - `proposal_count() -> u32`: returns the number of proposals created so far.
 - `get_signers() -> Vec<Address>`: returns the registered co-signers.
-- `quorum() -> u32`: returns the configured approval threshold.
+- `get_admin() -> Result<Address, GovernanceError>`: returns the admin address.
+  Returns `NotInitialized` if `init` has not been called.
+- `get_threshold() -> Result<u32, GovernanceError>`: returns the configured
+  approval threshold.  Returns `NotInitialized` if `init` has not been called.
+  For a non-erroring convenience wrapper (returns `0` when uninitialized), use
+  `quorum()`.
+- `quorum() -> u32`: returns the configured approval threshold (returns `0` if
+  uninitialized).  Convenience alias for `get_threshold()`.
 - `timelock_seconds() -> u64`: returns `GOVERNANCE_TIMELOCK_SECONDS`.
 - `max_proposal_age_seconds() -> u64`: returns `MAX_PROPOSAL_AGE_SECONDS`.
 - `get_quorum_info(proposal_id) -> Option<QuorumInfo>`: returns the stored


### PR DESCRIPTION
## Summary

This PR adds explicit read-only governance views for retrieving the current admin and approval threshold.

Previously, the governance contract only exposed `quorum()`, which returned `0` when the contract was uninitialized, and there was no direct way to retrieve the current admin without replaying `AdminChanged` events. This change introduces dedicated query entrypoints while reusing the existing storage helpers and preserving all existing behavior.

## Changes

* [x] Added `get_admin(env: Env) -> Result<Address, GovernanceError>` read-only view
* [x] Added `get_threshold(env: Env) -> Result<u32, GovernanceError>` read-only view
* [x] Reused the existing internal storage helpers (`get_admin` and `get_threshold`) with no duplicated logic
* [x] Added documentation comments for the new public views
* [x] Updated `quorum()` documentation to clarify that it is a convenience alias returning `0` when uninitialized
* [x] Updated `docs/governance.md` to document the new query entrypoints
* [x] Added unit tests covering initialized and pre-initialized behavior

## Tests

Added the following unit tests:

* [x] `test_get_admin_after_init`
* [x] `test_get_admin_pre_init`
* [x] `test_get_threshold_after_init`
* [x] `test_get_threshold_pre_init`

## Validation

* [x] `cargo test -p fluxora_governance`
* [x] **54/54 tests passing**
* [x] No regressions in existing functionality
* [x] No authorization or state mutation side effects
* [x] Existing `quorum()` behavior preserved for backward compatibility

#Closes #730
