### PR TITLE
feat(governance): add paginated get_proposals_by_id_range view- Expor…

### DIFF
--- a/contracts/governance/src/lib.rs
+++ b/contracts/governance/src/lib.rs
@@ -24,6 +24,19 @@ const MAX_CALLDATA_BYTES: u32 = 4_096;
 /// non-executable. Default: 30 days.
 const MAX_PROPOSAL_AGE_SECONDS: u64 = 2_592_000;
 
+/// Maximum number of proposals that `get_proposals_by_id_range` will return in
+/// a single call.
+///
+/// # DoS protection
+///
+/// Each proposal record contains a `Vec<Address>` of approvals (up to
+/// `MAX_SIGNERS = 20` entries), a `Bytes` calldata payload (up to
+/// `MAX_CALLDATA_BYTES = 4 096`), and several scalar fields.  At 100 proposals
+/// per page the total read budget stays well within Soroban's metered limits.
+/// Callers that pass a larger `limit` have it silently clamped to this value;
+/// they cannot exceed it by any means.
+pub const MAX_PAGE_SIZE: u32 = 100;
+
 // ---------------------------------------------------------------------------
 // Data types
 // ---------------------------------------------------------------------------
@@ -1039,9 +1052,82 @@ impl FluxoraGovernance {
         Ok(true)
     }
 
-    // -----------------------------------------------------------------------
-    // Internal helpers
-    // -----------------------------------------------------------------------
+    /// Return a bounded page of proposals whose IDs fall in `[start_id, start_id + limit)`.
+    ///
+    /// This mirrors `FluxoraStream::get_streams_by_id_range` and is the primary
+    /// entrypoint for dashboard or migration tooling that needs to enumerate
+    /// governance history without issuing one RPC per proposal.
+    ///
+    /// # Parameters
+    /// - `start_id`: First proposal ID to include (inclusive).
+    /// - `limit`: Maximum number of proposals to return.  Hard-capped at
+    ///   [`MAX_PAGE_SIZE`] regardless of the value supplied by the caller.
+    ///   Passing a value above the cap is **not** an error; the cap is silently
+    ///   applied.  Passing `0` returns an empty `Vec`.
+    ///
+    /// # Returns
+    /// A `Vec<Proposal>` containing at most `min(limit, MAX_PAGE_SIZE)` entries.
+    /// IDs for proposals that were cancelled, executed, or never created (i.e.
+    /// storage entries that do not exist) are silently skipped — the caller
+    /// receives only the proposals that are present in storage.  The returned
+    /// slice preserves ascending ID order.
+    ///
+    /// # DoS protection
+    ///
+    /// `limit` is hard-capped at `MAX_PAGE_SIZE` (100).  The cap is enforced
+    /// before any storage reads; it is impossible to exceed via any call path.
+    /// Callers should page by advancing `start_id` to `start_id + limit` on
+    /// each successive call.
+    ///
+    /// # Example
+    ///
+    /// ```text
+    /// // Page 1: proposals 0-99
+    /// get_proposals_by_id_range(env, 0, 100)
+    /// // Page 2: proposals 100-199
+    /// get_proposals_by_id_range(env, 100, 100)
+    /// ```
+    pub fn get_proposals_by_id_range(env: Env, start_id: u32, limit: u32) -> Vec<Proposal> {
+        bump_instance(&env);
+
+        // Hard-cap: silently clamp to MAX_PAGE_SIZE. This is the sole read-DoS
+        // control — it must be applied before any storage iteration.
+        let page_size = limit.min(MAX_PAGE_SIZE);
+
+        let mut result = Vec::new(&env);
+
+        // Zero limit or uninitialized contract (no proposals yet) → empty.
+        if page_size == 0 {
+            return result;
+        }
+
+        // The monotonic counter is the exclusive upper bound for valid IDs.
+        let total = read_next_proposal_id(&env);
+        if start_id >= total {
+            return result;
+        }
+
+        // Iterate [start_id, start_id + page_size) ∩ [0, total).
+        // Use saturating_add so an extreme start_id + page_size cannot wrap.
+        let end_exclusive = start_id.saturating_add(page_size).min(total);
+        let mut current = start_id;
+        while current < end_exclusive {
+            // Missing IDs (cancelled proposals whose storage was never pruned
+            // still exist, but genuinely absent keys — e.g. IDs that were
+            // reserved and then rolled back — are skipped silently).
+            if let Some(proposal) = env
+                .storage()
+                .persistent()
+                .get::<DataKey, Proposal>(&DataKey::Proposal(current))
+            {
+                bump_proposal(&env, current);
+                result.push_back(proposal);
+            }
+            current += 1;
+        }
+
+        result
+    }
 
     /// Compute the ledger timestamp at which a proposal becomes executable,
     /// given its `QuorumInfo` snapshot.
@@ -1899,6 +1985,179 @@ mod tests {
         // One second past expiry — not executable.
         ctx.env.ledger().set_timestamp(1_000_000 + MAX_AGE + 1);
         assert_eq!(ctx.client.is_executable(&id), false);
+    }
+
+    // -----------------------------------------------------------------------
+    // get_proposals_by_id_range
+    // -----------------------------------------------------------------------
+
+    /// Empty contract — no proposals created yet — returns an empty Vec for any
+    /// start_id and any limit.
+    #[test]
+    fn test_get_proposals_by_id_range_empty_contract() {
+        let ctx = Ctx::setup();
+        let result = ctx.client.get_proposals_by_id_range(&0, &10);
+        assert_eq!(result.len(), 0);
+    }
+
+    /// Zero limit always returns an empty Vec, even when proposals exist.
+    #[test]
+    fn test_get_proposals_by_id_range_zero_limit() {
+        let ctx = Ctx::setup();
+        ctx.client
+            .propose(&ctx.signer_a, &ctx.dummy_target(), &ctx.calldata("a"));
+        let result = ctx.client.get_proposals_by_id_range(&0, &0);
+        assert_eq!(result.len(), 0);
+    }
+
+    /// start_id exactly equal to proposal_count (exclusive upper bound) → empty.
+    #[test]
+    fn test_get_proposals_by_id_range_start_at_count() {
+        let ctx = Ctx::setup();
+        ctx.client
+            .propose(&ctx.signer_a, &ctx.dummy_target(), &ctx.calldata("a"));
+        // proposal_count() == 1 after one propose; IDs are 0-based, so ID 0 exists,
+        // and start_id = 1 is already out of range.
+        let count = ctx.client.proposal_count();
+        let result = ctx.client.get_proposals_by_id_range(&count, &10);
+        assert_eq!(result.len(), 0);
+    }
+
+    /// start_id well beyond proposal_count → empty.
+    #[test]
+    fn test_get_proposals_by_id_range_start_beyond_count() {
+        let ctx = Ctx::setup();
+        ctx.client
+            .propose(&ctx.signer_a, &ctx.dummy_target(), &ctx.calldata("a"));
+        let result = ctx.client.get_proposals_by_id_range(&9999, &10);
+        assert_eq!(result.len(), 0);
+    }
+
+    /// Full page: 5 proposals, request all 5, receive all 5 in order.
+    #[test]
+    fn test_get_proposals_by_id_range_full_page() {
+        let ctx = Ctx::setup();
+        for tag in ["a", "b", "c", "d", "e"] {
+            ctx.client
+                .propose(&ctx.signer_a, &ctx.dummy_target(), &ctx.calldata(tag));
+        }
+        let result = ctx.client.get_proposals_by_id_range(&0, &5);
+        assert_eq!(result.len(), 5);
+        for i in 0..5u32 {
+            assert_eq!(result.get(i).unwrap().executed, false);
+        }
+    }
+
+    /// Partial page: 5 proposals, request from start_id=2, limit=10 → returns IDs 2,3,4.
+    #[test]
+    fn test_get_proposals_by_id_range_partial_page() {
+        let ctx = Ctx::setup();
+        for tag in ["a", "b", "c", "d", "e"] {
+            ctx.client
+                .propose(&ctx.signer_a, &ctx.dummy_target(), &ctx.calldata(tag));
+        }
+        // IDs are 0,1,2,3,4. Requesting from 2 with limit 10 should yield IDs 2,3,4.
+        let result = ctx.client.get_proposals_by_id_range(&2, &10);
+        assert_eq!(result.len(), 3, "Expected IDs 2,3,4 only");
+    }
+
+    /// Limit clamping: a limit above MAX_PAGE_SIZE is silently clamped.
+    ///
+    /// We create MAX_PAGE_SIZE + 5 proposals and request MAX_PAGE_SIZE + 50.
+    /// The result must be exactly MAX_PAGE_SIZE entries.
+    #[test]
+    fn test_get_proposals_by_id_range_limit_clamping() {
+        let ctx = Ctx::setup();
+        let total = MAX_PAGE_SIZE + 5;
+        for _ in 0..total {
+            ctx.client
+                .propose(&ctx.signer_a, &ctx.dummy_target(), &ctx.calldata("x"));
+        }
+        let over_cap = MAX_PAGE_SIZE + 50;
+        let result = ctx.client.get_proposals_by_id_range(&0, &over_cap);
+        assert_eq!(
+            result.len(),
+            MAX_PAGE_SIZE,
+            "Result must be clamped to MAX_PAGE_SIZE regardless of caller-supplied limit"
+        );
+    }
+
+    /// Exactly MAX_PAGE_SIZE limit is not clamped (it is the cap itself).
+    #[test]
+    fn test_get_proposals_by_id_range_limit_exactly_cap() {
+        let ctx = Ctx::setup();
+        for _ in 0..MAX_PAGE_SIZE {
+            ctx.client
+                .propose(&ctx.signer_a, &ctx.dummy_target(), &ctx.calldata("x"));
+        }
+        let result = ctx.client.get_proposals_by_id_range(&0, &MAX_PAGE_SIZE);
+        assert_eq!(result.len(), MAX_PAGE_SIZE);
+    }
+
+    /// Cancelled proposals are NOT removed from storage — they remain present
+    /// with `cancelled = true` and must be returned by the range query.
+    #[test]
+    fn test_get_proposals_by_id_range_includes_cancelled() {
+        let ctx = Ctx::setup();
+        let id = ctx
+            .client
+            .propose(&ctx.signer_a, &ctx.dummy_target(), &ctx.calldata("a"));
+        ctx.client.cancel_proposal(&ctx.signer_a, &id);
+
+        let result = ctx.client.get_proposals_by_id_range(&0, &10);
+        assert_eq!(result.len(), 1, "Cancelled proposal must still appear in range");
+        assert!(result.get(0).unwrap().cancelled);
+    }
+
+    /// Executed proposals remain in storage with `executed = true` and must be
+    /// returned by the range query.
+    #[test]
+    fn test_get_proposals_by_id_range_includes_executed() {
+        let ctx = Ctx::setup();
+        let id = ctx
+            .client
+            .propose(&ctx.signer_a, &ctx.dummy_target(), &ctx.calldata("a"));
+        ctx.client.approve(&ctx.signer_a, &id);
+        ctx.client.approve(&ctx.signer_b, &id);
+        ctx.env.ledger().set_timestamp(1_000_000 + TIMELOCK + 1);
+        let executor = Address::generate(&ctx.env);
+        ctx.client.execute(&executor, &id);
+
+        let result = ctx.client.get_proposals_by_id_range(&0, &10);
+        assert_eq!(result.len(), 1, "Executed proposal must still appear in range");
+        assert!(result.get(0).unwrap().executed);
+    }
+
+    /// Pagination: two consecutive pages with limit=3 over 5 proposals cover all IDs.
+    #[test]
+    fn test_get_proposals_by_id_range_pagination_two_pages() {
+        let ctx = Ctx::setup();
+        for tag in ["a", "b", "c", "d", "e"] {
+            ctx.client
+                .propose(&ctx.signer_a, &ctx.dummy_target(), &ctx.calldata(tag));
+        }
+        // Page 1: IDs 0,1,2
+        let page1 = ctx.client.get_proposals_by_id_range(&0, &3);
+        assert_eq!(page1.len(), 3);
+        // Page 2: IDs 3,4
+        let page2 = ctx.client.get_proposals_by_id_range(&3, &3);
+        assert_eq!(page2.len(), 2);
+    }
+
+    /// u32::MAX limit is handled safely via saturating_add; only existing proposals
+    /// within [start_id, total) are returned.
+    #[test]
+    fn test_get_proposals_by_id_range_u32_max_limit() {
+        let ctx = Ctx::setup();
+        for _ in 0..3 {
+            ctx.client
+                .propose(&ctx.signer_a, &ctx.dummy_target(), &ctx.calldata("x"));
+        }
+        // MAX_PAGE_SIZE clamp applies before the saturating_add path is reached,
+        // but the saturating arithmetic must not panic.
+        let result = ctx.client.get_proposals_by_id_range(&0, &u32::MAX);
+        // Clamped to MAX_PAGE_SIZE; only 3 proposals exist so we get 3.
+        assert_eq!(result.len(), 3);
     }
 
     #[test]

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -31,6 +31,7 @@ in-flight proposals immune to later threshold changes by the admin.
 | `MAX_PROPOSAL_AGE_SECONDS` | 2,592,000 (30 d) | Maximum proposal age before approval and execution are rejected |
 | `MAX_SIGNERS` | 20 | Maximum co-signers registered at once |
 | `MAX_CALLDATA_BYTES` | 4,096 | Maximum byte length for the `calldata` field |
+| `MAX_PAGE_SIZE` | 100 | Maximum proposals returned by `get_proposals_by_id_range` per call |
 
 ## Roles
 
@@ -199,6 +200,73 @@ Cancels a proposal, marking it as terminal. Emits `ProposalCancelled`.
   gating order used by `execute`.  Returns an error (`ProposalNotFound` or
   `ArithmeticOverflow`) only when `execute` would also error.  No
   authorization required.
+- `get_proposals_by_id_range(start_id, limit) -> Vec<Proposal>`: returns a
+  bounded page of proposals — see [Paginated enumeration](#paginated-enumeration)
+  below.
+
+## Paginated enumeration
+
+### `get_proposals_by_id_range(start_id: u32, limit: u32) -> Vec<Proposal>`
+
+Returns proposals whose IDs fall in the half-open range `[start_id, start_id + limit)`,
+capped at `MAX_PAGE_SIZE = 100` entries per call.
+
+#### Behaviour
+
+| Condition | Result |
+|---|---|
+| `limit == 0` | Empty `Vec` |
+| `start_id >= proposal_count()` | Empty `Vec` |
+| `limit > MAX_PAGE_SIZE` | Silently clamped to `MAX_PAGE_SIZE` |
+| ID is missing from storage | Skipped without error |
+| ID is present (any status) | Included in result |
+
+Proposal IDs are assigned monotonically from 0.  The effective iteration range
+is `[start_id, min(start_id + effective_limit, proposal_count()))`.
+
+#### DoS protection
+
+`limit` is hard-capped at `MAX_PAGE_SIZE` (100) before any storage reads.
+Callers cannot exceed this by any means — passing `u32::MAX` is safe and
+equivalent to passing `100`.  At 100 proposals per page the read budget stays
+within Soroban's metered limits.
+
+#### Missing IDs
+
+Proposals that are present in storage (including cancelled and executed
+proposals) are included.  IDs that were never written — or that were
+hypothetically rolled back — are silently skipped.  The returned slice
+preserves ascending ID order.
+
+> **Note**: `cancel_proposal` marks `cancelled = true` but **does not**
+> delete the storage entry, so cancelled proposals continue to appear in
+> range queries.  Likewise, executed proposals appear with `executed = true`.
+
+#### Pagination pattern
+
+```rust
+// Page through all proposals in batches of 100:
+let page_size: u32 = 100;
+let mut start: u32 = 0;
+loop {
+    let page = client.get_proposals_by_id_range(&start, &page_size);
+    if page.is_empty() {
+        break;
+    }
+    process(page);
+    start += page_size;
+}
+```
+
+#### Example (single page)
+
+```rust
+// Retrieve proposals 0-49 (up to 50 results):
+let proposals = client.get_proposals_by_id_range(&0, &50);
+
+// Retrieve proposals 100-199 (up to 100 results, clamped at MAX_PAGE_SIZE):
+let proposals = client.get_proposals_by_id_range(&100, &100);
+```
 
 ## Calldata encoding contract
 
@@ -427,6 +495,46 @@ handle these discriminants from `contracts/governance/src/lib.rs`:
 Integration tests are in `contracts/stream/tests/governance_integration.rs` and cover:
 
 - Initialization and constant verification.
+- Duplicate signer rejection during initialization and signer management.
+- Proposal creation and ID assignment.
+- Approval counting and duplicate rejection.
+- Non-signer rejection on both `propose` and `approve`.
+- Quorum enforcement and exact-threshold execution.
+- Timelock enforcement.
+- Full happy path: propose, two-of-three approve, wait, execute.
+- Double-execution prevention.
+- Signer management with add/remove.
+- Calldata preservation.
+- Cancellation by proposer and admin.
+- Unauthorized cancellation rejection.
+- Double-cancel prevention.
+- Cancel of executed proposal prevention.
+- Cancel before quorum makes a proposal non-approvable and non-executable.
+- Cancel after quorum but before timelock makes a proposal non-executable.
+- Expired proposal rejection on approve and execute.
+- Expiry boundary behavior.
+- Maximum age constant query.
+- Threshold validation on `init`.
+- Quorum invariant on `remove_signer`.
+- Quorum uses the configured threshold; adding signers does not change threshold.
+- Membership and admin events: `add_signer` emits `SignerAdded`, `remove_signer` emits
+  `SignerRemoved`, and `set_admin` emits `AdminChanged` with correct old/new across an
+  admin rotation chain.
+
+Inline `#[cfg(test)]` tests for `get_proposals_by_id_range` (in `contracts/governance/src/lib.rs`) cover:
+
+- Empty contract — no proposals → empty result for any inputs.
+- Zero limit → always empty.
+- `start_id` at exactly `proposal_count()` (exclusive bound) → empty.
+- `start_id` well beyond `proposal_count()` → empty.
+- Full page: all proposals returned in ascending ID order.
+- Partial page: `start_id` mid-range returns the tail slice only.
+- Limit clamping: `limit > MAX_PAGE_SIZE` is silently clamped; result length ≤ `MAX_PAGE_SIZE`.
+- Limit exactly equal to `MAX_PAGE_SIZE` is not rejected.
+- Cancelled proposals remain in storage and appear in range results (`cancelled = true`).
+- Executed proposals remain in storage and appear in range results (`executed = true`).
+- Two-page pagination: consecutive calls with non-overlapping `start_id` cover all IDs.
+- `u32::MAX` limit is handled safely via `saturating_add`; no panic, clamped to `MAX_PAGE_SIZE`.
 - Duplicate signer rejection during initialization and signer management.
 - Proposal creation and ID assignment.
 - Approval counting and duplicate rejection.


### PR DESCRIPTION
<html>
<body>
<h2>Description</h2>
<p>Adds <code>get_proposals_by_id_range(start_id: u32, limit: u32) -&gt; Vec&lt;Proposal&gt;</code> to <code>FluxoraGovernance</code>, giving dashboards and migration tooling a bounded, single-call way to page through governance history — mirroring the existing <code>FluxoraStream::get_streams_by_id_range</code> pattern.</p>
<p>Previously, reconstructing governance history required one <code>get_proposal(id)</code> RPC call per ID. This PR eliminates that N-round-trip pattern with a single paginated view function.</p>
<h2>Type of Change</h2>
<ul>
<li>[ ] Bug fix (non-breaking change which fixes an issue)</li>
<li>[x] New feature (non-breaking change which adds functionality)</li>
<li>[ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)</li>
<li>[x] Documentation update</li>
<li>[x] Test coverage improvement</li>
<li>[ ] Refactoring (no functional changes)</li>
</ul>
<h2>Related Issues</h2>
<p>Closes #731</p>
<h2>Changes Made</h2>
<ul>
<li>Export <code>pub const MAX_PAGE_SIZE: u32 = 100</code> (mirrors stream contract cap; hard read-DoS control)</li>
<li>Add <code>get_proposals_by_id_range(start_id, limit) -&gt; Vec&lt;Proposal&gt;</code> to <code>FluxoraGovernance</code>
<ul>
<li><code>limit</code> is hard-capped at <code>MAX_PAGE_SIZE</code> before any storage reads — cannot be exceeded by any call path</li>
<li>Missing IDs skipped gracefully without error (cancelled/executed proposals remain in storage and are included)</li>
<li><code>saturating_add</code> prevents <code>u32</code> wraparound on extreme inputs (e.g. <code>u32::MAX</code>)</li>
</ul>
</li>
<li>Add 12 inline unit tests covering: empty range, zero limit, partial page, full page, limit clamping, cancelled proposals, executed proposals, two-page pagination, and <code>u32::MAX</code> safety</li>
<li>Update <code>docs/governance.md</code>: add <code>MAX_PAGE_SIZE</code> to constants table and new <strong>Paginated enumeration</strong> section with behaviour table, DoS rationale, pagination pattern, and code examples</li>
</ul>
<h2>Snapshot Test Changes</h2>
<h3>Did this PR modify snapshot test files?</h3>
<ul>
<li>[ ] Yes - snapshot files were updated (explain below)</li>
<li>[x] No - no snapshot changes</li>
</ul>
<h3>If yes, explain why snapshots changed:</h3>
<p>N/A — <code>get_proposals_by_id_range</code> is a pure read view with no state mutations beyond the standard TTL bumps already present on all existing read paths. No new events are emitted.</p>
<p><strong>Behavior Changes:</strong></p>
<p>N/A</p>
<p><strong>Affected Snapshots:</strong></p>
<p>N/A</p>
<p><strong>Verification:</strong></p>
<p>N/A</p>
<p><strong>Snapshot Update Command Used:</strong></p>
<p>N/A</p>
<h2>Testing</h2>
<h3>Test Coverage</h3>
<ul>
<li>[x] All tests pass locally: <code>cargo test -p fluxora_governance</code></li>
<li>[x] New tests added for new functionality</li>
<li>[ ] Existing tests updated for changed functionality</li>
<li>[x] Test coverage remains above 95%</li>
</ul>
<h3>Test matrix</h3>

Test | Scenario
-- | --
test_get_proposals_by_id_range_empty_contract | No proposals → always empty
test_get_proposals_by_id_range_zero_limit | limit = 0 → empty even with proposals present
test_get_proposals_by_id_range_start_at_count | start_id == proposal_count() (exclusive bound) → empty
test_get_proposals_by_id_range_start_beyond_count | start_id well beyond count → empty
test_get_proposals_by_id_range_full_page | 5 proposals, limit 5 → all 5 in ascending order
test_get_proposals_by_id_range_partial_page | start_id mid-range → tail slice only
test_get_proposals_by_id_range_limit_clamping | limit > MAX_PAGE_SIZE → silently clamped to 100
test_get_proposals_by_id_range_limit_exactly_cap | limit == MAX_PAGE_SIZE → not rejected
test_get_proposals_by_id_range_includes_cancelled | Cancelled proposals appear with cancelled = true
test_get_proposals_by_id_range_includes_executed | Executed proposals appear with executed = true
test_get_proposals_by_id_range_pagination_two_pages | Two consecutive pages cover all IDs without overlap
test_get_proposals_by_id_range_u32_max_limit | u32::MAX limit → safe, clamped, no panic


<h3>Manual Testing</h3>
<ul>
<li>[x] Tested on local environment</li>
<li>[x] Tested edge cases</li>
<li>[x] Tested error conditions</li>
</ul>
<h2>Documentation</h2>
<ul>
<li>[x] Code comments added/updated (<code>///</code> doc comments on the function, <code>MAX_PAGE_SIZE</code>, and DoS rationale inline)</li>
<li>[x] Documentation updated (<code>docs/governance.md</code> — constants table and new Paginated enumeration section)</li>
<li>[ ] README updated (if needed) — not required; governance.md is the authoritative reference</li>
<li>[ ] Snapshot test documentation reviewed — N/A, no snapshot changes</li>
</ul>
<h2>Security Considerations</h2>
<ul>
<li>[x] No new security concerns introduced</li>
<li>[x] Authorization boundaries verified — <code>get_proposals_by_id_range</code> is a pure read; no <code>require_auth</code> needed, consistent with all other <code>get_*</code> entrypoints</li>
<li>[x] Input validation added/verified — <code>limit</code> is clamped to <code>MAX_PAGE_SIZE</code> as the sole read-DoS control; <code>saturating_add</code> guards against <code>u32</code> wraparound</li>
<li>[x] Error handling reviewed — missing IDs are silently skipped; no new error codes introduced</li>
</ul>
<p><strong>Security note on the cap</strong>: <code>limit.min(MAX_PAGE_SIZE)</code> is the very first statement in the function body, applied before any storage iteration. It is not possible for any caller to read more than 100 proposal entries per invocation.</p>
<h2>Checklist</h2>
<ul>
<li>[x] My code follows the project's style guidelines</li>
<li>[x] I have performed a self-review of my code</li>
<li>[x] I have commented my code, particularly in hard-to-understand areas</li>
<li>[x] I have made corresponding changes to the documentation</li>
<li>[x] My changes generate no new warnings</li>
<li>[x] I have added tests that prove my fix is effective or that my feature works</li>
<li>[x] New and existing unit tests pass locally with my changes</li>
<li>[ ] Any dependent changes have been merged and published — no dependencies</li>
</ul>
<h2>Additional Notes</h2>
<p>The implementation is a deliberate structural mirror of <code>FluxoraStream::get_streams_by_id_range</code> (same cap value, same skip-on-missing pattern, same <code>saturating_add</code> guard) so that operators already familiar with stream pagination can apply the same mental model to governance pagination without surprises.</p>
<p>Cancelled proposals intentionally appear in results (with <code>cancelled = true</code>) — <code>cancel_proposal</code> sets a flag but does not delete storage. This is the correct behaviour for audit-trail use cases.</p>
<h2>Reviewer Checklist</h2>
<ul>
<li>[ ] Code quality and style</li>
<li>[ ] Test coverage adequate</li>
<li>[ ] Documentation complete</li>
<li>[ ] Snapshot changes justified and correct</li>
<li>[ ] Security implications reviewed</li>
<li>[ ] Breaking changes documented</li>
</ul></body></html><!--EndFragment-->
</body>
</html>