### PR TITLE
Enforce factory rate-per-second bounds in create_streams batch path

### DIFF
--- a/contracts/factory/tests/factory_stream_e2e.rs
+++ b/contracts/factory/tests/factory_stream_e2e.rs
@@ -785,4 +785,179 @@ fn test_create_streams_empty_batch_emits_no_events() {
     assert_eq!(total_count, 0);
 }
 
+// ---------------------------------------------------------------------------
+// Rate bounds enforcement in batch creation
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_create_streams_rate_below_min_fails() {
+    let ctx = Ctx::setup();
+    let now = ctx.now();
+
+    // Set min rate
+    ctx.factory.set_rate_bounds(&Some(100), &None);
+
+    let mut streams = soroban_sdk::Vec::new(&ctx.env);
+    streams.push_back(fluxora_stream::CreateStreamParams {
+        recipient: ctx.recipient.clone(),
+        deposit_amount: DEPOSIT_AMOUNT,
+        rate_per_second: 50, // below min
+        start_time: now,
+        cliff_time: now,
+        end_time: now + STREAM_DURATION,
+        withdraw_dust_threshold: Some(0),
+        memo: None,
+        kind: fluxora_stream::StreamKind::Linear,
+    });
+
+    let result = ctx.factory.try_create_streams(&ctx.sender, &streams);
+    assert_eq!(result, Err(Ok(FactoryError::RateBelowMin)));
+
+    // Verify atomic failure: no streams created
+    assert_eq!(ctx.stream.get_stream_count(), 0);
+}
+
+#[test]
+fn test_create_streams_rate_above_max_fails() {
+    let ctx = Ctx::setup();
+    let now = ctx.now();
+
+    // Set max rate
+    ctx.factory.set_rate_bounds(&None, &Some(200));
+
+    let mut streams = soroban_sdk::Vec::new(&ctx.env);
+    streams.push_back(fluxora_stream::CreateStreamParams {
+        recipient: ctx.recipient.clone(),
+        deposit_amount: DEPOSIT_AMOUNT,
+        rate_per_second: 300, // above max
+        start_time: now,
+        cliff_time: now,
+        end_time: now + STREAM_DURATION,
+        withdraw_dust_threshold: Some(0),
+        memo: None,
+        kind: fluxora_stream::StreamKind::Linear,
+    });
+
+    let result = ctx.factory.try_create_streams(&ctx.sender, &streams);
+    assert_eq!(result, Err(Ok(FactoryError::RateAboveMax)));
+
+    // Verify atomic failure: no streams created
+    assert_eq!(ctx.stream.get_stream_count(), 0);
+}
+
+#[test]
+fn test_create_streams_mixed_rates_fails_atomically() {
+    let ctx = Ctx::setup();
+    let now = ctx.now();
+
+    // Set rate bounds
+    ctx.factory.set_rate_bounds(&Some(100), &Some(200));
+
+    let mut streams = soroban_sdk::Vec::new(&ctx.env);
+    // Valid
+    streams.push_back(fluxora_stream::CreateStreamParams {
+        recipient: ctx.recipient.clone(),
+        deposit_amount: DEPOSIT_AMOUNT,
+        rate_per_second: 150,
+        start_time: now,
+        cliff_time: now,
+        end_time: now + STREAM_DURATION,
+        withdraw_dust_threshold: Some(0),
+        memo: None,
+        kind: fluxora_stream::StreamKind::Linear,
+    });
+    // Invalid (below min)
+    streams.push_back(fluxora_stream::CreateStreamParams {
+        recipient: ctx.recipient.clone(),
+        deposit_amount: DEPOSIT_AMOUNT,
+        rate_per_second: 50,
+        start_time: now,
+        cliff_time: now,
+        end_time: now + STREAM_DURATION,
+        withdraw_dust_threshold: Some(0),
+        memo: None,
+        kind: fluxora_stream::StreamKind::Linear,
+    });
+
+    let result = ctx.factory.try_create_streams(&ctx.sender, &streams);
+    assert_eq!(result, Err(Ok(FactoryError::RateBelowMin)));
+
+    // Verify atomic failure: no streams created
+    assert_eq!(ctx.stream.get_stream_count(), 0);
+}
+
+#[test]
+fn test_create_streams_rates_at_bounds_succeed() {
+    let ctx = Ctx::setup();
+    let now = ctx.now();
+
+    // Set rate bounds
+    ctx.factory.set_rate_bounds(&Some(100), &Some(200));
+
+    let mut streams = soroban_sdk::Vec::new(&ctx.env);
+    // At min
+    streams.push_back(fluxora_stream::CreateStreamParams {
+        recipient: ctx.recipient.clone(),
+        deposit_amount: DEPOSIT_AMOUNT,
+        rate_per_second: 100,
+        start_time: now,
+        cliff_time: now,
+        end_time: now + STREAM_DURATION,
+        withdraw_dust_threshold: Some(0),
+        memo: None,
+        kind: fluxora_stream::StreamKind::Linear,
+    });
+    // At max
+    streams.push_back(fluxora_stream::CreateStreamParams {
+        recipient: ctx.recipient.clone(),
+        deposit_amount: DEPOSIT_AMOUNT,
+        rate_per_second: 200,
+        start_time: now,
+        cliff_time: now,
+        end_time: now + STREAM_DURATION,
+        withdraw_dust_threshold: Some(0),
+        memo: None,
+        kind: fluxora_stream::StreamKind::Linear,
+    });
+
+    let ids = ctx.factory.create_streams(&ctx.sender, &streams);
+    assert_eq!(ids.len(), 2);
+    assert_eq!(ctx.stream.get_stream_count(), 2);
+}
+
+#[test]
+fn test_create_streams_without_bounds_succeeds() {
+    let ctx = Ctx::setup();
+    let now = ctx.now();
+
+    // No bounds set
+    let mut streams = soroban_sdk::Vec::new(&ctx.env);
+    streams.push_back(fluxora_stream::CreateStreamParams {
+        recipient: ctx.recipient.clone(),
+        deposit_amount: DEPOSIT_AMOUNT,
+        rate_per_second: 50,
+        start_time: now,
+        cliff_time: now,
+        end_time: now + STREAM_DURATION,
+        withdraw_dust_threshold: Some(0),
+        memo: None,
+        kind: fluxora_stream::StreamKind::Linear,
+    });
+    streams.push_back(fluxora_stream::CreateStreamParams {
+        recipient: ctx.recipient.clone(),
+        deposit_amount: DEPOSIT_AMOUNT,
+        rate_per_second: 300,
+        start_time: now,
+        cliff_time: now,
+        end_time: now + STREAM_DURATION,
+        withdraw_dust_threshold: Some(0),
+        memo: None,
+        kind: fluxora_stream::StreamKind::Linear,
+    });
+
+    let ids = ctx.factory.create_streams(&ctx.sender, &streams);
+    assert_eq!(ids.len(), 2);
+    assert_eq!(ctx.stream.get_stream_count(), 2);
+}
+
 


### PR DESCRIPTION
Updated File

## Requirements Checklist
✅ 1. Rate bounds enforcement in create_streams loop :
 The create_streams function in contracts/factory/src/lib.rs already uses the existing validate_rate_bounds helper function, which returns the same errors as single-stream creation ( FactoryError::RateBelowMin and FactoryError::RateAboveMax ).

✅ 2. Bounds read once before loop :
 Lines 855-856 in lib.rs read min_rate and max_rate from storage once before entering the loop, avoiding repeated reads.

✅ 3. Tests added :
 We added 5 comprehensive tests covering all cases:

- test_create_streams_rate_below_min_fails : Fails when rate < min bound
- test_create_streams_rate_above_max_fails : Fails when rate > max bound
- test_create_streams_mixed_rates_fails_atomically : Single invalid entry fails the entire batch
- test_create_streams_rates_at_bounds_succeed : Rates exactly at min/max are accepted
- test_create_streams_without_bounds_succeeds : No bounds means no restrictions
✅ 4. Single-stream enforcement untouched :
 The single-stream create_stream function was not modified at all.

✅ 5. Security (atomic batch failure) :
 The test test_create_streams_mixed_rates_fails_atomically verifies that a single invalid entry aborts the entire batch, with no partial stream creation.

✅ 6. Documentation :
 The file docs/factory.md already mentions rate bounds enforcement in batch creation (line 75), so no further changes were needed.
 
Closes #727 