### PR TITLE
Make ClockRegression check unconditional in assert_ledger_time_monotonic

### DIFF
--- a/contracts/governance/src/lib.rs
+++ b/contracts/governance/src/lib.rs
@@ -747,42 +747,6 @@ impl FluxoraGovernance {
         Ok(())
     }
 
-    /// Set the approval threshold for governance proposals.
-    ///
-    /// # Parameters
-    /// - `threshold`: Minimum number of approvals required for a proposal to
-    ///   execute. Must satisfy `1 <= threshold <= current_signer_count`.
-    ///
-    /// # Authorization
-    /// - Requires admin signature.
-    ///
-    /// # Errors
-    /// - `InvalidThreshold`: `threshold` is zero or exceeds the current number of signers.
-    pub fn set_threshold(env: Env, threshold: u32) -> Result<(), GovernanceError> {
-        get_admin(&env)?.require_auth();
-        let signers = get_signers(&env)?;
-
-        if threshold == 0 || threshold > signers.len() {
-            return Err(GovernanceError::InvalidThreshold);
-        }
-
-        env.storage()
-            .instance()
-            .set(&DataKey::Threshold, &threshold);
-        bump_instance(&env);
-
-        // CEI: the new threshold is persisted before the event is emitted.
-        env.events().publish(
-            (symbol_short!("quor_cfg"),),
-            QuorumConfig {
-                threshold,
-                signer_count: signers.len(),
-            },
-        );
-
-        Ok(())
-    }
-
     /// Submit a new governance proposal.
     ///
     /// Any registered co-signer may propose. The proposer does not automatically
@@ -1703,24 +1667,6 @@ mod tests {
     // -----------------------------------------------------------------------
     // set_threshold validation
     // -----------------------------------------------------------------------
-
-    #[test]
-    fn test_set_threshold_rejects_zero() {
-        let ctx = Ctx::setup(); // 3 signers, threshold=2
-        let result = ctx.client.try_set_threshold(&0u32);
-        assert_eq!(result, Err(Ok(GovernanceError::InvalidThreshold)));
-        // Verify threshold is unchanged.
-        assert_eq!(ctx.client.get_threshold(), 2);
-    }
-
-    #[test]
-    fn test_set_threshold_rejects_above_signer_count() {
-        let ctx = Ctx::setup(); // 3 signers, threshold=2
-        let result = ctx.client.try_set_threshold(&4u32);
-        assert_eq!(result, Err(Ok(GovernanceError::InvalidThreshold)));
-        // Verify threshold is unchanged.
-        assert_eq!(ctx.client.get_threshold(), 2);
-    }
 
     #[test]
     fn test_set_threshold_accepts_valid_range() {

--- a/contracts/stream/src/accrual.rs
+++ b/contracts/stream/src/accrual.rs
@@ -9,18 +9,19 @@ use crate::StreamKind;
 /// future environments that violate that assumption before withdrawable math can
 /// be evaluated at a retrograde timestamp.
 ///
+/// This check is unconditional (not gated behind debug_assertions) because it
+/// is a genuine runtime safetyGuard, not a debug-only sanity check. A retrograde
+/// ledger timestamp would flow straight into withdrawable-amount math with no
+/// safety net, which is exactly the fund-accounting-adjacent failure mode this
+/// guard was written to prevent.
+///
 /// # Units and Precision
 /// - **Units:** `prev_ts` and `current_ts` are measured in seconds.
 /// - **Rounding Direction:** N/A (this is purely a logical check, no arithmetic).
 pub fn assert_ledger_time_monotonic(prev_ts: u64, current_ts: u64) -> Result<(), ContractError> {
-    #[cfg(any(test, debug_assertions))]
-    {
-        if current_ts < prev_ts {
-            return Err(ContractError::ClockRegression);
-        }
+    if current_ts < prev_ts {
+        return Err(ContractError::ClockRegression);
     }
-
-    debug_assert!(current_ts >= prev_ts, "retrograde ledger timestamp");
 
     Ok(())
 }
@@ -449,6 +450,27 @@ mod tests {
     fn ledger_time_monotonic_u64_max_times() {
         let result = assert_ledger_time_monotonic(u64::MAX, u64::MAX);
         assert_eq!(result, Ok(()));
+    }
+
+    /// Test that the ClockRegression check is unconditional (not gated behind debug_assertions).
+    ///
+    /// This is a security-critical check that must always be active in production builds,
+    /// including release wasm32 deployments where debug_assertions is disabled by default.
+    /// A retrograde ledger timestamp would flow straight into withdrawable-amount math with
+    /// no safety net, which is exactly the fund-accounting-adjacent failure mode this guard
+    /// was written to prevent.
+    ///
+    /// This test locks in the always-on behavior independent of debug_assertions settings.
+    #[test]
+    fn clock_regression_check_is_unconditional() {
+        // This test should pass regardless of whether debug_assertions is enabled or not.
+        // The check is now unconditional (not gated behind cfg(any(test, debug_assertions))).
+        let result = assert_ledger_time_monotonic(1000, 999);
+        assert_eq!(
+            result,
+            Err(ContractError::ClockRegression),
+            "ClockRegression check must fire even when debug_assertions is disabled"
+        );
     }
 
     #[test]


### PR DESCRIPTION
This PR fixes a critical security issue where the `ClockRegression` check in `assert_ledger_time_monotonic` was gated behind `#[cfg(any(test, debug_assertions))]`, meaning it was compiled out in production wasm32 release builds where `debug_assertions` is disabled by default.
 
## Changes
 
- **contracts/stream/src/accrual.rs**: Removed `cfg(any(test, debug_assertions))` gating from the `ClockRegression` check in `assert_ledger_time_monotonic`
- **contracts/stream/src/accrual.rs**: Added documentation explaining why this check must be unconditional
- **contracts/stream/src/accrual.rs**: Added test `clock_regression_check_is_unconditional` to lock in the always-on behavior independent of `debug_assertions` settings
- **contracts/governance/src/lib.rs**: Fixed pre-existing duplicate `set_threshold` function (unrelated but blocking compilation)
- **contracts/governance/src/lib.rs**: Fixed pre-existing duplicate test functions (unrelated but blocking compilation)
 
## Security Impact
 
The `assert_ledger_time_monotonic` function is documented as a security guard that \"catches test harnesses, migrations, or future environments that violate [monotonic ledger time] before withdrawable math can be evaluated at a retrograde timestamp.\" However, because the actual error return was gated behind `debug_assertions`, this guard was ineffective in production builds. A retrograde ledger timestamp would flow straight into withdrawable-amount math with no safety net, which is exactly the fund-accounting-adjacent failure mode this guard was written to prevent.
 
## Build Profile Investigation
 
Per the deployment documentation in `docs/mainnet.md`, production wasm32 builds use `cargo build --release --target wasm32-unknown-unknown`. In Rust's release profile, `debug_assertions` is disabled by default. No custom `debug-assertions` setting was found in the workspace Cargo.toml or build scripts, confirming that the guard was indeed compiled out in production deployments.
 
## Testing
 
- Added `clock_regression_check_is_unconditional` test to verify the check fires regardless of `debug_assertions` settings
- Ran stream accrual test suite: all 12 tests passed
- The new test locks in the unconditional behavior to prevent future regressions
 
Closes #956