### PR TITLE
feat(governance): emit QuorumConfig event on membership changes

### DIFF
--- a/contracts/governance/src/lib.rs
+++ b/contracts/governance/src/lib.rs
@@ -279,6 +279,20 @@ pub struct SignerRemoved {
     pub signer: Address,
 }
 
+/// Emitted when the co-signer set size changes, allowing indexers to track
+/// whether the current threshold remains satisfiable and how close the
+/// membership is to dropping below the threshold.
+///
+/// Published by [`add_signer`](FluxoraGovernance::add_signer) and
+/// [`remove_signer`](FluxoraGovernance::remove_signer) after the membership
+/// change is persisted.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct QuorumConfig {
+    pub threshold: u32,
+    pub signer_count: u32,
+}
+
 /// Emitted when the admin address is rotated.
 ///
 /// Published by [`set_admin`](FluxoraGovernance::set_admin) after the new admin
@@ -533,6 +547,15 @@ impl FluxoraGovernance {
         env.events()
             .publish((symbol_short!("sgnr_add"),), SignerAdded { signer });
 
+        let threshold = get_threshold(&env)?;
+        env.events().publish(
+            (symbol_short!("quor_cfg"),),
+            QuorumConfig {
+                threshold,
+                signer_count: signers.len(),
+            },
+        );
+
         Ok(())
     }
 
@@ -578,6 +601,15 @@ impl FluxoraGovernance {
         // no event).
         env.events()
             .publish((symbol_short!("sgnr_rm"),), SignerRemoved { signer });
+
+        env.events().publish(
+            (symbol_short!("quor_cfg"),),
+            QuorumConfig {
+                threshold,
+                signer_count: signers.len(),
+            },
+        );
+
         Ok(())
     }
 
@@ -1962,5 +1994,56 @@ mod tests {
             ctx.client.try_execute(&executor, &id3),
             Err(Ok(GovernanceError::ProposalExpired))
         );
+    }
+
+    #[test]
+    fn test_quorum_config_events_on_membership_changes() {
+        use soroban_sdk::testutils::Events;
+        use soroban_sdk::{symbol_short, IntoVal, TryFromVal};
+
+        let ctx = Ctx::setup();
+        // Ctx::setup() sets up a contract with 3 signers and a threshold of 2.
+        
+        let new_signer = Address::generate(&ctx.env);
+        
+        // Add a signer
+        ctx.client.add_signer(&new_signer);
+        
+        let events = ctx.env.events().all();
+        let quor_event = events.iter().rfind(|(_, topics, _)| {
+            topics == &soroban_sdk::vec![
+                &ctx.env,
+                symbol_short!("quor_cfg").into_val(&ctx.env)
+            ]
+        });
+        assert!(quor_event.is_some(), "quor_cfg event must be emitted on add");
+
+        let (_, _, data) = quor_event.unwrap();
+        let payload = QuorumConfig::try_from_val(&ctx.env, &data)
+            .expect("event data must deserialize as QuorumConfig");
+        
+        // Started with 3, added 1 -> 4
+        assert_eq!(payload.threshold, 2);
+        assert_eq!(payload.signer_count, 4);
+
+        // Remove the signer
+        ctx.client.remove_signer(&new_signer);
+
+        let events = ctx.env.events().all();
+        let quor_event = events.iter().rfind(|(_, topics, _)| {
+            topics == &soroban_sdk::vec![
+                &ctx.env,
+                symbol_short!("quor_cfg").into_val(&ctx.env)
+            ]
+        });
+        assert!(quor_event.is_some(), "quor_cfg event must be emitted on remove");
+
+        let (_, _, data) = quor_event.unwrap();
+        let payload = QuorumConfig::try_from_val(&ctx.env, &data)
+            .expect("event data must deserialize as QuorumConfig");
+        
+        // Removed 1 -> 3
+        assert_eq!(payload.threshold, 2);
+        assert_eq!(payload.signer_count, 3);
     }
 }

--- a/docs/events.md
+++ b/docs/events.md
@@ -484,6 +484,25 @@ applicable (e.g. `AdminUpd`).
 
 ---
 
+## Governance contract events (`fluxora_governance`)
+
+All state-changing governance entrypoints emit structured events. Topics are ≤ 9
+characters (`symbol_short!` constraint). 
+
+| Event name | Topic(s) | Data (shape & types) | When emitted |
+|---|---|---|---|
+| ProposalCreated | `["proposed", proposal_id: u32]` | `ProposalCreated { proposal_id: u32, proposer: Address, target: Address }` | When `propose` is called successfully. |
+| ProposalApproved | `["approved", proposal_id: u32]` | `ProposalApproved { proposal_id: u32, approver: Address, approval_count: u32 }` | When a co-signer successfully approves a proposal. |
+| QuorumReached | `["quorum", proposal_id: u32]` | `QuorumReached { proposal_id: u32, quorum_reached_at: u64, executable_after: u64 }` | When a proposal reaches the approval threshold. |
+| ProposalCancelled | `["cancelled", proposal_id: u32]` | `ProposalCancelled { proposal_id: u32, canceller: Address }` | When a proposal is cancelled. |
+| ProposalExecuted | `["executed", proposal_id: u32]` | `ProposalExecuted { proposal_id: u32, executor: Address, target: Address, calldata: Bytes }` | When a proposal is executed successfully. |
+| SignerAdded | `["sgnr_add"]` | `SignerAdded { signer: Address }` | When `add_signer` adds a new co-signer. |
+| SignerRemoved | `["sgnr_rm"]` | `SignerRemoved { signer: Address }` | When `remove_signer` successfully removes a co-signer. |
+| AdminChanged | `["adm_chg"]` | `AdminChanged { old: Address, new: Address }` | When the contract admin is rotated. |
+| QuorumConfig | `["quor_cfg"]` | `QuorumConfig { threshold: u32, signer_count: u32 }` | Emitted after `SignerAdded` and `SignerRemoved` to allow indexers to track quorum health and threshold satisfiability. |
+
+---
+
 ## Keeping this doc in sync
 
 This file is derived from `contracts/stream/src/lib.rs` and `contracts/factory/src/lib.rs` emit calls:


### PR DESCRIPTION
Closes #734 
**Title**: feat(governance): emit QuorumConfig event on membership changes

    **Summary**
    This PR resolves an issue where indexers previously had to manually recalculate governance threshold satisfiability on every signer change. We now emit a dedicated
  `QuorumConfig` snapshot event with the required threshold and updated signer count immediately after any membership mutations. 

    **What Changed**
    - Added `QuorumConfig` event struct (`threshold`, `signer_count`).
    - Updated `add_signer` and `remove_signer` to emit `QuorumConfig` after their state updates and respective `SignerAdded` / `SignerRemoved` events (adhering strictly to CEI).
    - Added `test_quorum_config_events_on_membership_changes` inside `lib.rs`'s test suite to assert correct event emission and count boundaries.
    - Updated `docs/events.md` to formally document the `fluxora_governance` contract events, including the new `QuorumConfig`.

    **Key Design Decisions**
    - Reused the existing `threshold` read in `remove_signer` and introduced a single negligible storage read for `get_threshold(&env)?` in `add_signer` to ensure the snapshot is
  entirely self-contained without risking duplicate state logic.

    **Acceptance Criteria Checklist**
    - [x] `QuorumConfig` event emitted on add/remove
    - [x] Payload carries threshold + signer count
    - [x] Emitted after state write (CEI)
    - [x] Snapshot/assertion test added
    - [x] `docs/events.md` updated

    **Test Output & Coverage**
    The changes are strictly tested for event correctness. `cargo test -p fluxora_governance` passes flawlessly, and coverage on `contracts/governance/src/lib.rs` meets the 95%
  threshold.

    **Follow-ups**
    None at this time; this fulfills all requirements for the `QuorumConfig` issue.

    **Security Notes**
    The `QuorumConfig` event exclusively broadcasts numerical values (`u32` for `threshold` and `signer_count`). It deliberately avoids exposing any private signer metadata beyond
  what is inherently public.

