### PR TITLE
feat: implement real subscriber stats and stream cleanup in WebSocketHub

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -21,7 +21,8 @@
         "pg": "^8.11.3",
         "typeorm": "^0.3.17",
         "uuid": "^9.0.1",
-        "winston": "^3.11.0"
+        "winston": "^3.11.0",
+        "ws": "8.18.0"
       },
       "devDependencies": {
         "@types/bcrypt": "^5.0.2",
@@ -32,6 +33,7 @@
         "@types/node": "^20.10.0",
         "@types/supertest": "^6.0.3",
         "@types/uuid": "^9.0.7",
+        "@types/ws": "8.5.14",
         "jest": "^29.7.0",
         "supertest": "^6.3.4",
         "ts-jest": "^29.4.9",
@@ -1573,6 +1575,16 @@
       "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.15.10.tgz",
       "integrity": "sha512-T8L6i7wCuyoK8A/ZeLYt1+q0ty3Zb9+qbSSvrIVitzT3YjZqkTZ40IbRsPanlB4h1QB3JVL1SYCdR6ngtFYcuA==",
       "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.14.tgz",
+      "integrity": "sha512-bd/YFLW+URhBzMXurx7lWByOu+xzU9+kb3RboOteXYDfW+tr+JZa99OyNmPINEGB/ahzKrEuc8rcv4gnpJmxTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/yargs": {
       "version": "17.0.35",
@@ -7283,6 +7295,27 @@
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/xtend": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -25,7 +25,8 @@
     "pg": "^8.11.3",
     "typeorm": "^0.3.17",
     "uuid": "^9.0.1",
-    "winston": "^3.11.0"
+    "winston": "^3.11.0",
+    "ws": "8.18.0"
   },
   "devDependencies": {
     "@types/bcrypt": "^5.0.2",
@@ -36,6 +37,7 @@
     "@types/node": "^20.10.0",
     "@types/supertest": "^6.0.3",
     "@types/uuid": "^9.0.7",
+    "@types/ws": "8.5.14",
     "jest": "^29.7.0",
     "supertest": "^6.3.4",
     "ts-jest": "^29.4.9",

--- a/backend/src/websockets/streamChannel.ts
+++ b/backend/src/websockets/streamChannel.ts
@@ -106,20 +106,25 @@ export class StreamChannel {
   }
 
   /**
-   * Get subscription statistics for a stream
+   * Get subscription statistics for a stream.
+   * Returns the real, current subscriber count sourced from hub state.
+   * Returns null if streamId is not a valid UUID.
    */
   getStreamSubscriptionStats(streamId: string): { subscriberCount: number } | null {
-    // This would need access to hub's internal state
-    // For now, return placeholder
-    return { subscriberCount: 0 };
+    if (!StreamChannel.validateStreamId(streamId)) {
+      return null;
+    }
+    return { subscriberCount: this.hub.getSubscriberCount(streamId) };
   }
 
   /**
-   * Clean up stream subscriptions
+   * Clean up all subscriptions for a stream when it is deleted or archived.
+   * Removes the stream from hub state and from each subscribed client's
+   * subscription set. Sends a stream_unavailable notification to every
+   * affected client so they can update their UI accordingly.
    */
   cleanupStreamSubscriptions(streamId: string): void {
-    // This would clean up all subscriptions for a stream
-    // when it's deleted or archived
     logger.info('Cleaning up stream subscriptions', { streamId });
+    this.hub.forceUnsubscribeAll(streamId, true);
   }
 }

--- a/backend/src/ws/hub.ts
+++ b/backend/src/ws/hub.ts
@@ -77,7 +77,10 @@ export class WebSocketHub {
 
     try {
       // Validate payload size
-      if (data.length > this.MAX_PAYLOAD_SIZE) {
+      const byteLength = Buffer.isBuffer(data)
+        ? data.length
+        : Buffer.byteLength(data.toString());
+      if (byteLength > this.MAX_PAYLOAD_SIZE) {
         this.sendError(clientId, 'Payload too large', 'PAYLOAD_TOO_LARGE');
         return;
       }
@@ -315,6 +318,48 @@ export class WebSocketHub {
         this.removeConnection(clientId);
       }
     }
+  }
+
+  /**
+   * Get the number of clients currently subscribed to a stream.
+   * Returns 0 if the stream has no subscribers or has never been subscribed to.
+   */
+  getSubscriberCount(streamId: string): number {
+    return this.streamSubscriptions.get(streamId)?.size ?? 0;
+  }
+
+  /**
+   * Force-unsubscribe every client from a stream and remove it from hub state.
+   * Each affected client's subscribedStreams set is cleaned up so the client's
+   * subscription state remains consistent. Optionally sends a notification
+   * message to each affected client before removing the subscription.
+   */
+  forceUnsubscribeAll(streamId: string, notify = true): void {
+    const subscribers = this.streamSubscriptions.get(streamId);
+    if (!subscribers || subscribers.size === 0) {
+      this.streamSubscriptions.delete(streamId);
+      return;
+    }
+
+    // Snapshot the set before mutating it
+    const affectedClientIds = Array.from(subscribers);
+
+    for (const clientId of affectedClientIds) {
+      const client = this.clients.get(clientId);
+      if (client) {
+        client.subscribedStreams.delete(streamId);
+        if (notify) {
+          this.sendToClient(clientId, {
+            type: 'stream_unavailable',
+            streamId,
+            payload: { reason: 'Stream is no longer available', streamId }
+          });
+        }
+      }
+    }
+
+    this.streamSubscriptions.delete(streamId);
+    logger.info('Force-unsubscribed all clients from stream', { streamId, clientCount: affectedClientIds.length });
   }
 
   /**

--- a/backend/tests/ws.test.ts
+++ b/backend/tests/ws.test.ts
@@ -418,4 +418,158 @@ describe('StreamChannel', () => {
       );
     });
   });
+
+  // ---------------------------------------------------------------------------
+  // Helpers shared by the subscription-stats and cleanup test blocks
+  // ---------------------------------------------------------------------------
+
+  /** Subscribe a mock socket to `streamId` via the hub's message handler. */
+  function subscribeClientToStream(socket: any, streamId: string): void {
+    const messageHandler = socket.on.mock.calls.find((c: any[]) => c[0] === 'message')[1];
+    messageHandler(JSON.stringify({ type: 'subscribe', streamId }));
+  }
+
+  const STREAM_A = '123e4567-e89b-12d3-a456-426614174001';
+  const STREAM_B = '123e4567-e89b-12d3-a456-426614174002';
+
+  describe('getStreamSubscriptionStats', () => {
+    test('returns subscriberCount 0 for a stream with no subscribers', () => {
+      const stats = channel.getStreamSubscriptionStats(STREAM_A);
+      expect(stats).not.toBeNull();
+      expect(stats!.subscriberCount).toBe(0);
+    });
+
+    test('returns null for an invalid stream ID', () => {
+      expect(channel.getStreamSubscriptionStats('not-a-uuid')).toBeNull();
+      expect(channel.getStreamSubscriptionStats('')).toBeNull();
+    });
+
+    test('returns the real subscriber count for a stream with one subscriber', () => {
+      const request = { socket: { remoteAddress: '127.0.0.1' } };
+      hub.addConnection(mockSocket, request);
+      subscribeClientToStream(mockSocket, STREAM_A);
+
+      const stats = channel.getStreamSubscriptionStats(STREAM_A);
+      expect(stats).not.toBeNull();
+      expect(stats!.subscriberCount).toBe(1);
+    });
+
+    test('returns the real subscriber count for a stream with multiple subscribers', () => {
+      const sockets: any[] = [0, 1, 2].map(() => ({
+        readyState: 1,
+        send: jest.fn(),
+        close: jest.fn(),
+        on: jest.fn()
+      }));
+
+      const request = { socket: { remoteAddress: '127.0.0.1' } };
+      sockets.forEach(s => {
+        hub.addConnection(s, request);
+        subscribeClientToStream(s, STREAM_A);
+      });
+
+      const stats = channel.getStreamSubscriptionStats(STREAM_A);
+      expect(stats!.subscriberCount).toBe(3);
+    });
+
+    test('counts subscribers independently per stream', () => {
+      const request = { socket: { remoteAddress: '127.0.0.1' } };
+      hub.addConnection(mockSocket, request);
+      subscribeClientToStream(mockSocket, STREAM_A);
+
+      const statsA = channel.getStreamSubscriptionStats(STREAM_A);
+      const statsB = channel.getStreamSubscriptionStats(STREAM_B);
+      expect(statsA!.subscriberCount).toBe(1);
+      expect(statsB!.subscriberCount).toBe(0);
+    });
+  });
+
+  describe('cleanupStreamSubscriptions', () => {
+    test('is a no-op for a stream with no subscribers and does not throw', () => {
+      expect(() => channel.cleanupStreamSubscriptions(STREAM_A)).not.toThrow();
+      // Stats should still return 0
+      expect(channel.getStreamSubscriptionStats(STREAM_A)!.subscriberCount).toBe(0);
+    });
+
+    test('removes the stream from hub so subscriberCount becomes 0 after cleanup', () => {
+      const request = { socket: { remoteAddress: '127.0.0.1' } };
+      hub.addConnection(mockSocket, request);
+      subscribeClientToStream(mockSocket, STREAM_A);
+
+      // Sanity-check: 1 subscriber before cleanup
+      expect(channel.getStreamSubscriptionStats(STREAM_A)!.subscriberCount).toBe(1);
+
+      channel.cleanupStreamSubscriptions(STREAM_A);
+
+      // Stream-side map: subscriberCount must be 0
+      expect(channel.getStreamSubscriptionStats(STREAM_A)!.subscriberCount).toBe(0);
+    });
+
+    test('removes the stream from each affected client\'s subscription set', () => {
+      const sockets: any[] = [0, 1].map(() => ({
+        readyState: 1,
+        send: jest.fn(),
+        close: jest.fn(),
+        on: jest.fn()
+      }));
+
+      const request = { socket: { remoteAddress: '127.0.0.1' } };
+      sockets.forEach(s => {
+        hub.addConnection(s, request);
+        subscribeClientToStream(s, STREAM_A);
+      });
+
+      channel.cleanupStreamSubscriptions(STREAM_A);
+
+      // Hub-level stats: STREAM_A should have 0 subscribers
+      expect(channel.getStreamSubscriptionStats(STREAM_A)!.subscriberCount).toBe(0);
+
+      // Global hub stats: total subscriptions for STREAM_A gone, hub otherwise intact
+      const hubStats = hub.getStats();
+      expect(hubStats.streamsWithSubscribers).toBe(0);
+      expect(hubStats.totalSubscriptions).toBe(0);
+    });
+
+    test('sends stream_unavailable notification to each affected client', () => {
+      const sockets: any[] = [0, 1].map(() => ({
+        readyState: 1,
+        send: jest.fn(),
+        close: jest.fn(),
+        on: jest.fn()
+      }));
+
+      const request = { socket: { remoteAddress: '127.0.0.1' } };
+      sockets.forEach(s => {
+        hub.addConnection(s, request);
+        subscribeClientToStream(s, STREAM_A);
+      });
+
+      channel.cleanupStreamSubscriptions(STREAM_A);
+
+      sockets.forEach(s => {
+        const unavailableCalls = s.send.mock.calls.filter((call: string[]) =>
+          call[0].includes('"type":"stream_unavailable"')
+        );
+        expect(unavailableCalls.length).toBe(1);
+        expect(unavailableCalls[0][0]).toContain(STREAM_A);
+      });
+    });
+
+    test('only cleans up the targeted stream and leaves other stream subscriptions intact', () => {
+      const request = { socket: { remoteAddress: '127.0.0.1' } };
+      hub.addConnection(mockSocket, request);
+      subscribeClientToStream(mockSocket, STREAM_A);
+      subscribeClientToStream(mockSocket, STREAM_B);
+
+      channel.cleanupStreamSubscriptions(STREAM_A);
+
+      // STREAM_A gone, STREAM_B untouched
+      expect(channel.getStreamSubscriptionStats(STREAM_A)!.subscriberCount).toBe(0);
+      expect(channel.getStreamSubscriptionStats(STREAM_B)!.subscriberCount).toBe(1);
+
+      const hubStats = hub.getStats();
+      expect(hubStats.streamsWithSubscribers).toBe(1);
+      expect(hubStats.totalSubscriptions).toBe(1);
+    });
+  });
 });

--- a/backend/tsconfig.test.json
+++ b/backend/tsconfig.test.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "noUnusedLocals": false,
     "noUnusedParameters": false,
+    "noImplicitAny": false,
     "rootDir": "."
   },
   "include": ["src/**/*", "tests/**/*"]


### PR DESCRIPTION
- Add getSubscriberCount(streamId) to WebSocketHub returning the live count from streamSubscriptions map
- Add forceUnsubscribeAll(streamId, notify) to WebSocketHub that removes the stream from hub state and from each affected client's subscribedStreams set, with optional stream_unavailable notification to clients
- Wire StreamChannel.getStreamSubscriptionStats to hub.getSubscriberCount instead of returning a hardcoded 0; returns null for invalid UUIDs
- Wire StreamChannel.cleanupStreamSubscriptions to hub.forceUnsubscribeAll so cleanup is real and not a log-only no-op
- Fix pre-existing TS2339 on RawData.length (ArrayBuffer lacks .length)
- Add noImplicitAny: false to tsconfig.test.json to match existing noUnusedLocals/noUnusedParameters relaxations for test files
- Add 10 new tests covering zero-subscriber, single, and multi-subscriber cases for both methods, including stream_unavailable notification and cross-stream isolation; all 33 tests pass

# Pull Request

## Description

<!-- Provide a clear and concise description of your changes -->

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test coverage improvement
- [ ] Refactoring (no functional changes)

## Related Issues

<!-- Link to related issues using #issue_number -->

Closes #

## Changes Made

<!-- List the specific changes made in this PR -->

-
-
-

## Snapshot Test Changes

<!-- REQUIRED if snapshot files were modified -->

### Did this PR modify snapshot test files?

- [ ] Yes - snapshot files were updated (explain below)
- [ ] No - no snapshot changes

### If yes, explain why snapshots changed:

<!-- Provide detailed explanation of what behavior changed and why -->

**Behavior Changes:**

-

**Affected Snapshots:**

- `test_snapshots/test/test_*.json`

**Verification:**

- [ ] Reviewed every changed `.json` file
- [ ] Verified storage changes match intended behavior
- [ ] Verified event payloads are correct
- [ ] Verified authorization requirements are correct
- [ ] Updated relevant documentation

**Snapshot Update Command Used:**

```bash
SOROBAN_SNAPSHOT_UPDATE=1 cargo test -p fluxora_stream
```

## Testing

### Test Coverage

- [ ] All tests pass locally: `cargo test -p fluxora_stream`
- [ ] New tests added for new functionality
- [ ] Existing tests updated for changed functionality
- [ ] Test coverage remains above 95%

### Manual Testing

<!-- Describe any manual testing performed -->

- [ ] Tested on local environment
- [ ] Tested edge cases
- [ ] Tested error conditions

## Documentation

- [ ] Code comments added/updated
- [ ] Documentation updated (if behavior changed)
- [ ] README updated (if needed)
- [ ] Snapshot test documentation reviewed

## Security Considerations

<!-- Address any security implications of your changes -->

- [ ] No new security concerns introduced
- [ ] Authorization boundaries verified
- [ ] Input validation added/verified
- [ ] Error handling reviewed

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

<!-- Any additional information that reviewers should know -->

## Reviewer Checklist

<!-- For reviewers to complete -->

- [ ] Code quality and style
- [ ] Test coverage adequate
- [ ] Documentation complete
- [ ] Snapshot changes justified and correct
- [ ] Security implications reviewed
- [ ] Breaking changes documented

closes #967