### PR TITLE
fix: use saturating_sub for withdrawal frequency check (prevents timestamp underflow bypass)

### DIFF
--- a/contracts/stream/src/lib.rs
+++ b/contracts/stream/src/lib.rs
@@ -2833,11 +2833,12 @@ impl FluxoraStream {
         stream.recipient.require_auth();
 
         // Enforce withdrawal frequency limit to prevent excessive ledger I/O.
-        // Invariant: current_ledger >= last_withdraw_ledger (monotonic ledger progression).
+        // Use saturating_sub to prevent underflow from backward timestamp skew
+        // (if current_ledger < last_withdraw_ledger, elapsed=0, withdrawal blocked).
         // First withdrawal (last_withdraw_ledger == 0) always succeeds.
         let current_ledger = env.ledger().sequence();
         if stream.last_withdraw_ledger != 0
-            && current_ledger - stream.last_withdraw_ledger < MIN_WITHDRAW_INTERVAL_LEDGERS
+            && current_ledger.saturating_sub(stream.last_withdraw_ledger) < MIN_WITHDRAW_INTERVAL_LEDGERS
         {
             return Err(ContractError::WithdrawalTooFrequent);
         }
@@ -3255,9 +3256,9 @@ impl FluxoraStream {
             let current_ledger = env.ledger().sequence();
             // Enforce withdrawal frequency limit per stream in the batch.
             // Each stream must respect its own last_withdraw_ledger independently.
-            // Invariant: current_ledger >= last_withdraw_ledger (monotonic ledger progression).
+            // Use saturating_sub to prevent underflow from backward timestamp skew.
             if stream.last_withdraw_ledger != 0
-                && current_ledger - stream.last_withdraw_ledger < MIN_WITHDRAW_INTERVAL_LEDGERS
+                && current_ledger.saturating_sub(stream.last_withdraw_ledger) < MIN_WITHDRAW_INTERVAL_LEDGERS
             {
                 return Err(ContractError::WithdrawalTooFrequent);
             }
@@ -3557,11 +3558,11 @@ impl FluxoraStream {
         let mut stream = load_stream(&env, stream_id)?;
 
         // 3. Enforce withdrawal frequency limit to prevent excessive ledger I/O.
-        // Invariant: current_ledger >= last_withdraw_ledger (monotonic ledger progression).
+        // Use saturating_sub to prevent underflow from backward timestamp skew.
         // First withdrawal (last_withdraw_ledger == 0) always succeeds.
         let current_ledger = env.ledger().sequence();
         if stream.last_withdraw_ledger != 0
-            && current_ledger - stream.last_withdraw_ledger < MIN_WITHDRAW_INTERVAL_LEDGERS
+            && current_ledger.saturating_sub(stream.last_withdraw_ledger) < MIN_WITHDRAW_INTERVAL_LEDGERS
         {
             return Err(ContractError::WithdrawalTooFrequent);
         }

--- a/contracts/stream/src/lib.rs
+++ b/contracts/stream/src/lib.rs
@@ -2838,7 +2838,8 @@ impl FluxoraStream {
         // First withdrawal (last_withdraw_ledger == 0) always succeeds.
         let current_ledger = env.ledger().sequence();
         if stream.last_withdraw_ledger != 0
-            && current_ledger.saturating_sub(stream.last_withdraw_ledger) < MIN_WITHDRAW_INTERVAL_LEDGERS
+            && current_ledger.saturating_sub(stream.last_withdraw_ledger)
+                < MIN_WITHDRAW_INTERVAL_LEDGERS
         {
             return Err(ContractError::WithdrawalTooFrequent);
         }
@@ -3258,7 +3259,8 @@ impl FluxoraStream {
             // Each stream must respect its own last_withdraw_ledger independently.
             // Use saturating_sub to prevent underflow from backward timestamp skew.
             if stream.last_withdraw_ledger != 0
-                && current_ledger.saturating_sub(stream.last_withdraw_ledger) < MIN_WITHDRAW_INTERVAL_LEDGERS
+                && current_ledger.saturating_sub(stream.last_withdraw_ledger)
+                    < MIN_WITHDRAW_INTERVAL_LEDGERS
             {
                 return Err(ContractError::WithdrawalTooFrequent);
             }
@@ -3562,7 +3564,8 @@ impl FluxoraStream {
         // First withdrawal (last_withdraw_ledger == 0) always succeeds.
         let current_ledger = env.ledger().sequence();
         if stream.last_withdraw_ledger != 0
-            && current_ledger.saturating_sub(stream.last_withdraw_ledger) < MIN_WITHDRAW_INTERVAL_LEDGERS
+            && current_ledger.saturating_sub(stream.last_withdraw_ledger)
+                < MIN_WITHDRAW_INTERVAL_LEDGERS
         {
             return Err(ContractError::WithdrawalTooFrequent);
         }

--- a/contracts/stream/tests/withdrawal_frequency.rs
+++ b/contracts/stream/tests/withdrawal_frequency.rs
@@ -493,3 +493,79 @@ fn test_multiple_streams_independent_rate_limits() {
     let result = ctx.client.withdraw(&stream_id1);
     assert!(result.is_ok());
 }
+
+// ─── Backward timestamp skew test (issue #940) ─────────────────────────────
+
+/// After a withdrawal records `last_withdraw_ledger`, set the ledger to a
+/// timestamp with a sequence number earlier than the recorded value.
+/// This simulates a validator clock anomaly.
+///
+/// Without `saturating_sub`, `current_ledger - last_withdraw_ledger` would
+/// underflow to a huge u32 value, bypassing the frequency limiter.
+/// With `saturating_sub`, the elapsed time is clamped to 0, and the
+/// withdrawal is correctly rejected.
+#[test]
+fn test_backward_timestamp_skew_cannot_bypass_rate_limit() {
+    use soroban_sdk::testutils::{Ledger, LedgerInfo};
+
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, FluxoraStream);
+    let client = FluxoraStreamClient::new(&env, &contract_id);
+
+    let token_id = env
+        .register_stellar_asset_contract_v2(Address::generate(&env))
+        .address();
+
+    let admin = Address::generate(&env);
+    let sender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+
+    client.init(&token_id, &admin);
+
+    // Create a stream: deposit=1000, rate=1/s, no cliff, duration=1000
+    let stream_id = client
+        .create_stream(&sender, &recipient, &1000, &1, &0, &0, &1000, &0, &None)
+        .unwrap();
+
+    // Advance to ledger 100 to accrue tokens
+    let ledger_100 = LedgerInfo {
+        timestamp: 500,
+        protocol_version: 20,
+        sequence_number: 100,
+        network_id: Default::default(),
+        base_reserve: 10,
+        min_temp_entry_ttl: 16,
+        min_persistent_entry_ttl: 16,
+        max_entry_ttl: 6312000,
+    };
+    env.ledger().set(ledger_100);
+
+    // First withdrawal — succeeds, records last_withdraw_ledger = 100
+    let result = client.withdraw(&stream_id).unwrap();
+    assert!(result > 0, "first withdrawal should accrue tokens");
+
+    // ── ATTACK: set ledger backward ──
+    // Simulate a validator clock anomaly: sequence number jumps BACK
+    // from 100 to 50 (earlier than the recorded last_withdraw_ledger).
+    let ledger_backward = LedgerInfo {
+        timestamp: 250, // earlier timestamp too
+        protocol_version: 20,
+        sequence_number: 50, // < last_withdraw_ledger (100)
+        network_id: Default::default(),
+        base_reserve: 10,
+        min_temp_entry_ttl: 16,
+        min_persistent_entry_ttl: 16,
+        max_entry_ttl: 6312000,
+    };
+    env.ledger().set(ledger_backward);
+
+    // With `saturating_sub`: elapsed = 50 - 100 = 0 (clamped)
+    // 0 < MIN_WITHDRAW_INTERVAL_LEDGERS → withdrawal REJECTED
+    // Without the fix: 50 - 100 would underflow to 4294967246,
+    // which is >> MIN_WITHDRAW_INTERVAL_LEDGERS → withdrawal ALLOWED (vuln)
+    let result = client.try_withdraw(&stream_id);
+    assert_eq!(result, Err(Ok(ContractError::WithdrawalTooFrequent)),
+        "backward timestamp skew must NOT bypass rate limit");
+}

--- a/contracts/stream/tests/withdrawal_frequency.rs
+++ b/contracts/stream/tests/withdrawal_frequency.rs
@@ -526,7 +526,15 @@ fn test_backward_timestamp_skew_cannot_bypass_rate_limit() {
 
     // Create a stream: deposit=1000, rate=1/s, no cliff, duration=1000
     let stream_id = client.create_stream(
-        &sender, &recipient, &1000, &1, &0, &0, &1000, &0, &None,
+        &sender,
+        &recipient,
+        &1000,
+        &1,
+        &0,
+        &0,
+        &1000,
+        &0,
+        &None,
         &StreamKind::Linear,
     );
     assert!(stream_id > 0, "stream should be created");
@@ -567,6 +575,9 @@ fn test_backward_timestamp_skew_cannot_bypass_rate_limit() {
     // Without the fix: 50 - 100 would underflow to 4294967246,
     // which is >> MIN_WITHDRAW_INTERVAL_LEDGERS → withdrawal ALLOWED (vuln)
     let result = client.try_withdraw(&stream_id);
-    assert_eq!(result, Err(Ok(ContractError::WithdrawalTooFrequent)),
-        "backward timestamp skew must NOT bypass rate limit");
+    assert_eq!(
+        result,
+        Err(Ok(ContractError::WithdrawalTooFrequent)),
+        "backward timestamp skew must NOT bypass rate limit"
+    );
 }

--- a/contracts/stream/tests/withdrawal_frequency.rs
+++ b/contracts/stream/tests/withdrawal_frequency.rs
@@ -1,7 +1,7 @@
 #![cfg(test)]
 extern crate std;
 
-use fluxora_stream::{ContractError, FluxoraStream, FluxoraStreamClient};
+use fluxora_stream::{ContractError, FluxoraStream, FluxoraStreamClient, StreamKind};
 use soroban_sdk::{
     testutils::{Address as _, Ledger, LedgerInfo},
     token::Client as TokenClient,
@@ -525,10 +525,11 @@ fn test_backward_timestamp_skew_cannot_bypass_rate_limit() {
     client.init(&token_id, &admin);
 
     // Create a stream: deposit=1000, rate=1/s, no cliff, duration=1000
-    let stream_id = client
-        .create_stream(&sender, &recipient, &1000, &1, &0, &0, &1000, &0, &None)
-        .unwrap();
-
+    let stream_id = client.create_stream(
+        &sender, &recipient, &1000, &1, &0, &0, &1000, &0, &None,
+        &StreamKind::Linear,
+    );
+    assert!(stream_id > 0, "stream should be created");
     // Advance to ledger 100 to accrue tokens
     let ledger_100 = LedgerInfo {
         timestamp: 500,
@@ -543,7 +544,7 @@ fn test_backward_timestamp_skew_cannot_bypass_rate_limit() {
     env.ledger().set(ledger_100);
 
     // First withdrawal — succeeds, records last_withdraw_ledger = 100
-    let result = client.withdraw(&stream_id).unwrap();
+    let result = client.withdraw(&stream_id);
     assert!(result > 0, "first withdrawal should accrue tokens");
 
     // ── ATTACK: set ledger backward ──


### PR DESCRIPTION
## Summary

Fixes #940 — backward timestamp skew bypass of withdrawal rate limit.

### Vulnerability

All 3 withdrawal paths (`withdraw`, `batch_withdraw`, `delegated_withdraw`) used raw `current_ledger - last_withdraw_ledger` (u32) to compute elapsed ledgers since the last withdrawal. If a validator clock anomaly sets `current_ledger < last_withdraw_ledger`, the subtraction underflows to a huge value (e.g. `50 - 100 = 4294967246`), bypassing the `MIN_WITHDRAW_INTERVAL_LEDGERS` check entirely.

### Fix

Replaced raw subtraction with `saturating_sub` in all 3 paths. On backward skew, `saturating_sub` returns 0, which is blocked by `MIN_WITHDRAW_INTERVAL_LEDGERS` — correctly treating the anomaly as "no time elapsed."

### Test

Added `test_backward_timestamp_skew_cannot_bypass_rate_limit`:
1. Perform a withdrawal at ledger 100
2. Set ledger backward to sequence 50
3. Attempt another withdrawal → assert `WithdrawalTooFrequent`

Without the fix this test would pass (underflow bypass), confirming the vulnerability.

### Changes
- `contracts/stream/src/lib.rs`: 3x `-` → `saturating_sub`
- `contracts/stream/tests/withdrawal_frequency.rs`: +1 test