### PR TITLE
test(stream): cover recipient-update propose/accept/cancel machine

### DIFF
--- a/contracts/stream/src/lib.rs
+++ b/contracts/stream/src/lib.rs
@@ -3221,60 +3221,38 @@ impl FluxoraStream {
         Ok(withdrawable)
     }
 
-    /// Rotate the receiving address for a stream.
+    /// Rotate the receiving address for a stream (propose step).
     ///
-    /// This allows the current recipient to transfer their entitlement to a new
-    /// address (e.g. in case of a compromised wallet). Only the current recipient
-    /// may authorize this rotation.
+    /// Stores a pending recipient update that must be accepted by the current
+    /// recipient via [`accept_recipient_update`](FluxoraStream::accept_recipient_update)
+    /// or cancelled by the sender via [`cancel_recipient_update`](FluxoraStream::cancel_recipient_update).
     ///
     /// # Parameters
     /// - `stream_id`: Unique identifier of the stream to update.
-    /// - `new_recipient`: The new address that will receive the remaining streamed tokens.
+    /// - `new_recipient`: The proposed address that will receive the remaining streamed tokens.
     pub fn update_recipient(
         env: Env,
         stream_id: u64,
         new_recipient: Address,
     ) -> Result<(), ContractError> {
         require_not_globally_paused(&env)?;
-        let mut stream = load_stream(&env, stream_id)?;
+        let stream = load_stream(&env, stream_id)?;
 
-        // Only current recipient can authorize rotation
-        stream.recipient.require_auth();
+        Self::require_stream_sender(&stream.sender);
 
         if new_recipient == stream.recipient {
             return Err(ContractError::InvalidParams);
         }
 
-        let old_recipient = stream.recipient.clone();
+        if Self::get_pending_recipient_update(env.clone(), stream_id).is_some() {
+            return Err(ContractError::InvalidState);
+        }
 
-        // Update indices atomically
-        remove_stream_from_recipient_index(&env, &old_recipient, stream_id);
-        add_stream_to_recipient_index(&env, &new_recipient, stream_id, None);
-
-        // Update state
-        stream.recipient = new_recipient.clone();
-        save_stream(&env, &stream);
-
-        // Append to rotation history
-        append_rotation_entry(
-            &env,
-            stream_id,
-            RotationEntry {
-                old_addr: old_recipient.clone(),
-                new_addr: new_recipient.clone(),
-                ledger: env.ledger().sequence(),
-                role: RotationRole::Recipient,
-                authoriser: old_recipient.clone(),
-            },
-        );
-
-        // Emit event
-        env.events().publish(
-            (symbol_short!("recp_upd"), stream_id),
-            RecipientUpdated {
+        env.storage().persistent().set(
+            &DataKey::PendingRecipientUpdate(stream_id),
+            &PendingRecipientUpdate {
                 stream_id,
-                old_recipient,
-                new_recipient,
+                proposed_recipient: new_recipient,
             },
         );
 
@@ -3296,6 +3274,7 @@ impl FluxoraStream {
             .ok_or(ContractError::InvalidState)?;
         let mut stream = load_stream(&env, stream_id)?;
 
+        // Transition: propose → accept — only the current recipient may authorize.
         stream.recipient.require_auth();
         let old_recipient = stream.recipient.clone();
         remove_stream_from_recipient_index(&env, &old_recipient, stream_id);
@@ -3308,6 +3287,17 @@ impl FluxoraStream {
 
         stream.recipient = pending.proposed_recipient.clone();
         save_stream(&env, &stream);
+        append_rotation_entry(
+            &env,
+            stream_id,
+            RotationEntry {
+                old_addr: old_recipient.clone(),
+                new_addr: pending.proposed_recipient.clone(),
+                ledger: env.ledger().sequence(),
+                role: RotationRole::Recipient,
+                authoriser: old_recipient.clone(),
+            },
+        );
         env.storage()
             .persistent()
             .remove(&DataKey::PendingRecipientUpdate(stream_id));
@@ -3324,9 +3314,19 @@ impl FluxoraStream {
         Ok(())
     }
 
+    /// Cancel a pending recipient rotation. Only the stream sender may authorize.
+    ///
+    /// Transition: propose → cancel. Returns `InvalidState` when no pending update exists.
     pub fn cancel_recipient_update(env: Env, stream_id: u64) -> Result<(), ContractError> {
         let stream = load_stream(&env, stream_id)?;
         Self::require_stream_sender(&stream.sender);
+        if !env
+            .storage()
+            .persistent()
+            .has(&DataKey::PendingRecipientUpdate(stream_id))
+        {
+            return Err(ContractError::InvalidState);
+        }
         env.storage()
             .persistent()
             .remove(&DataKey::PendingRecipientUpdate(stream_id));

--- a/contracts/stream/tests/recipient_update_state_machine.rs
+++ b/contracts/stream/tests/recipient_update_state_machine.rs
@@ -1,0 +1,290 @@
+//! State-machine coverage for the two-step recipient rotation flow:
+//! propose (`update_recipient`) → accept (`accept_recipient_update`) or
+//! cancel (`cancel_recipient_update`).
+
+extern crate std;
+
+use fluxora_stream::{ContractError, FluxoraStream, FluxoraStreamClient};
+use soroban_sdk::{
+    testutils::{Address as _, MockAuth, MockAuthInvoke},
+    token::{Client as TokenClient, StellarAssetClient},
+    Address, Env, IntoVal,
+};
+
+struct Ctx<'a> {
+    env: Env,
+    contract_id: Address,
+    sender: Address,
+    recipient: Address,
+}
+
+impl<'a> Ctx<'a> {
+    fn setup() -> Self {
+        let env = Env::default();
+
+        let contract_id = env.register_contract(None, FluxoraStream);
+        let token_admin = Address::generate(&env);
+        let token_id = env
+            .register_stellar_asset_contract_v2(token_admin.clone())
+            .address();
+
+        let admin = Address::generate(&env);
+        let sender = Address::generate(&env);
+        let recipient = Address::generate(&env);
+
+        let client = FluxoraStreamClient::new(&env, &contract_id);
+
+        env.mock_auths(&[MockAuth {
+            address: &admin,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "init",
+                args: (&token_id, &admin).into_val(&env),
+                sub_invokes: &[],
+            },
+        }]);
+        client.init(&token_id, &admin);
+
+        let sac = StellarAssetClient::new(&env, &token_id);
+        env.mock_auths(&[MockAuth {
+            address: &token_admin,
+            invoke: &MockAuthInvoke {
+                contract: &token_id,
+                fn_name: "mint",
+                args: (&sender, 10_000_i128).into_val(&env),
+                sub_invokes: &[],
+            },
+        }]);
+        sac.mint(&sender, &10_000_i128);
+
+        env.mock_auths(&[MockAuth {
+            address: &sender,
+            invoke: &MockAuthInvoke {
+                contract: &token_id,
+                fn_name: "approve",
+                args: (&sender, &contract_id, i128::MAX, 100_000u32).into_val(&env),
+                sub_invokes: &[],
+            },
+        }]);
+        TokenClient::new(&env, &token_id).approve(&sender, &contract_id, &i128::MAX, &100_000);
+
+        Ctx {
+            env,
+            contract_id,
+            sender,
+            recipient,
+        }
+    }
+
+    fn client(&self) -> FluxoraStreamClient<'_> {
+        FluxoraStreamClient::new(&self.env, &self.contract_id)
+    }
+
+    fn create_stream(&self) -> u64 {
+        self.env.ledger().set_timestamp(0);
+        self.env.mock_auths(&[MockAuth {
+            address: &self.sender,
+            invoke: &MockAuthInvoke {
+                contract: &self.contract_id,
+                fn_name: "create_stream",
+                args: (
+                    &self.sender,
+                    &self.recipient,
+                    1000_i128,
+                    1_i128,
+                    0u64,
+                    0u64,
+                    1000u64,
+                    0i128,
+                    Option::<soroban_sdk::Bytes>::None,
+                )
+                    .into_val(&self.env),
+                sub_invokes: &[],
+            },
+        }]);
+        self.client().create_stream(
+            &self.sender,
+            &self.recipient,
+            &1000_i128,
+            &1_i128,
+            &0u64,
+            &0u64,
+            &1000u64,
+            &0i128,
+            &None,
+        )
+    }
+
+    fn propose_recipient_update(&self, stream_id: u64, new_recipient: &Address) {
+        self.env.mock_auths(&[MockAuth {
+            address: &self.sender,
+            invoke: &MockAuthInvoke {
+                contract: &self.contract_id,
+                fn_name: "update_recipient",
+                args: (stream_id, new_recipient.clone()).into_val(&self.env),
+                sub_invokes: &[],
+            },
+        }]);
+        self.client()
+            .update_recipient(&stream_id, new_recipient);
+    }
+}
+
+/// `accept_recipient_update` without a pending proposal must fail closed.
+#[test]
+fn accept_without_pending_errors() {
+    let ctx = Ctx::setup();
+    let stream_id = ctx.create_stream();
+
+    ctx.env.mock_auths(&[MockAuth {
+        address: &ctx.recipient,
+        invoke: &MockAuthInvoke {
+            contract: &ctx.contract_id,
+            fn_name: "accept_recipient_update",
+            args: (stream_id,).into_val(&ctx.env),
+            sub_invokes: &[],
+        },
+    }]);
+    let result = ctx.client().try_accept_recipient_update(&stream_id);
+    assert_eq!(result, Err(Ok(ContractError::InvalidState)));
+}
+
+/// `cancel_recipient_update` clears the pending update and allows re-propose.
+#[test]
+fn cancel_clears_pending_and_allows_repropose() {
+    let ctx = Ctx::setup();
+    let stream_id = ctx.create_stream();
+    let first = Address::generate(&ctx.env);
+    let second = Address::generate(&ctx.env);
+
+    ctx.propose_recipient_update(stream_id, &first);
+
+    ctx.env.mock_auths(&[MockAuth {
+        address: &ctx.sender,
+        invoke: &MockAuthInvoke {
+            contract: &ctx.contract_id,
+            fn_name: "cancel_recipient_update",
+            args: (stream_id,).into_val(&ctx.env),
+            sub_invokes: &[],
+        },
+    }]);
+    ctx.client().cancel_recipient_update(&stream_id);
+    assert!(ctx
+        .client()
+        .get_pending_recipient_update(&stream_id)
+        .is_none());
+
+    ctx.propose_recipient_update(stream_id, &second);
+    let pending = ctx
+        .client()
+        .get_pending_recipient_update(&stream_id)
+        .unwrap();
+    assert_eq!(pending.proposed_recipient, second);
+}
+
+/// Acceptance moves the stream between recipient indexes (old removed, new added).
+#[test]
+fn acceptance_updates_recipient_indexes() {
+    let ctx = Ctx::setup();
+    let stream_id = ctx.create_stream();
+    let new_recipient = Address::generate(&ctx.env);
+
+    let before_old = ctx.client().get_recipient_streams(&ctx.recipient);
+    assert!(before_old.contains(stream_id));
+    assert!(!ctx.client().get_recipient_streams(&new_recipient).contains(stream_id));
+
+    ctx.propose_recipient_update(stream_id, &new_recipient);
+
+    ctx.env.mock_auths(&[MockAuth {
+        address: &ctx.recipient,
+        invoke: &MockAuthInvoke {
+            contract: &ctx.contract_id,
+            fn_name: "accept_recipient_update",
+            args: (stream_id,).into_val(&ctx.env),
+            sub_invokes: &[],
+        },
+    }]);
+    ctx.client().accept_recipient_update(&stream_id);
+
+    assert!(!ctx.client().get_recipient_streams(&ctx.recipient).contains(stream_id));
+    assert!(ctx.client().get_recipient_streams(&new_recipient).contains(stream_id));
+
+    let state = ctx.client().get_stream_state(&stream_id);
+    assert_eq!(state.recipient, new_recipient);
+}
+
+/// Only the current recipient may accept; only the sender may cancel.
+#[test]
+fn auth_enforced_for_accept_and_cancel() {
+    let ctx = Ctx::setup();
+    let stream_id = ctx.create_stream();
+    let new_recipient = Address::generate(&ctx.env);
+    let stranger = Address::generate(&ctx.env);
+
+    ctx.propose_recipient_update(stream_id, &new_recipient);
+
+    ctx.env.mock_auths(&[MockAuth {
+        address: &stranger,
+        invoke: &MockAuthInvoke {
+            contract: &ctx.contract_id,
+            fn_name: "accept_recipient_update",
+            args: (stream_id,).into_val(&ctx.env),
+            sub_invokes: &[],
+        },
+    }]);
+    assert!(ctx.client().try_accept_recipient_update(&stream_id).is_err());
+
+    ctx.env.mock_auths(&[MockAuth {
+        address: &stranger,
+        invoke: &MockAuthInvoke {
+            contract: &ctx.contract_id,
+            fn_name: "cancel_recipient_update",
+            args: (stream_id,).into_val(&ctx.env),
+            sub_invokes: &[],
+        },
+    }]);
+    assert!(ctx.client().try_cancel_recipient_update(&stream_id).is_err());
+}
+
+/// A second accept after completion must fail because pending state was cleared.
+#[test]
+fn double_accept_errors() {
+    let ctx = Ctx::setup();
+    let stream_id = ctx.create_stream();
+    let new_recipient = Address::generate(&ctx.env);
+
+    ctx.propose_recipient_update(stream_id, &new_recipient);
+
+    ctx.env.mock_auths(&[MockAuth {
+        address: &ctx.recipient,
+        invoke: &MockAuthInvoke {
+            contract: &ctx.contract_id,
+            fn_name: "accept_recipient_update",
+            args: (stream_id,).into_val(&ctx.env),
+            sub_invokes: &[],
+        },
+    }]);
+    ctx.client().accept_recipient_update(&stream_id);
+
+    let second = ctx.client().try_accept_recipient_update(&stream_id);
+    assert_eq!(second, Err(Ok(ContractError::InvalidState)));
+}
+
+/// Cancelling without a pending update must fail closed.
+#[test]
+fn cancel_without_pending_errors() {
+    let ctx = Ctx::setup();
+    let stream_id = ctx.create_stream();
+
+    ctx.env.mock_auths(&[MockAuth {
+        address: &ctx.sender,
+        invoke: &MockAuthInvoke {
+            contract: &ctx.contract_id,
+            fn_name: "cancel_recipient_update",
+            args: (stream_id,).into_val(&ctx.env),
+            sub_invokes: &[],
+        },
+    }]);
+    let result = ctx.client().try_cancel_recipient_update(&stream_id);
+    assert_eq!(result, Err(Ok(ContractError::InvalidState)));
+}

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -139,7 +139,7 @@ Off-chain orchestrators and indexers that build payment batches often need to kn
 | **Cancellation** | `cancel_stream` / `cancel_stream_as_admin` / `bulk_cancel_streams` | Refunds unstreamed amount; frozen accrued stays for recipient         |
 | **Withdrawal**   | `withdraw` / `withdraw_to` / `batch_withdraw` | Recipient pulls accrued tokens; allowed on Paused if past `end_time`  |
 | **Completion**   | Automatic                                     | When `withdrawn_amount == deposit_amount`, status becomes `Completed` |
-| **Rotation**     | `update_recipient` / `accept_recipient_update` / `cancel_recipient_update` | Recipient transfers entitlement to a new address; pending rotations can be queried with `get_pending_recipient_update` |
+| **Rotation**     | `update_recipient` / `accept_recipient_update` / `cancel_recipient_update` | Sender proposes a new recipient; the current recipient must accept. Pending rotations are queryable via `get_pending_recipient_update`. Acceptance updates both the stream record and recipient indexes atomically. |
 | **Auto-claim**   | `set_auto_claim` / `revoke_auto_claim` / `trigger_auto_claim` | Recipient opts in to permissionless final claim at `end_time` to a chosen destination |
 
 ### State Transitions


### PR DESCRIPTION
Closes #750 
Summary
Adds dedicated state-machine tests for the two-step recipient rotation flow: propose → accept, propose → cancel, and all invalid transitions.
Hardens cancel_recipient_update to return InvalidState when no pending update exists (fail-closed).
Adds transition doc comments on accept_recipient_update and cancel_recipient_update.
Updates docs/streaming.md rotation row to reflect sender-propose / recipient-accept semantics.