### PR TITLE
test(stream): dust-threshold intersection tests for batch_withdraw_to (#953)

### DIFF
--- a/contracts/stream/tests/batch_withdraw_to_auth.rs
+++ b/contracts/stream/tests/batch_withdraw_to_auth.rs
@@ -376,3 +376,173 @@ fn test_batch_withdraw_to_rejects_contract_destination() {
     );
     assert_eq!(ctx.token.balance(&ctx.contract_id), 1000);
 }
+
+// ---------------------------------------------------------------------------
+// Dust-threshold interaction with batch_withdraw_to (issue #955)
+// ---------------------------------------------------------------------------
+
+/// Mixed dust-blocked and non-dust-blocked streams in the same batch.
+/// The dust-blocked entry must produce amount=0 and no state change/token
+/// transfer, while the non-dust-blocked entry transfers its withdrawable.
+#[test]
+fn test_batch_withdraw_to_mixed_dust_and_non_dust() {
+    let ctx = TestContext::setup();
+    ctx.env.ledger().set_timestamp(0);
+
+    // Two streams, same recipient, different dust thresholds:
+    //
+    //   Stream A: deposit=1000, threshold=100,  rate=1, end=1000
+    //     at ts=500 → withdrawable=500, 500 >= 100 → NOT dust-blocked
+    //
+    //   Stream B: deposit=1000, threshold=600,  rate=1, end=1000
+    //     at ts=500 → withdrawable=500, 500 < 600 → dust-blocked
+    let stream_id_a = ctx.client().create_stream(
+        &ctx.sender,
+        &ctx.recipient,
+        &1000_i128,
+        &1_i128,
+        &0u64,
+        &0u64,
+        &1000u64,
+        &100,    // low dust threshold
+        &None,
+        &StreamKind::Linear,
+    );
+    let stream_id_b = ctx.client().create_stream(
+        &ctx.sender,
+        &ctx.recipient,
+        &1000_i128,
+        &1_i128,
+        &0u64,
+        &0u64,
+        &1000u64,
+        &600,   // high dust threshold
+        &None,
+        &StreamKind::Linear,
+    );
+
+    ctx.env.ledger().set_timestamp(500);
+    let dest_a = Address::generate(&ctx.env);
+    let dest_b = Address::generate(&ctx.env);
+    let withdrawals = soroban_sdk::vec![
+        &ctx.env,
+        WithdrawToParam {
+            stream_id: stream_id_a,
+            destination: dest_a.clone(),
+        },
+        WithdrawToParam {
+            stream_id: stream_id_b,
+            destination: dest_b.clone(),
+        },
+    ];
+
+    let results = ctx
+        .client()
+        .batch_withdraw_to(&ctx.recipient, &withdrawals);
+
+    assert_eq!(results.len(), 2);
+    assert_eq!(
+        results.get(0).unwrap().amount,
+        500,
+        "non-dust stream must transfer full withdrawable"
+    );
+    assert_eq!(
+        results.get(1).unwrap().amount,
+        0,
+        "dust-blocked stream must return amount 0"
+    );
+
+    // Token balance assertions
+    assert_eq!(ctx.token.balance(&dest_a), 500);
+    assert_eq!(ctx.token.balance(&dest_b), 0);
+
+    // State change: only stream A had its withdrawn_amount updated
+    assert_eq!(
+        ctx.client().get_stream_state(&stream_id_a).withdrawn_amount,
+        500
+    );
+    assert_eq!(
+        ctx.client().get_stream_state(&stream_id_b).withdrawn_amount,
+        0,
+        "dust-blocked stream must not mutate withdrawn_amount"
+    );
+}
+
+/// Every entry in the batch is dust-blocked — the call still succeeds
+/// as a no-op (transfers zero, no state mutations, no error).
+#[test]
+fn test_batch_withdraw_to_all_dust_blocked_is_no_op() {
+    let ctx = TestContext::setup();
+    ctx.env.ledger().set_timestamp(0);
+
+    // Two streams both with high thresholds so all entries are dust-blocked.
+    let stream_id_a = ctx.client().create_stream(
+        &ctx.sender,
+        &ctx.recipient,
+        &1000_i128,
+        &1_i128,
+        &0u64,
+        &0u64,
+        &1000u64,
+        &600,
+        &None,
+        &StreamKind::Linear,
+    );
+    let stream_id_b = ctx.client().create_stream(
+        &ctx.sender,
+        &ctx.recipient,
+        &1000_i128,
+        &1_i128,
+        &0u64,
+        &0u64,
+        &1000u64,
+        &700,
+        &None,
+        &StreamKind::Linear,
+    );
+
+    ctx.env.ledger().set_timestamp(500);
+    let dest_a = Address::generate(&ctx.env);
+    let dest_b = Address::generate(&ctx.env);
+    let withdrawals = soroban_sdk::vec![
+        &ctx.env,
+        WithdrawToParam {
+            stream_id: stream_id_a,
+            destination: dest_a.clone(),
+        },
+        WithdrawToParam {
+            stream_id: stream_id_b,
+            destination: dest_b.clone(),
+        },
+    ];
+
+    let results = ctx
+        .client()
+        .batch_withdraw_to(&ctx.recipient, &withdrawals);
+
+    assert_eq!(results.len(), 2);
+    assert_eq!(
+        results.get(0).unwrap().amount,
+        0,
+        "dust-blocked stream A must return amount 0"
+    );
+    assert_eq!(
+        results.get(1).unwrap().amount,
+        0,
+        "dust-blocked stream B must return amount 0"
+    );
+
+    // No tokens transferred
+    assert_eq!(ctx.token.balance(&dest_a), 0);
+    assert_eq!(ctx.token.balance(&dest_b), 0);
+
+    // No state mutations
+    assert_eq!(
+        ctx.client().get_stream_state(&stream_id_a).withdrawn_amount,
+        0
+    );
+    assert_eq!(
+        ctx.client().get_stream_state(&stream_id_b).withdrawn_amount,
+        0
+    );
+}


### PR DESCRIPTION
## Summary

Add two tests verifying that batch_withdraw_to correctly handles the dust threshold on a per-stream basis — dust-blocked entries return amount 0 without erroring or reverting the batch.

No production code changes were needed. The dust enforcement logic is already identical across all four withdrawal entry points (withdraw, withdraw_to, batch_withdraw, batch_withdraw_to).

## Changes

### contracts/stream/tests/batch_withdraw_to_auth.rs
- test_batch_withdraw_to_mixed_dust_and_non_dust — one stream above threshold (transfers 500), one below (amount 0, no state change, no token transfer).
- test_batch_withdraw_to_all_dust_blocked_is_no_op — every entry dust-blocked; the batch succeeds as a no-op rather than erroring.

## Verification
- All 6 batch_withdraw_to_auth tests pass.
- All 9 dust_threshold tests pass.
- Zero compilation warnings.

Closes #953