### PR TITLE
feat: reject empty calldata during proposal creation

### DIFF
--- a/contracts/governance/src/lib.rs
+++ b/contracts/governance/src/lib.rs
@@ -42,6 +42,7 @@ pub struct Proposal {
     /// Target contract whose parameters should be changed upon execution.
     pub target: Address,
     /// Opaque calldata encoding the intended function call and arguments.
+    /// Must be non-empty (at least 1 byte) and must not exceed `MAX_CALLDATA_BYTES`.
     pub calldata: Bytes,
     /// List of co-signer addresses that have approved this proposal.
     pub approvals: Vec<Address>,
@@ -95,6 +96,8 @@ pub enum GovernanceError {
     DuplicateSigner = 17,
     /// Governance arithmetic would overflow instead of producing a valid deadline or ID.
     ArithmeticOverflow = 18,
+    /// Proposal calldata is empty; at least one byte is required.
+    CalldataEmpty = 19,
 }
 
 /// Storage keys for the governance contract.
@@ -530,6 +533,7 @@ impl FluxoraGovernance {
     ///
     /// # Errors
     /// - `NotASigner`: `proposer` is not in the registered signers list.
+    /// - `CalldataEmpty`: `calldata` is empty (zero bytes).
     /// - `CalldataTooLarge`: `calldata.len() > MAX_CALLDATA_BYTES`.
     /// - `ArithmeticOverflow`: proposal ID counter has reached `u32::MAX`.
     pub fn propose(
@@ -543,6 +547,10 @@ impl FluxoraGovernance {
         // O(1) signer membership check via Map index.
         if !Self::is_signer(&env, &proposer)? {
             return Err(GovernanceError::NotASigner);
+        }
+
+        if calldata.len() == 0 {
+            return Err(GovernanceError::CalldataEmpty);
         }
 
         if calldata.len() > MAX_CALLDATA_BYTES {
@@ -1728,6 +1736,58 @@ mod tests {
         // One second past expiry — not executable.
         ctx.env.ledger().set_timestamp(1_000_000 + MAX_AGE + 1);
         assert_eq!(ctx.client.is_executable(&id), false);
+    }
+
+    // -----------------------------------------------------------------------
+    // Calldata validation (#733)
+    // -----------------------------------------------------------------------
+
+    /// Empty calldata is rejected before the proposal ID is consumed.
+    #[test]
+    fn test_propose_rejects_empty_calldata() {
+        let ctx = Ctx::setup();
+        let empty = Bytes::new(&ctx.env);
+        let before = ctx.client.proposal_count();
+        let result = ctx.client.try_propose(&ctx.signer_a, &ctx.dummy_target(), &empty);
+        assert_eq!(result, Err(Ok(GovernanceError::CalldataEmpty)));
+        // Proposal ID counter must not have advanced.
+        assert_eq!(ctx.client.proposal_count(), before);
+    }
+
+    /// One-byte calldata satisfies the minimum and is accepted.
+    #[test]
+    fn test_propose_accepts_one_byte_calldata() {
+        let ctx = Ctx::setup();
+        let one_byte = Bytes::from_slice(&ctx.env, &[0x01]);
+        let result = ctx.client.try_propose(&ctx.signer_a, &ctx.dummy_target(), &one_byte);
+        assert!(result.is_ok());
+    }
+
+    /// MAX_CALLDATA_BYTES-length calldata is still accepted (existing upper bound unchanged).
+    #[test]
+    fn test_propose_accepts_max_calldata() {
+        let ctx = Ctx::setup();
+        // Build exactly MAX_CALLDATA_BYTES bytes via repeated concatenation.
+        let mut calldata = Bytes::new(&ctx.env);
+        let one = Bytes::from_slice(&ctx.env, &[0xABu8]);
+        for _ in 0..MAX_CALLDATA_BYTES {
+            calldata.append(&one);
+        }
+        let result = ctx.client.try_propose(&ctx.signer_a, &ctx.dummy_target(), &calldata);
+        assert!(result.is_ok());
+    }
+
+    /// Calldata one byte over the maximum is still rejected with CalldataTooLarge.
+    #[test]
+    fn test_propose_rejects_oversized_calldata() {
+        let ctx = Ctx::setup();
+        let mut calldata = Bytes::new(&ctx.env);
+        let one = Bytes::from_slice(&ctx.env, &[0xFFu8]);
+        for _ in 0..MAX_CALLDATA_BYTES + 1 {
+            calldata.append(&one);
+        }
+        let result = ctx.client.try_propose(&ctx.signer_a, &ctx.dummy_target(), &calldata);
+        assert_eq!(result, Err(Ok(GovernanceError::CalldataTooLarge)));
     }
 
     #[test]

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -133,9 +133,11 @@ Submits a new governance proposal and returns its monotonically increasing ID.
 
 - `proposer` must authorize the call and be a registered co-signer.
 - `calldata` is stored as opaque bytes for on-chain auditability.
+- `calldata` must be non-empty (at least 1 byte); empty calldata is rejected with `CalldataEmpty`.
 - `calldata.len()` must be less than or equal to `MAX_CALLDATA_BYTES`.
 - The proposer is not automatically counted as an approver.
 - Emits `ProposalCreated` with topic `("proposed", proposal_id)`.
+- Rejected proposals (empty or oversized calldata, non-signer) do not consume a proposal ID.
 
 ### `approve(approver, proposal_id)`
 
@@ -341,6 +343,8 @@ handle these discriminants from `contracts/governance/src/lib.rs`:
 | `InvalidThreshold` | 15 | `init` threshold is zero or exceeds signer count | Choose a threshold in the range `1..=signers.len()`. |
 | `QuorumWouldBreak` | 16 | `remove_signer` would leave fewer signers than threshold | Lower the threshold through a governed migration or keep enough signers registered. |
 | `DuplicateSigner` | 17 | `init` or `add_signer` includes an already-registered signer | Remove duplicate entries before submitting. |
+| `ArithmeticOverflow` | 18 | Timelock or expiry deadline arithmetic would overflow `u64` | This should not occur under normal ledger conditions; treat as a fatal contract error. |
+| `CalldataEmpty` | 19 | `propose` called with zero-length calldata | Provide at least one byte of calldata encoding the intended operation. |
 
 ## Security considerations
 
@@ -363,15 +367,19 @@ handle these discriminants from `contracts/governance/src/lib.rs`:
     admin key, but parameter changes still require quorum and timelock.
 11. **Calldata is an audit payload**: the governance contract does not decode or enforce
     target-specific calldata semantics.
-12. **CEI ordering in `execute`**: the proposal is marked executed and persisted before
+12. **Non-empty calldata required**: `propose` rejects zero-length calldata with
+    `CalldataEmpty` before any state mutation — the proposal ID counter is not incremented
+    and no storage is written. This prevents vacuous proposals from entering governance and
+    ensures every on-chain proposal carries a verifiable intent payload.
+13. **CEI ordering in `execute`**: the proposal is marked executed and persisted before
     `ProposalExecuted` is emitted.
-13. **Threshold invariant prevents governance bricking**: `remove_signer` enforces
+14. **Threshold invariant prevents governance bricking**: `remove_signer` enforces
     `signers.len() - 1 >= threshold`, so the signer set can never shrink below the required
     approval threshold.
-14. **Threshold is snapshotted at quorum time**: execution uses the threshold recorded in
+15. **Threshold is snapshotted at quorum time**: execution uses the threshold recorded in
     `QuorumInfo`, so an admin cannot raise or lower the live threshold after quorum to change
     the outcome of an in-flight proposal.
-15. **Auditable membership and admin changes**: `add_signer`, `remove_signer`, and
+16. **Auditable membership and admin changes**: `add_signer`, `remove_signer`, and
     `set_admin` emit `SignerAdded`, `SignerRemoved`, and `AdminChanged` respectively, all
     after the state mutation is persisted (CEI). No membership or admin change is silent,
     so indexers can reconstruct the live signer set and admin history from events. A


### PR DESCRIPTION
## Summary

Closes #733

Rejects proposals with zero-length calldata in `FluxoraGovernance::propose`, preventing vacuous proposals from entering governance.

## Changes

### `contracts/governance/src/lib.rs`
- Added `CalldataEmpty = 19` to `GovernanceError`
- Added `calldata.len() == 0` check in `propose` before any state mutation
- Updated `Proposal.calldata` doc comment to document min/max constraints
- Updated `propose` error docs to include `CalldataEmpty`
- Added four unit tests: empty / one-byte / max-size / oversized calldata

### `docs/governance.md`
- `propose` entrypoint: documented non-empty requirement and that rejected proposals do not consume IDs
- Error table: added `CalldataEmpty = 19` row
- Security considerations: added item 12 explaining pre-mutation validation order

## Security Note

Both the empty-calldata check (`calldata.len() == 0`) and the existing size check (`calldata.len() > MAX_CALLDATA_BYTES`) execute **before** `increment_proposal_id` and **before** any `save_proposal` call. Rejected proposals leave `NextProposalId` and all persistent storage completely unchanged — no proposal ID is consumed on rejection.

## Tests

| Test | Assertion |
|---|---|
| `test_propose_rejects_empty_calldata` | Empty bytes → `CalldataEmpty`; proposal ID counter unchanged |
| `test_propose_accepts_one_byte_calldata` | `[0x01]` → accepted, proposal created |
| `test_propose_accepts_max_calldata` | `MAX_CALLDATA_BYTES` bytes → accepted |
| `test_propose_rejects_oversized_calldata` | `MAX_CALLDATA_BYTES + 1` bytes → `CalldataTooLarge` (existing behavior unchanged) |