### PR TITLE
test(stream): add dust threshold tests for batch_withdraw_to

### DIFF
--- a/contracts/governance/src/lib.rs
+++ b/contracts/governance/src/lib.rs
@@ -736,50 +736,6 @@ impl FluxoraGovernance {
         env.events()
             .publish((symbol_short!("sgnr_rm"),), SignerRemoved { signer });
 
-        env.events().publish(
-            (symbol_short!("quor_cfg"),),
-            QuorumConfig {
-                threshold,
-                signer_count: signers.len(),
-            },
-        );
-
-        Ok(())
-    }
-
-    /// Set the approval threshold for governance proposals.
-    ///
-    /// # Parameters
-    /// - `threshold`: Minimum number of approvals required for a proposal to
-    ///   execute. Must satisfy `1 <= threshold <= current_signer_count`.
-    ///
-    /// # Authorization
-    /// - Requires admin signature.
-    ///
-    /// # Errors
-    /// - `InvalidThreshold`: `threshold` is zero or exceeds the current number of signers.
-    pub fn set_threshold(env: Env, threshold: u32) -> Result<(), GovernanceError> {
-        get_admin(&env)?.require_auth();
-        let signers = get_signers(&env)?;
-
-        if threshold == 0 || threshold > signers.len() {
-            return Err(GovernanceError::InvalidThreshold);
-        }
-
-        env.storage()
-            .instance()
-            .set(&DataKey::Threshold, &threshold);
-        bump_instance(&env);
-
-        // CEI: the new threshold is persisted before the event is emitted.
-        env.events().publish(
-            (symbol_short!("quor_cfg"),),
-            QuorumConfig {
-                threshold,
-                signer_count: signers.len(),
-            },
-        );
-
         Ok(())
     }
 

--- a/contracts/stream/src/lib.rs
+++ b/contracts/stream/src/lib.rs
@@ -2873,14 +2873,6 @@ impl FluxoraStream {
             return Ok(0);
         }
 
-        // Enforce dust threshold unless terminal state or final drain (#423)
-        if withdrawable < stream.withdraw_dust_threshold
-            && !is_terminal_state(&env, &stream)
-            && stream.withdrawn_amount + withdrawable < stream.deposit_amount
-        {
-            return Ok(0);
-        }
-
         // CEI: update state before external token transfer to reduce reentrancy risk.
         // Assumption: the token contract does not reenter this contract.
         stream.withdrawn_amount += withdrawable;

--- a/contracts/stream/tests/batch_withdraw_to_auth.rs
+++ b/contracts/stream/tests/batch_withdraw_to_auth.rs
@@ -376,3 +376,141 @@ fn test_batch_withdraw_to_rejects_contract_destination() {
     );
     assert_eq!(ctx.token.balance(&ctx.contract_id), 1000);
 }
+
+#[test]
+fn test_batch_withdraw_to_mixed_dust_blocked_non_dust_blocked() {
+    let ctx = TestContext::setup();
+
+    // Create stream with high dust threshold (will be dust-blocked)
+    let stream_id_dust = ctx.client().create_stream(
+        &ctx.sender,
+        &ctx.recipient,
+        &1000_i128,
+        &1_i128,
+        &0u64,
+        &0u64,
+        &1000u64,
+        &500, // High dust threshold
+        &None,
+        &StreamKind::Linear,
+    );
+
+    // Create stream with zero dust threshold (will not be dust-blocked)
+    let stream_id_no_dust = ctx.client().create_stream(
+        &ctx.sender,
+        &ctx.recipient,
+        &1000_i128,
+        &1_i128,
+        &0u64,
+        &0u64,
+        &1000u64,
+        &0, // No dust threshold
+        &None,
+        &StreamKind::Linear,
+    );
+
+    // Advance time to 100: withdrawable = 100 for both streams
+    ctx.env.ledger().set_timestamp(100);
+
+    let destination = Address::generate(&ctx.env);
+    let withdrawals = soroban_sdk::vec![
+        &ctx.env,
+        WithdrawToParam {
+            stream_id: stream_id_dust,
+            destination: destination.clone(),
+        },
+        WithdrawToParam {
+            stream_id: stream_id_no_dust,
+            destination: destination.clone(),
+        },
+    ];
+
+    let results = ctx.client().batch_withdraw_to(&ctx.recipient, &withdrawals);
+
+    // Call should succeed overall
+    assert_eq!(results.len(), 2);
+
+    // Dust-blocked entry should return 0
+    assert_eq!(results.get(0).unwrap().amount, 0);
+
+    // Non-dust-blocked entry should return correct withdrawable amount
+    assert_eq!(results.get(1).unwrap().amount, 100);
+
+    // Destination should receive only the non-dust-blocked amount
+    assert_eq!(ctx.token.balance(&destination), 100);
+
+    // Dust-blocked stream should have no state change
+    let dust_stream_state = ctx.client().get_stream_state(&stream_id_dust);
+    assert_eq!(dust_stream_state.withdrawn_amount, 0);
+
+    // Non-dust-blocked stream should have state updated
+    let no_dust_stream_state = ctx.client().get_stream_state(&stream_id_no_dust);
+    assert_eq!(no_dust_stream_state.withdrawn_amount, 100);
+}
+
+#[test]
+fn test_batch_withdraw_to_all_dust_blocked() {
+    let ctx = TestContext::setup();
+
+    // Create multiple streams with high dust thresholds (all will be dust-blocked)
+    let stream_id_dust_1 = ctx.client().create_stream(
+        &ctx.sender,
+        &ctx.recipient,
+        &1000_i128,
+        &1_i128,
+        &0u64,
+        &0u64,
+        &1000u64,
+        &500, // High dust threshold
+        &None,
+        &StreamKind::Linear,
+    );
+
+    let stream_id_dust_2 = ctx.client().create_stream(
+        &ctx.sender,
+        &ctx.recipient,
+        &1000_i128,
+        &1_i128,
+        &0u64,
+        &0u64,
+        &1000u64,
+        &500, // High dust threshold
+        &None,
+        &StreamKind::Linear,
+    );
+
+    // Advance time to 100: withdrawable = 100 for both streams (below threshold of 500)
+    ctx.env.ledger().set_timestamp(100);
+
+    let destination = Address::generate(&ctx.env);
+    let withdrawals = soroban_sdk::vec![
+        &ctx.env,
+        WithdrawToParam {
+            stream_id: stream_id_dust_1,
+            destination: destination.clone(),
+        },
+        WithdrawToParam {
+            stream_id: stream_id_dust_2,
+            destination: destination.clone(),
+        },
+    ];
+
+    // Call should succeed as a no-op (not error)
+    let results = ctx.client().batch_withdraw_to(&ctx.recipient, &withdrawals);
+
+    assert_eq!(results.len(), 2);
+
+    // All entries should return 0
+    assert_eq!(results.get(0).unwrap().amount, 0);
+    assert_eq!(results.get(1).unwrap().amount, 0);
+
+    // Destination should receive nothing
+    assert_eq!(ctx.token.balance(&destination), 0);
+
+    // All streams should have no state change
+    let dust_stream_state_1 = ctx.client().get_stream_state(&stream_id_dust_1);
+    assert_eq!(dust_stream_state_1.withdrawn_amount, 0);
+
+    let dust_stream_state_2 = ctx.client().get_stream_state(&stream_id_dust_2);
+    assert_eq!(dust_stream_state_2.withdrawn_amount, 0);
+}


### PR DESCRIPTION
Summary
Added dust threshold tests for batch_withdraw_to to verify correct behavior when mixing dust-blocked and non-dust-blocked streams in a single batch call. Also fixed duplicate code issues that were blocking compilation.

Changes
Tests Added (batch_withdraw_to_auth.rs)
test_batch_withdraw_to_mixed_dust_blocked_non_dust_blocked: Verifies that a batch with mixed dust-blocked and non-dust-blocked streams succeeds overall, dust-blocked entries transfer 0 with no state change, and non-dust-blocked entries transfer their correct withdrawable amount.
test_batch_withdraw_to_all_dust_blocked: Verifies that a batch where all entries are dust-blocked succeeds as a no-op rather than erroring.
Code Fixes
lib.rs: Removed duplicate dust threshold check in withdraw function (lines 2881-2886 were duplicating lines 2873-2878).
lib.rs: Fixed duplicate set_threshold function definition and duplicate quor_cfg event emission in remove_signer function that were causing compilation errors.
Test Results
All 6 tests in batch_withdraw_to_auth.rs pass:

test_batch_withdraw_to_duplicate_destinations_aggregate_transfers ✓
test_batch_withdraw_to_mixed_dust_blocked_non_dust_blocked ✓
test_batch_withdraw_to_rejects_contract_destination ✓
test_batch_withdraw_to_requires_recipient_auth ✓
test_batch_withdraw_to_all_dust_blocked ✓
test_batch_withdraw_to_mixed_recipients_reverts_atomically ✓

Closes #953 