### PR TITLE
feat(factory): add rate bounds view

### DIFF
--- a/contracts/factory/src/lib.rs
+++ b/contracts/factory/src/lib.rs
@@ -727,6 +727,19 @@ impl FluxoraFactory {
             .unwrap_or(false)
     }
 
+    /// Return the configured inclusive rate-per-second bounds.
+    ///
+    /// Each side is optional: `None` means that side of the interval is
+    /// unbounded. Missing keys, including before factory initialization, are
+    /// reported as `(None, None)` rather than an initialization error so
+    /// clients can safely preflight rate validation without auth.
+    pub fn get_rate_bounds(env: Env) -> (Option<i128>, Option<i128>) {
+        let min_rate: Option<i128> = env.storage().instance().get(&DataKey::MinRatePerSecond);
+        let max_rate: Option<i128> = env.storage().instance().get(&DataKey::MaxRatePerSecond);
+        bump_instance(&env);
+        (min_rate, max_rate)
+    }
+
     /// Return the current factory policy configuration.
     pub fn get_factory_config(env: Env) -> Result<FactoryConfig, FactoryError> {
         Ok(FactoryConfig {

--- a/contracts/factory/tests/factory_setters.rs
+++ b/contracts/factory/tests/factory_setters.rs
@@ -677,6 +677,94 @@ fn test_load_policy_defaults_rate_bounds_to_none() {
     assert_eq!(policy.max_rate_per_second, None);
 }
 
+/// `get_rate_bounds` is a permissionless preflight view and returns the
+/// permissive `(None, None)` state before initialization or stored bounds.
+#[test]
+fn test_get_rate_bounds_returns_none_none_before_and_after_init() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let fid = env.register_contract(None, FluxoraFactory);
+    let factory = FluxoraFactoryClient::new(&env, &fid);
+
+    assert_eq!(factory.get_rate_bounds(), (None, None));
+
+    let admin = Address::generate(&env);
+    let sc = Address::generate(&env);
+    factory.init(&admin, &sc, &10_000, &100);
+    assert_eq!(factory.get_rate_bounds(), (None, None));
+}
+
+/// `get_rate_bounds` reports a lower bound while preserving an unset upper
+/// bound as `None`.
+#[test]
+fn test_get_rate_bounds_returns_min_only() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let fid = env.register_contract(None, FluxoraFactory);
+    let factory = FluxoraFactoryClient::new(&env, &fid);
+    let admin = Address::generate(&env);
+    let sc = Address::generate(&env);
+
+    factory.init(&admin, &sc, &10_000, &100);
+    factory.set_rate_bounds(&Some(50), &None);
+
+    assert_eq!(factory.get_rate_bounds(), (Some(50), None));
+}
+
+/// `get_rate_bounds` reports an upper bound while preserving an unset lower
+/// bound as `None`.
+#[test]
+fn test_get_rate_bounds_returns_max_only() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let fid = env.register_contract(None, FluxoraFactory);
+    let factory = FluxoraFactoryClient::new(&env, &fid);
+    let admin = Address::generate(&env);
+    let sc = Address::generate(&env);
+
+    factory.init(&admin, &sc, &10_000, &100);
+    factory.set_rate_bounds(&None, &Some(1_000));
+
+    assert_eq!(factory.get_rate_bounds(), (None, Some(1_000)));
+}
+
+/// `get_rate_bounds` reports both inclusive bounds once they are configured.
+#[test]
+fn test_get_rate_bounds_returns_both_bounds() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let fid = env.register_contract(None, FluxoraFactory);
+    let factory = FluxoraFactoryClient::new(&env, &fid);
+    let admin = Address::generate(&env);
+    let sc = Address::generate(&env);
+
+    factory.init(&admin, &sc, &10_000, &100);
+    factory.set_rate_bounds(&Some(50), &Some(1_000));
+
+    assert_eq!(factory.get_rate_bounds(), (Some(50), Some(1_000)));
+}
+
+/// Calling `get_rate_bounds` bumps instance TTL so frequent client preflight
+/// reads keep factory policy storage alive.
+#[test]
+fn test_get_rate_bounds_bumps_instance_ttl() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let fid = env.register_contract(None, FluxoraFactory);
+    let factory = FluxoraFactoryClient::new(&env, &fid);
+    let admin = Address::generate(&env);
+    let sc = Address::generate(&env);
+
+    factory.init(&admin, &sc, &10_000, &100);
+    factory.set_rate_bounds(&Some(50), &Some(1_000));
+
+    env.ledger().set_sequence_number(env.ledger().sequence() + 10_000);
+    assert_eq!(factory.get_rate_bounds(), (Some(50), Some(1_000)));
+
+    env.ledger().set_sequence_number(env.ledger().sequence() + 10_000);
+    assert_eq!(factory.get_factory_config().max_deposit, 10_000);
+}
+
 /// `set_batch_cap_enforcement` flips `batch_cap_enforced` in both directions,
 /// which `load_policy` must surface verbatim for the batch path to honour.
 #[test]


### PR DESCRIPTION
## Summary
- add `get_rate_bounds(env: Env) -> (Option<i128>, Option<i128>)` to expose the factory's optional inclusive rate bounds
- return `(None, None)` when bounds are absent, including before initialization, so clients can safely preflight without auth
- bump instance TTL from the view and cover none/min-only/max-only/both states plus TTL continuity in factory setter tests

Closes #810

## Validation
- `git diff --check`
- `cargo test -p fluxora_factory factory_setters -- --nocapture` could not run locally because this Windows environment does not have `cargo` installed
