### PR TITLE
fix(recommendations): count only completed sessions

### DIFF
--- a/backend/src/services/recommendation.service.ts
+++ b/backend/src/services/recommendation.service.ts
@@ -1,7 +1,7 @@
 import { AppDataSource } from '../config/database';
 import { User, UserRole } from '../models/User';
 import { Mentor, MentorPublicProfile } from '../models/Mentor';
-import { Session } from '../models/Session';
+import { Session, SessionStatus } from '../models/Session';
 import { RecommendationEvent, EventType, ScoreBreakdown } from '../models/RecommendationEvent';
 import { NotFoundError } from '../utils/errors';
 import cache from '../utils/cache';
@@ -232,7 +232,7 @@ export class RecommendationService {
     });
     const dismissedIds = dismissedMentors.map((e: RecommendationEvent) => e.mentorId);
 
-    // Build query with session count subquery
+    // Only completed sessions represent prior engagement for the session cap.
     const query = this.mentorRepository
       .createQueryBuilder('mentor')
       .leftJoin(
@@ -241,6 +241,9 @@ export class RecommendationService {
           .select('session.mentorId', 'mentorId')
           .addSelect('COUNT(*)', 'sessionCount')
           .where('session.learnerId = :learnerId', { learnerId })
+          .andWhere('session.status = :completedStatus', {
+            completedStatus: SessionStatus.COMPLETED
+          })
           .groupBy('session.mentorId'),
         'sessions',
         'sessions.mentorId = mentor.id'

--- a/backend/tests/services/recommendation.service.test.ts
+++ b/backend/tests/services/recommendation.service.test.ts
@@ -3,6 +3,7 @@
  */
 
 import { EventType, RecommendationEvent } from '../../src/models/RecommendationEvent';
+import { SessionStatus } from '../../src/models/Session';
 import { UserRole } from '../../src/models/User';
 import { NotFoundError } from '../../src/utils/errors';
 
@@ -200,6 +201,49 @@ describe('RecommendationService', () => {
   describe('getRecommendations', () => {
     const learnerId = '11111111-1111-1111-1111-111111111111';
 
+    const setUpPriorSessionCount = (sessionCount: string, mentorId: string) => {
+      mockUserRepository.findOne.mockResolvedValueOnce({
+        id: learnerId,
+        role: UserRole.LEARNER,
+        goals: ['TypeScript'],
+        skillGaps: [],
+        budget: 100,
+        pricePreference: 'standard'
+      });
+      mockEventRepository.find.mockResolvedValueOnce([]);
+
+      const mockQueryBuilder = {
+        leftJoin: jest.fn(),
+        from: jest.fn().mockReturnThis(),
+        select: jest.fn().mockReturnThis(),
+        addSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        groupBy: jest.fn().mockReturnThis(),
+        getRawAndEntities: jest.fn().mockResolvedValueOnce({
+          entities: [{
+            id: mentorId,
+            skills: ['TypeScript'],
+            averageRating: 4.8,
+            hourlyRate: 80,
+            isAvailable: true,
+            availabilitySlots: ['slot1'],
+            availabilityCount: 1
+          }],
+          raw: [{ sessionCount }]
+        })
+      };
+      mockQueryBuilder.leftJoin.mockImplementation((subqueryFactory: (queryBuilder: any) => unknown) => {
+        subqueryFactory(mockQueryBuilder);
+        return mockQueryBuilder;
+      });
+
+      mockMentorRepository.createQueryBuilder.mockReturnValue(mockQueryBuilder);
+      mockEventRepository.save.mockResolvedValue([]);
+
+      return mockQueryBuilder;
+    };
+
     it('returns cached result on cache hit', async () => {
       const cached = {
         recommendations: [],
@@ -296,6 +340,28 @@ describe('RecommendationService', () => {
       // mentor-4 is filtered out due to max prior sessions
       expect(result.recommendations.length).toBe(3);
       expect(result.recommendations[0].rank).toBe(1);
+    });
+
+    it('counts only completed sessions so cancelled-only histories remain eligible', async () => {
+      const mockQueryBuilder = setUpPriorSessionCount('0', 'cancelled-only-mentor');
+
+      const result = await service.getRecommendations(learnerId);
+
+      expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
+        'session.status = :completedStatus',
+        { completedStatus: SessionStatus.COMPLETED }
+      );
+      expect(result.recommendations.map(recommendation => recommendation.mentorId))
+        .toContain('cancelled-only-mentor');
+    });
+
+    it('still excludes mentors at the completed-session cap', async () => {
+      setUpPriorSessionCount('3', 'completed-history-mentor');
+
+      const result = await service.getRecommendations(learnerId);
+
+      expect(result.recommendations.map(recommendation => recommendation.mentorId))
+        .not.toContain('completed-history-mentor');
     });
 
     it('handles learner without goals/skillGaps and pricePreference strings', async () => {


### PR DESCRIPTION
## Summary
- count only `SessionStatus.COMPLETED` rows toward the prior-session recommendation cap
- document that the cap represents substantive completed engagement
- add focused regression coverage for cancelled-only eligibility and completed-session exclusion

Closes #976

## Testing
- `npm test -- --runTestsByPath tests/services/recommendation.service.test.ts` (15/15 passed)
- `git diff --check` (passed)
- Upstream CI: Docs Alignment Check, Lint, Build, and Test pass
- Upstream Code Coverage is red on the same pre-existing Rust failure as the current `main` push ([main run](https://github.com/Fluxora-Org/Fluxora-Contracts/actions/runs/29858751251), [PR run](https://github.com/Fluxora-Org/Fluxora-Contracts/actions/runs/29860036937)): Tarpaulin compiles `fluxora_governance` and fails because `__set_threshold` is generated twice at `contracts/governance/src/lib.rs:532`; this PR changes only backend TypeScript
- Local `npm test` ran 66 passing tests across four suites; two pre-existing websocket suites fail TypeScript compilation because `ws` is absent and callback parameters are implicitly `any`
- Local `npm run test:coverage` reports the changed service at 98.14% statements and 98.11% lines; the repository-wide 95% gate remains blocked by existing untested modules plus the websocket/type errors
- Local `npm run build` is blocked by existing unused-parameter, Redis overload, and missing-`ws` TypeScript errors outside this change