### PR TITLE
feat(factory): add batch cap enforcement view

### DIFF
--- a/contracts/factory/src/lib.rs
+++ b/contracts/factory/src/lib.rs
@@ -727,6 +727,21 @@ impl FluxoraFactory {
             .unwrap_or(false)
     }
 
+    /// Return whether the aggregate batch-cap check is currently enforced.
+    ///
+    /// This permissionless view mirrors the stored `BatchCapEnforced` policy
+    /// flag without requiring callers to decode the full factory config. A
+    /// missing key falls back to the same `true` default written by `init`.
+    pub fn is_batch_cap_enforced(env: Env) -> bool {
+        let enabled = env
+            .storage()
+            .instance()
+            .get(&DataKey::BatchCapEnforced)
+            .unwrap_or(true);
+        bump_instance(&env);
+        enabled
+    }
+
     /// Return the current factory policy configuration.
     pub fn get_factory_config(env: Env) -> Result<FactoryConfig, FactoryError> {
         Ok(FactoryConfig {

--- a/contracts/factory/tests/factory_setters.rs
+++ b/contracts/factory/tests/factory_setters.rs
@@ -698,6 +698,48 @@ fn test_load_policy_reflects_batch_cap_toggle() {
     assert!(load_policy(&env).unwrap().batch_cap_enforced);
 }
 
+/// `is_batch_cap_enforced` exposes the dedicated batch-cap flag view without
+/// requiring callers to decode the full `FactoryConfig` struct.
+#[test]
+fn test_is_batch_cap_enforced_view_tracks_default_and_toggles() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let fid = env.register_contract(None, FluxoraFactory);
+    let factory = FluxoraFactoryClient::new(&env, &fid);
+    let admin = Address::generate(&env);
+    let sc = Address::generate(&env);
+
+    factory.init(&admin, &sc, &10_000, &100);
+    assert!(factory.is_batch_cap_enforced());
+
+    factory.set_batch_cap_enforcement(&false);
+    assert!(!factory.is_batch_cap_enforced());
+
+    factory.set_batch_cap_enforcement(&true);
+    assert!(factory.is_batch_cap_enforced());
+}
+
+/// Calling the dedicated batch-cap view bumps instance TTL, so lightweight
+/// off-chain polling helps keep the config alive just like other policy access.
+#[test]
+fn test_is_batch_cap_enforced_bumps_instance_ttl() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let fid = env.register_contract(None, FluxoraFactory);
+    let factory = FluxoraFactoryClient::new(&env, &fid);
+    let admin = Address::generate(&env);
+    let sc = Address::generate(&env);
+
+    factory.init(&admin, &sc, &10_000, &100);
+    assert!(factory.is_batch_cap_enforced());
+
+    env.ledger().set_sequence_number(env.ledger().sequence() + 10_000);
+    assert!(factory.is_batch_cap_enforced());
+
+    env.ledger().set_sequence_number(env.ledger().sequence() + 10_000);
+    assert_eq!(factory.get_factory_config().batch_cap_enforced, true);
+}
+
 /// `set_factory_paused` flips `creation_paused`, which is the very first
 /// semantic guard after the policy load on both creation paths.
 #[test]


### PR DESCRIPTION
## Summary
- add `is_batch_cap_enforced(env: Env) -> bool` as a dedicated factory view for `DataKey::BatchCapEnforced`
- preserve the `true` fallback that matches the `init` default when the key is absent
- bump instance TTL from the view and cover default/false/true states in factory setter tests

Closes #812

## Validation
- `git diff --check`
- `cargo test -p fluxora_factory factory_setters -- --nocapture` could not run locally because this Windows environment does not have `cargo` installed
- `rustfmt --version` could not run locally because `rustfmt` is not installed in this environment
