### PR TITLE
fix(governance): extend ProposalApprovalIdx TTL on each approval

### DIFF
--- a/contracts/governance/src/lib.rs
+++ b/contracts/governance/src/lib.rs
@@ -334,7 +334,26 @@ fn save_signer_index(env: &Env, index: &Map<Address, bool>) {
     env.storage().instance().set(&DataKey::SignerIndex, index);
 }
 
+/// Extends the TTL of the per-proposal approval index so it outlives the
+/// proposal record. Called on every read and write of `ProposalApprovalIdx(id)`
+/// to prevent duplicate-approval detection from silently failing when the index
+/// archives before the proposal.
+fn bump_approval_index(env: &Env, proposal_id: u32) {
+    if env
+        .storage()
+        .persistent()
+        .has(&DataKey::ProposalApprovalIdx(proposal_id))
+    {
+        env.storage().persistent().extend_ttl(
+            &DataKey::ProposalApprovalIdx(proposal_id),
+            PERSISTENT_LIFETIME_THRESHOLD,
+            PERSISTENT_BUMP_AMOUNT,
+        );
+    }
+}
+
 fn get_approval_index(env: &Env, proposal_id: u32) -> Map<Address, bool> {
+    bump_approval_index(env, proposal_id);
     env.storage()
         .persistent()
         .get(&DataKey::ProposalApprovalIdx(proposal_id))
@@ -345,11 +364,7 @@ fn save_approval_index(env: &Env, proposal_id: u32, index: &Map<Address, bool>) 
     env.storage()
         .persistent()
         .set(&DataKey::ProposalApprovalIdx(proposal_id), index);
-    env.storage().persistent().extend_ttl(
-        &DataKey::ProposalApprovalIdx(proposal_id),
-        PERSISTENT_LIFETIME_THRESHOLD,
-        PERSISTENT_BUMP_AMOUNT,
-    );
+    bump_approval_index(env, proposal_id);
 }
 
 fn get_admin(env: &Env) -> Result<Address, GovernanceError> {
@@ -405,6 +420,7 @@ fn load_proposal(env: &Env, id: u32) -> Result<Proposal, GovernanceError> {
         .get(&DataKey::Proposal(id))
         .ok_or(GovernanceError::ProposalNotFound)?;
     bump_proposal(env, id);
+    bump_approval_index(env, id);
     Ok(proposal)
 }
 
@@ -707,6 +723,7 @@ impl FluxoraGovernance {
 
         save_proposal(&env, proposal_id, &proposal);
         save_approval_index(&env, proposal_id, &approval_idx);
+        bump_approval_index(&env, proposal_id);
         bump_instance(&env);
 
         env.events().publish(

--- a/contracts/stream/tests/governance_ttl.rs
+++ b/contracts/stream/tests/governance_ttl.rs
@@ -383,3 +383,41 @@ fn test_execute_fails_closed_if_quorum_entry_missing() {
     let result = ctx.client.try_execute(&executor, &id);
     assert_eq!(result, Err(Ok(GovernanceError::QuorumNotReached)));
 }
+
+// ---------------------------------------------------------------------
+// ProposalApprovalIdx TTL regression (issue #732)
+// ---------------------------------------------------------------------
+
+/// After a long idle period between approvals, the approval index TTL must
+/// remain coupled to the proposal so duplicate approvals are still rejected.
+#[test]
+fn test_approval_index_ttl_refreshed_rejects_duplicate_after_long_delay() {
+    let ctx = GovCtx::setup();
+    let id = ctx.create_proposal();
+
+    ctx.client.approve(&ctx.signer_a, &id);
+
+    ctx.advance_ledgers(PERSISTENT_BUMP_AMOUNT - 500);
+
+    let duplicate = ctx.client.try_approve(&ctx.signer_a, &id);
+    assert_eq!(duplicate, Err(Ok(GovernanceError::AlreadyApproved)));
+
+    ctx.client.approve(&ctx.signer_b, &id);
+    let proposal = ctx.client.get_proposal(&id);
+    assert_eq!(proposal.approvals.len(), 2);
+}
+
+/// Each approval refreshes the approval-index TTL so later signers can still
+/// rely on duplicate detection near the proposal-age horizon.
+#[test]
+fn test_approval_index_ttl_bumped_on_every_approve() {
+    let ctx = GovCtx::setup();
+    let id = ctx.create_proposal();
+
+    ctx.client.approve(&ctx.signer_a, &id);
+    ctx.advance_ledgers(PERSISTENT_LIFETIME_THRESHOLD + 1_000);
+    ctx.client.approve(&ctx.signer_b, &id);
+
+    let duplicate = ctx.client.try_approve(&ctx.signer_a, &id);
+    assert_eq!(duplicate, Err(Ok(GovernanceError::AlreadyApproved)));
+}

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -334,13 +334,17 @@ write that touches the entry:
 - **`QuorumReachedAt(id)`**: bumped when quorum is first reached inside
   `approve` (write path), and also bumped on read by `get_quorum_info`
   and `is_executable` (read path).
+- **`ProposalApprovalIdx(id)`**: bumped via `bump_approval_index` in
+  `get_approval_index` (read path), `save_approval_index` (write path),
+  `load_proposal` (keeps the index coupled to the proposal record TTL),
+  and explicitly after every successful `approve`.
 
 Constants:
 
 | Symbol | Value | Purpose |
 |---|---:|---|
 | `PERSISTENT_LIFETIME_THRESHOLD` | 17,280 ledgers (~1 d) | Soroban archival threshold; entries whose remaining TTL falls below this value are bump-extended. |
-| `PERSISTENT_BUMP_AMOUNT` | 120,960 ledgers (~7 d) | Bump amount applied on every read and write of `Proposal(id)`, and on `QuorumReachedAt(id)` at quorum-reach. |
+| `PERSISTENT_BUMP_AMOUNT` | 120,960 ledgers (~7 d) | Bump amount applied on every read and write of `Proposal(id)`, `ProposalApprovalIdx(id)`, and on `QuorumReachedAt(id)` at quorum-reach. |
 
 The 48-hour timelock corresponds to ~34,560 ledgers, which is comfortably
 covered by a single 7-day bump. The 30-day `MAX_PROPOSAL_AGE_SECONDS`
@@ -478,6 +482,19 @@ cover:
 The `QuorumReachedAt(proposal_id)` persistent storage entry is bumped on:
 - Every `approve` call when quorum is reached
 - Every `execute` call when reading the entry
+
+### ProposalApprovalIdx Entry TTL
+The `ProposalApprovalIdx(proposal_id)` duplicate-approval index must outlive the
+proposal record so quorum integrity cannot be undermined by storage expiry.
+Its TTL is bumped on:
+- Every `approve` call after recording an approval
+- Every read via `get_approval_index` and `load_proposal`
+- Every write via `save_approval_index`
+
+Security implication: if the approval index archives before the proposal,
+duplicate-approval detection silently fails and a signer could approve twice.
+The coupling to `load_proposal` ensures any path that touches the proposal
+also refreshes the index TTL when the index entry still exists.
 
 ### Constants
 | Constant | Value | Duration |


### PR DESCRIPTION
Closes #732

Summary
Adds bump_approval_index() and calls it on every read/write of ProposalApprovalIdx(id), in load_proposal, and explicitly after each successful approve.
Keeps the duplicate-approval index TTL coupled to the proposal record so quorum integrity cannot be undermined by storage expiry.
Adds regression tests in contracts/stream/tests/governance_ttl.rs for duplicate rejection after long ledger delays.
Documents TTL coupling in docs/governance.md.