### PR TITLE
Test/delegation validate params

### DIFF
--- a/contracts/stream/src/delegation.rs
+++ b/contracts/stream/src/delegation.rs
@@ -160,4 +160,155 @@ mod tests {
         let result = validate_delegation_params(&env, 999, 0, 100);
         assert_eq!(result, Err(ContractError::StreamNotFound));
     }
+
+    // ── Deadline boundary ───────────────────────────────────────────────
+
+    /// deadline=0 when timestamp > 0 must fail.
+    #[test]
+    fn test_deadline_zero_fails() {
+        let (env, _client, stream_id, _recipient) = setup();
+        env.ledger().set_timestamp(1);
+
+        let result = validate_delegation_params(&env, stream_id, 0, 0);
+        assert_eq!(result, Err(ContractError::SignatureDeadlineExpired));
+    }
+
+    /// deadline=u64::MAX must pass (well into the future).
+    #[test]
+    fn test_deadline_max_value_passes() {
+        let (env, _client, stream_id, _recipient) = setup();
+        env.ledger().set_timestamp(100);
+
+        let result = validate_delegation_params(&env, stream_id, 0, u64::MAX);
+        assert_eq!(result, Ok(()));
+    }
+
+    // ── Validation ordering ─────────────────────────────────────────────
+
+    /// When both deadline and nonce are wrong, SignatureDeadlineExpired wins
+    /// because deadline is checked before nonce.
+    #[test]
+    fn test_deadline_checked_before_nonce() {
+        let (env, _client, stream_id, _recipient) = setup();
+        env.ledger().set_timestamp(200);
+
+        // deadline=100 is expired, nonce=999 is wrong — deadline error first
+        let result = validate_delegation_params(&env, stream_id, 999, 100);
+        assert_eq!(result, Err(ContractError::SignatureDeadlineExpired));
+    }
+
+    /// When stream doesn't exist AND nonce is wrong, StreamNotFound wins
+    /// because stream lookup happens before nonce check.
+    #[test]
+    fn test_stream_not_found_checked_before_nonce() {
+        let (env, _client, _stream_id, _recipient) = setup();
+        env.ledger().set_timestamp(50);
+
+        // stream_id=999 doesn't exist, nonce=999 is wrong — StreamNotFound first
+        let result = validate_delegation_params(&env, 999, 999, 100);
+        assert_eq!(result, Err(ContractError::StreamNotFound));
+    }
+
+    // ── Nonce boundary ──────────────────────────────────────────────────
+
+    /// nonce=u64::MAX when stored nonce is 0 must fail.
+    #[test]
+    fn test_nonce_max_value_fails() {
+        let (env, _client, stream_id, _recipient) = setup();
+        env.ledger().set_timestamp(50);
+
+        let result = validate_delegation_params(&env, stream_id, u64::MAX, 100);
+        assert_eq!(result, Err(ContractError::InvalidParams));
+    }
+
+    // ── Nonce invariants ────────────────────────────────────────────────
+
+    /// Nonce is scoped per-recipient: creating a second stream with a
+    /// different recipient must not affect the first recipient's nonce.
+    #[test]
+    fn test_nonce_is_per_recipient() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register_contract(None, FluxoraStream);
+        let token_admin = Address::generate(&env);
+        let token_id = env
+            .register_stellar_asset_contract_v2(token_admin.clone())
+            .address();
+        let admin = Address::generate(&env);
+        let sender = Address::generate(&env);
+        let recipient_a = Address::generate(&env);
+        let recipient_b = Address::generate(&env);
+
+        let client = FluxoraStreamClient::new(&env, &contract_id);
+        client.init(&token_id, &admin);
+
+        let sac = soroban_sdk::token::StellarAssetClient::new(&env, &token_id);
+        sac.mint(&sender, &10_000_i128);
+        TokenClient::new(&env, &token_id).approve(&sender, &contract_id, &i128::MAX, &100_000);
+
+        env.ledger().set_timestamp(0);
+        let stream_a = client.create_stream(
+            &sender,
+            &recipient_a,
+            &1000_i128,
+            &1_i128,
+            &0u64,
+            &0u64,
+            &1000u64,
+            &0,
+            &None,
+            &StreamKind::Linear,
+        );
+        let _stream_b = client.create_stream(
+            &sender,
+            &recipient_b,
+            &1000_i128,
+            &1_i128,
+            &0u64,
+            &0u64,
+            &1000u64,
+            &0,
+            &None,
+            &StreamKind::Linear,
+        );
+
+        env.ledger().set_timestamp(50);
+
+        // Both recipients have default nonce=0; nonce 0 must pass for both
+        assert_eq!(
+            validate_delegation_params(&env, stream_a, 0, 100),
+            Ok(())
+        );
+        assert_eq!(
+            validate_delegation_params(&env, _stream_b, 0, 100),
+            Ok(())
+        );
+
+        // Nonce 1 must fail for both (stored is 0)
+        assert_eq!(
+            validate_delegation_params(&env, stream_a, 1, 100),
+            Err(ContractError::InvalidParams)
+        );
+        assert_eq!(
+            validate_delegation_params(&env, _stream_b, 1, 100),
+            Err(ContractError::InvalidParams)
+        );
+    }
+
+    /// A failed validate_delegation_params call must not consume the nonce;
+    /// a subsequent call with the correct nonce must still succeed.
+    #[test]
+    fn test_failed_validation_does_not_consume_nonce() {
+        let (env, _client, stream_id, _recipient) = setup();
+        env.ledger().set_timestamp(50);
+
+        // First call: wrong nonce → fails
+        let result_fail = validate_delegation_params(&env, stream_id, 1, 100);
+        assert_eq!(result_fail, Err(ContractError::InvalidParams));
+
+        // Second call: correct nonce → must still succeed
+        let result_ok = validate_delegation_params(&env, stream_id, 0, 100);
+        assert_eq!(result_ok, Ok(()));
+    }
 }


### PR DESCRIPTION
## Summary

Closes #738.

This PR has been rebased onto the current `main` branch and now contains **only complementary edge-case test coverage** for `validate_delegation_params`.

All changes that were already merged through **#770** and **#772** have been removed from this branch.

### Additional Test Coverage

This PR adds coverage for validation scenarios that are not exercised by #772:

* Validation ordering

  * Deadline validation takes precedence over nonce validation
  * Missing stream is reported before nonce validation
* Deadline boundary values

  * `deadline = 0`
  * `deadline = u64::MAX`
* Nonce boundary value

  * `nonce = u64::MAX`
* Validation invariants

  * Nonce is scoped per recipient
  * Failed validation does not consume the delegated nonce

### Notes

* Production logic is unchanged.
* No contract behavior is modified.
* This PR only extends unit test coverage for delegation validation.

### Validation

* ✅ `cargo check -p fluxora_stream --lib`

