### PR TITLE
docs(governance): add stream rate worked example and CallData ABI sta…

### DIFF
--- a/docs/governance.md
+++ b/docs/governance.md
@@ -231,6 +231,30 @@ let calldata = CallData::FactorySetCap(100_000_i128).to_xdr(&env);
 governance_client.propose(&proposer, &factory_address, &calldata);
 ```
 
+### Worked example: routing a stream rate change
+
+`set_max_rate_per_second` on the stream contract is admin-only, so once the
+stream contract's admin has been transferred to governance (see
+[Integration](#integration-with-the-factory-and-stream-contracts)) the rate can
+only be changed through a proposal. Encode the change as a `StreamSetMaxRate`
+variant:
+
+```rust
+use soroban_sdk::xdr::ToXdr;
+use fluxora_governance::CallData;
+
+// Raise the per-second rate cap on the stream contract to 5_000 units.
+let calldata = CallData::StreamSetMaxRate(5_000_i128).to_xdr(&env);
+let proposal_id = governance_client.propose(&proposer, &stream_address, &calldata);
+```
+
+On `execute`, the contract decodes the bytes back into
+`CallData::StreamSetMaxRate(5_000)` and dispatches
+`set_max_rate_per_second(5_000)` to `stream_address`. The emitted
+`ProposalExecuted { proposal_id, executor, target, calldata }` event carries the
+exact `calldata` bytes, so an indexer can decode them with `CallData::from_xdr`
+and confirm the applied rate without reading the stream contract's storage.
+
 ### Failure modes
 
 | Condition | Behaviour |
@@ -247,6 +271,29 @@ Security boundary: a successful `execute` call now proves that the downstream
 parameter change has been applied on-chain. The `ProposalExecuted` event carries
 the original `calldata` bytes, letting indexers verify the dispatched operation
 without any side-channel.
+
+### ABI stability of the `CallData` enum
+
+`CallData` is part of the protocol's external ABI: proposers encode against it
+and indexers decode `ProposalExecuted.calldata` against it. Because the enum
+derives `#[contracttype]`, each variant is serialised with its **name** as the
+leading symbol followed by its payload, so the variant *names and payload
+shapes* — not their declaration order — are what integrators depend on. Treat
+the enum under the frozen-discriminant rules in
+[`ABI_STABILITY.md` §5](ABI_STABILITY.md#5-frozen-enum-discriminants) and the
+breaking-change taxonomy in
+[`ABI_STABILITY.md` §3](ABI_STABILITY.md#3-what-counts-as-a-breaking-change):
+
+| Change to `CallData` | Breaking? | Why |
+|---|---|---|
+| Append a new variant at the end | No | Existing calldata still decodes. The new name is only recognised by deployments that ship the variant; older deployments return `InvalidCalldata` (19), which is already the documented behaviour for unknown variants. |
+| Reorder existing variants | No | Decoding keys off the variant name, not its position. |
+| Rename a variant | Yes | Changes the leading symbol, so calldata stored in open proposals and indexer decoders keyed on the old name stop matching. |
+| Remove a variant | Yes | Any proposal whose stored calldata references it can no longer execute. |
+| Change a variant's payload type or arity | Yes | Alters the ScVal shape after the name symbol, so previously-encoded calldata mis-decodes. |
+
+Any change in the "Breaking" rows requires a `CONTRACT_VERSION` increment and a
+new deployment, consistent with §3.1.
 
 
 ## Integration with the factory and stream contracts


### PR DESCRIPTION

# Pull Request

## Description

Documentation-only follow-up to #781 (closed). It adds the two items requested in that PR's review — a worked example and ABI stability notes—on top of the typed `CallData` dispatch model introduced in #767, rather than the off-chain executor model the original PR described. No contract code or behavior changes.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Test coverage improvement
- [ ] Refactoring (no functional changes)

## Related Issues

Closes #760

Follow-up to #781 (closed); builds on the typed `CallData` model from #767.

## Changes Made

- Added a **Worked example: routing a stream rate change** subsection showing how to encode a `CallData::StreamSetMaxRate` proposal, the downstream call it dispatches (`set_max_rate_per_second`), and how to verify the applied rate from the `ProposalExecuted` event.
- Added an **ABI stability of the `CallData` enum** subsection with a breaking vs non-breaking table, clarifying that the `#[contracttype]` encoding is name-keyed (reordering variants is safe; renaming, removing, or retyping a variant is breaking).
- Cross-referenced `ABI_STABILITY.md` §3 (breaking-change taxonomy) and §5 (frozen enum discriminants), which previously did not reference governance's `CallData`.

All changes are additive to `docs/governance.md` (+47 / -0, single file). No existing text was modified or removed.

## Snapshot Test Changes

### Did this PR modify snapshot test files?

- [ ] Yes - snapshot files were updated (explain below)
- [x] No - no snapshot changes

N/A — documentation-only change; no snapshot, contract, or test files were touched.

## Testing

### Test Coverage

Documentation-only change; no Rust sources modified, so the contract test suites are unaffected.

- [ ] All tests pass locally: `cargo test -p fluxora_stream` — N/A (no code changes)
- [ ] New tests added for new functionality — N/A
- [ ] Existing tests updated for changed functionality — N/A
- [ ] Test coverage remains above 95% — N/A (no code changes)

### Manual Testing

Verified locally that the markdown renders (code fences balanced), the `rust` example is well-formed, and the `ABI_STABILITY.md` §3/§5 and internal Integration cross-references resolve.

- [x] Tested on local environment
- [ ] Tested edge cases — N/A (documentation only)
- [ ] Tested error conditions — N/A (documentation only)

## Documentation

- [ ] Code comments added/updated — N/A (no code)
- [x] Documentation updated (new subsections; no behavior changed)
- [ ] README updated (if needed) — N/A
- [ ] Snapshot test documentation reviewed — N/A (no snapshot changes)

## Security Considerations

- [x] No new security concerns introduced (documentation-only)
- [ ] Authorization boundaries verified — N/A (no code); the docs accurately describe `set_max_rate_per_second` as admin-only
- [ ] Input validation added/verified — N/A
- [ ] Error handling reviewed — N/A; the docs reference the existing `InvalidCalldata` (19) behavior, unchanged

## Checklist

- [x] My code follows the project's style guidelines (matches existing `governance.md` structure and relative-link style)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas — N/A (no code)
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works — N/A (documentation only)
- [ ] New and existing unit tests pass locally with my changes — N/A (no code changes)
- [x] Any dependent changes have been merged and published (builds on #767, already merged)

## Additional Notes

Intentionally scoped to additive documentation only — it does not modify the typed-dispatch description added in #767. Items above referencing code, tests, and snapshots are marked N/A because no Rust sources or test fixtures were changed.

## Reviewer Checklist

<!-- For reviewers to complete -->
- [ ] Code quality and style
- [ ] Test coverage adequate
- [ ] Documentation complete
- [ ] Snapshot changes justified and correct
- [ ] Security implications reviewed
- [ ] Breaking changes documented