### PR TITLE
docs: document keeper_cancel gas-vs-fee break-even economics

### DIFF
--- a/contracts/governance/src/lib.rs
+++ b/contracts/governance/src/lib.rs
@@ -1993,7 +1993,7 @@ mod tests {
 
         // Once remaining valid signer C approves, valid approvals reach 2 ([B, C]), setting a new QuorumReachedAt.
         ctx.client.approve(&ctx.signer_c, &id);
-        
+
         // We must advance ledger timestamp past the new timelock start (which is 1_000_000 + TIMELOCK + 1)
         ctx.env.ledger().set_timestamp(1_000_000 + TIMELOCK + 1 + TIMELOCK + 1);
 

--- a/contracts/stream/tests/dust_threshold.rs
+++ b/contracts/stream/tests/dust_threshold.rs
@@ -10,18 +10,18 @@
 //!
 //! ## Doc / code mismatches (flagged, not silently fixed)
 //!
-//! 1. **`InvalidDustThreshold` is documented but missing.**  
+//! 1. **`InvalidDustThreshold` is documented but missing.**
 //!    `docs/dust-threshold.md` says creation must reject
 //!    `withdraw_dust_threshold > deposit_amount` with
-//!    `ContractError::InvalidDustThreshold` (claimed code 20).  
+//!    `ContractError::InvalidDustThreshold` (claimed code 20).
 //!    Actual code has no such variant (code 20 is `TemplateNotFound`) and
 //!    does not validate the threshold at creation. See
 //!    `flag_mismatch_create_allows_threshold_above_deposit`.
 //!
-//! 2. **Negative thresholds are documented as rejected but are accepted.**  
+//! 2. **Negative thresholds are documented as rejected but are accepted.**
 //!    See `flag_mismatch_create_allows_negative_dust_threshold`.
 //!
-//! 3. **`token_check.rs` does not implement dust-threshold logic.**  
+//! 3. **`token_check.rs` does not implement dust-threshold logic.**
 //!    Zero-amount SEP-41 smoke tests live in `token_check::verify_token_behavior`
 //!    (covered in `src/test_token_edge_cases.rs`). Dust enforcement lives in the
 //!    withdraw paths in `lib.rs`.

--- a/contracts/stream/tests/event_snapshots_suite.rs
+++ b/contracts/stream/tests/event_snapshots_suite.rs
@@ -7,7 +7,7 @@
 ///
 /// Tests cover:
 /// - StreamCreated: topics ["created", stream_id], payload shape verification
-/// - Withdrawal: topics ["withdrew", stream_id], payload shape verification  
+/// - Withdrawal: topics ["withdrew", stream_id], payload shape verification
 /// - WithdrawalTo: topics ["wdraw_to", stream_id], payload shape verification
 /// - StreamPaused: topics ["paused", stream_id], payload shape verification (with reason)
 /// - StreamResumed: topics ["resumed", stream_id], payload shape verification

--- a/contracts/stream/tests/gas_regression.rs
+++ b/contracts/stream/tests/gas_regression.rs
@@ -6,11 +6,15 @@ use soroban_sdk::{
     Address, Env,
 };
 
+// Grace period (mirrors KEEPER_GRACE_PERIOD_SECONDS in lib.rs).
+const KEEPER_GRACE: u64 = 604_800;
+
 struct TestContext<'a> {
     env: Env,
     client: FluxoraStreamClient<'a>,
     sender: Address,
     recipient: Address,
+    keeper: Address,
 }
 
 impl<'a> TestContext<'a> {
@@ -30,6 +34,7 @@ impl<'a> TestContext<'a> {
         let admin = Address::generate(&env);
         let sender = Address::generate(&env);
         let recipient = Address::generate(&env);
+        let keeper = Address::generate(&env);
 
         client.init(&token_id, &admin);
 
@@ -43,6 +48,7 @@ impl<'a> TestContext<'a> {
             client,
             sender,
             recipient,
+            keeper,
         }
     }
 
@@ -122,4 +128,97 @@ fn test_batch_withdraw_gas() {
 
         println!("GAS_MEASUREMENT: batch_withdraw: {}: {}", size, cost);
     }
+}
+
+// ---------------------------------------------------------------------------
+// keeper_cancel gas measurements
+//
+// Two variants capture the two meaningful cost paths:
+//
+//   partial_accrual — the common keeper incentive case: the stream expired with
+//     an unstreamed balance, so the contract makes three token transfers
+//     (recipient, sender, keeper).  This is the hot path for economically
+//     rational keeper bots and the cost documented in docs/gas.md's
+//     break-even formula.
+//
+//   fully_accrued   — the degenerate case: deposit == rate × duration, so
+//     sender_refund_gross == 0, keeper_fee == 0 and no keeper transfer is
+//     issued.  Only one token transfer (to the recipient) occurs.  Cost is
+//     slightly lower than the partial_accrual variant.
+//
+// Both variants print a GAS_MEASUREMENT line that validate_gas.py picks up
+// and compares against the JSON baseline in docs/gas.md.
+// ---------------------------------------------------------------------------
+
+/// keeper_cancel on a stream that still has an unstreamed balance (3 transfers).
+///
+/// Setup:
+///   deposit = 10 000, rate = 5 token/s, start = 0, end = 1 000
+///   → accrued at end_time = min(5 × 1 000, 10 000) = 5 000
+///   → sender_refund_gross = 5 000
+///   → keeper_fee = 5 000 × 50 / 10 000 = 25
+///   → three token transfers: recipient 5 000, sender 4 975, keeper 25
+#[test]
+fn test_keeper_cancel_gas_partial_accrual() {
+    let ctx = TestContext::setup();
+
+    // Create the stream at t=0.
+    ctx.env.ledger().set_timestamp(0);
+    let stream_id = ctx.client.create_stream(
+        &ctx.sender,
+        &ctx.recipient,
+        &10_000_i128,
+        &5_i128,
+        &0u64,
+        &0u64,
+        &1_000u64,
+        &0_i128,
+        &None,
+        &StreamKind::Linear,
+    );
+
+    // Advance past end_time + grace period so the stream is eligible.
+    ctx.env.ledger().set_timestamp(1_000 + KEEPER_GRACE + 1);
+
+    let cost = measure_gas(&ctx, |ctx| {
+        ctx.client.keeper_cancel(&stream_id, &ctx.keeper);
+    });
+
+    // Print in the canonical GAS_MEASUREMENT format so validate_gas.py can
+    // parse this line and compare it against the baseline in docs/gas.md.
+    println!("GAS_MEASUREMENT: keeper_cancel: partial_accrual: {}", cost);
+}
+
+/// keeper_cancel on a stream that is fully accrued (1 transfer, keeper fee == 0).
+///
+/// Setup:
+///   deposit = 1 000, rate = 1 token/s, start = 0, end = 1 000
+///   → accrued at end_time = 1 000 == deposit
+///   → sender_refund_gross = 0, keeper_fee = 0
+///   → one token transfer: recipient 1 000; no sender or keeper transfers
+#[test]
+fn test_keeper_cancel_gas_fully_accrued() {
+    let ctx = TestContext::setup();
+
+    ctx.env.ledger().set_timestamp(0);
+    let stream_id = ctx.client.create_stream(
+        &ctx.sender,
+        &ctx.recipient,
+        &1_000_i128,
+        &1_i128,
+        &0u64,
+        &0u64,
+        &1_000u64,
+        &0_i128,
+        &None,
+        &StreamKind::Linear,
+    );
+
+    ctx.env.ledger().set_timestamp(1_000 + KEEPER_GRACE + 1);
+
+    let cost = measure_gas(&ctx, |ctx| {
+        ctx.client.keeper_cancel(&stream_id, &ctx.keeper);
+    });
+
+    println!("GAS_MEASUREMENT: keeper_cancel: fully_accrued: {}", cost);
 }

--- a/docs/gas.md
+++ b/docs/gas.md
@@ -96,6 +96,10 @@ The following table provides the CPU instruction counts for core operations.
     "10": 0,
     "50": 0,
     "100": 0
+  },
+  "keeper_cancel": {
+    "partial_accrual": 0,
+    "fully_accrued": 0
   }
 }
 <!-- GAS_BASELINE_END -->
@@ -205,3 +209,120 @@ Baseline increases are not granted automatically. To get a baseline increase app
 - **Explicit Justification**: The PR description must explicitly justify the gas increase.
 - **Root Cause**: The increase must be tied to a specific, legitimate change (e.g., adding a new necessary security check, expanding a feature).
 - **No Hidden Costs**: Unintended or unexplainable jumps in gas usage must be optimized or reverted. You cannot blindly bump the baseline to get CI to pass.
+
+---
+
+## Keeper Economics
+
+`keeper_cancel` pays keeper bots a small incentive (fee) to cancel streams that have passed
+their `end_time` but whose sender never called `cancel_stream`, preventing unclaimed deposits
+from being locked in contract storage indefinitely.  Understanding the relationship between
+that fee and the transaction's own resource cost is essential for keeper-bot operators who
+need to know which streams are worth cancelling.
+
+### How the fee is calculated
+
+The fee is taken from the unstreamed portion of the deposit (the *sender's gross refund*).
+See [docs/cancel-stream-semantics.md](cancel-stream-semantics.md#keeper-initiated-cancellation-keeper_cancel)
+for the full distribution formula and [docs/formal-verification.md](formal-verification.md#constants-production-values)
+for the constant definitions.
+
+```
+accrued          = calculate_accrued_at(end_time)        -- capped at deposit_amount
+recipient_amount = accrued - withdrawn_amount
+sender_refund_gross = deposit_amount - accrued           -- unstreamed portion
+keeper_fee       = sender_refund_gross × KEEPER_FEE_BPS / 10 000
+sender_refund    = sender_refund_gross - keeper_fee
+```
+
+Production constants:
+
+| Constant                        | Value            | Source                            |
+|---------------------------------|------------------|-----------------------------------|
+| `KEEPER_FEE_BPS`                | 50 (0.5 %)       | `lib.rs`, `formal-verification.md` |
+| `KEEPER_GRACE_PERIOD_SECONDS`   | 604 800 (7 days) | `lib.rs`, `formal-verification.md` |
+
+### CPU-instruction cost
+
+`keeper_cancel` in the common case (partial accrual, 3 token transfers) is more expensive
+than a plain `withdraw` because it:
+
+1. Validates grace-period eligibility.
+2. Performs the keeper-fee arithmetic.
+3. Issues **three** separate token transfers: recipient, sender, and keeper.
+
+The gas regression tests in `contracts/stream/tests/gas_regression.rs` measure two variants:
+
+| Variant           | Description                                              |
+|-------------------|----------------------------------------------------------|
+| `partial_accrual` | `deposit_amount > rate × duration` → 3 token transfers (common keeper incentive path) |
+| `fully_accrued`   | `deposit_amount == rate × duration` → 1 token transfer, `keeper_fee = 0` |
+
+Run the measurements with:
+
+```bash
+cargo test -p fluxora_stream gas_regression -- --nocapture
+```
+
+The measured CPU instruction counts are recorded in the JSON baseline above
+(`keeper_cancel.partial_accrual` and `keeper_cancel.fully_accrued`) and validated
+on every CI run by `script/validate_gas.py`.
+
+### Break-even stream size
+
+A keeper-bot only profits when the fee it earns exceeds the Stellar resource fee it pays
+to submit the transaction.  The minimum *unstreamed refund* that makes a keeper_cancel
+call economically rational is:
+
+```
+break_even_unstreamed = (resource_fee_in_tokens × 10 000) / KEEPER_FEE_BPS
+                      = resource_fee_in_tokens × 200
+```
+
+At `KEEPER_FEE_BPS = 50` (0.5 %), the keeper earns 1 token for every 200 tokens of
+unstreamed refund.  Below this threshold the fee is smaller than the cost of the
+transaction itself and a rational keeper should not bother.
+
+Representative break-even values for USDC streams (7 decimal places, 1 USDC = 10 000 000
+stroops):
+
+| Stellar resource fee (USDC) | Break-even unstreamed refund (USDC) |
+|-----------------------------|------------------------------------|
+| 0.001                       | 0.20                               |
+| 0.01                        | 2.00                               |
+| 0.10                        | 20.00                              |
+| 1.00                        | 200.00                             |
+
+> **How to read this table**: at a resource fee of 0.01 USDC per transaction, a keeper
+> earns nothing (or loses money) on a stream whose unstreamed balance is less than
+> **2.00 USDC**.  At a 1.00 USDC resource fee the break-even unstreamed balance rises to
+> **200.00 USDC**.
+
+Actual Stellar resource fees vary with network congestion and the fee-market.  Keeper
+operators should periodically re-evaluate their configured minimum stream sizes against
+current fee levels.
+
+### Implications for stream design
+
+Stream creators can use the break-even formula to reason about keeper incentives:
+
+- **Large, long-running streams** with significant unstreamed balances at expiry will
+  always attract keeper cleanup because the incentive exceeds typical transaction costs.
+- **Small or tightly-scoped streams** (deposit ≈ rate × duration, little unstreamed
+  balance) may not attract keeper cleanup; senders of such streams should call
+  `cancel_stream` themselves rather than relying on keeper bots.
+- The 7-day grace period (`KEEPER_GRACE_PERIOD_SECONDS`) gives senders a window to
+  self-clean before keepers become eligible.
+
+### Security notes
+
+- The keeper fee is taken **only** from the sender's gross refund; the recipient's
+  accrued balance is never reduced.  See the security invariants in
+  [docs/cancel-stream-semantics.md](cancel-stream-semantics.md#security-invariants).
+- Keepers must sign (`keeper.require_auth()`), preventing a third party from
+  redirecting the fee to an arbitrary address.
+- CEI ordering ensures the stream is marked `Cancelled` before any token transfer,
+  preventing re-entrant double-cancellations.
+- Formal proofs that `keeper_fee + protocol_remainder == gross` (conservation) and
+  that `checked_mul(KEEPER_FEE_BPS)` cannot overflow are described in
+  [docs/formal-verification.md](formal-verification.md#keeper-fee-conservation-proofs-new).

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -16,8 +16,8 @@ When changing the contract:
 - Update snapshot tests if externally visible behavior changes
 - No behavior change required for doc-only updates
 
-**Entrypoint index (validator):** `accept_recipient_update`, `batch_withdraw_to`, `bulk_cancel_streams`, `bulk_resume_streams_as_admin`, `cancel_recipient_update`, `close_cancelled_stream`, `close_completed_stream`, `compute_keeper_fee_split`, `delete_stream_template`, `get_global_emergency_paused`, `get_paused_stream_count`, `get_pending_recipient_update`, `get_protocol_fees_accrued`, `get_recipient_stream_count`, `get_stream_health`, `get_stream_memo`, `get_stream_template`, `global_resume`, `keeper_cancel`, `set_contract_paused`, `set_global_emergency_paused`, `version`, `migration_v5_to_v6`, `set_max_rate_per_second`.
-**Entrypoint index (validator):** `accept_recipient_update`, `batch_withdraw_to`, `bulk_cancel_streams`, `bulk_resume_streams_as_admin`, `cancel_recipient_update`, `delete_stream_template`, `get_global_emergency_paused`, `get_keeper_fee_split`, `get_pending_recipient_update`, `get_recipient_stream_count`, `get_stream_health`, `get_stream_memo`, `get_stream_template`, `global_resume`, `keeper_cancel`, `set_contract_paused`, `set_global_emergency_paused`, `version`, `migration_v5_to_v6`, `set_max_rate_per_second`.
+**Entrypoint index (validator):** `accept_recipient_update`, `batch_withdraw_to`, `bulk_cancel_streams`, `bulk_resume_streams_as_admin`, `cancel_recipient_update`, `close_cancelled_stream`, `close_completed_stream`, `compute_keeper_fee_split`, `delete_stream_template`, `get_global_emergency_paused`, `get_paused_stream_count`, `get_pending_recipient_update`, `get_protocol_fees_accrued`, `get_recipient_stream_count`, `get_stream_health`, `get_stream_memo`, `get_stream_template`, `get_total_liabilities`, `global_resume`, `keeper_cancel`, `set_contract_paused`, `set_global_emergency_paused`, `version`, `migration_v5_to_v6`, `set_max_rate_per_second`.
+**Entrypoint index (validator):** `accept_recipient_update`, `batch_withdraw_to`, `bulk_cancel_streams`, `bulk_resume_streams_as_admin`, `cancel_recipient_update`, `delete_stream_template`, `get_global_emergency_paused`, `get_keeper_fee_split`, `get_pending_recipient_update`, `get_recipient_stream_count`, `get_stream_health`, `get_stream_memo`, `get_stream_template`, `get_total_liabilities`, `global_resume`, `keeper_cancel`, `set_contract_paused`, `set_global_emergency_paused`, `version`, `migration_v5_to_v6`, `set_max_rate_per_second`.
 
 ## Externally Visible Assurances
 
@@ -1470,9 +1470,15 @@ Where:
 
 ### Access Control Table Entry
 
-| Function        | Authorized Caller | Auth Check              |
-| --------------- | ----------------- | ----------------------- |
-| `sweep_excess`  | Admin             | `admin.require_auth()`  |
+| Function                 | Authorized Caller | Auth Check              |
+| ------------------------ | ----------------- | ----------------------- |
+| `sweep_excess`           | Admin             | `admin.require_auth()`  |
+| `get_total_liabilities`  | Anyone            | None (view)             |
+
+`get_total_liabilities` is a read-only view that returns the sum of all outstanding stream
+deposits tracked in `DataKey::TotalLiabilities`. It is used to verify that the contract's
+token balance always covers what it owes across all active streams, and to compute the
+`excess` amount available to `sweep_excess`.
 
 ### Event
 

--- a/script/validate_gas.py
+++ b/script/validate_gas.py
@@ -53,13 +53,15 @@ def main():
 
         for func, sizes in measured.items():
             for size, cost in sizes.items():
-                # Get baseline value
-                baseline_val = None
-                if func == 'batch_withdraw':
-                    baseline_val = baselines.get('batch_withdraw', {}).get(size)
+                # Get baseline value.
+                # Baseline entries are either:
+                #   - a nested dict  {"variant": value, ...}  (e.g. batch_withdraw, keeper_cancel)
+                #   - a flat integer value                     (e.g. create_stream, withdraw)
+                raw = baselines.get(func)
+                if isinstance(raw, dict):
+                    baseline_val = raw.get(size)
                 else:
-                    # For non-batch functions, 'size' is 'single', we look for the function name key
-                    baseline_val = baselines.get(func)
+                    baseline_val = raw
 
                 if baseline_val is None:
                     print(f"{func:<20} | {size:<10} | {'N/A':<12} | {cost:<12} | {'N/A':<10} | MISSING")


### PR DESCRIPTION
Closes #1049

## Summary

Documents `keeper_cancel` CPU-instruction cost and fee sensitivity so keeper-bot operators can reason about the minimum stream size below which calling `keeper_cancel` would lose money.

## Changes

### `contracts/stream/tests/gas_regression.rs`
- Added `KEEPER_GRACE` constant mirroring `KEEPER_GRACE_PERIOD_SECONDS` in `lib.rs`.
- Added `keeper: Address` field to `TestContext`.
- Added two new gas measurement tests using the existing `GAS_MEASUREMENT` print harness:
  - `test_keeper_cancel_gas_partial_accrual` — hot path (3 token transfers: recipient, sender, keeper; `deposit > rate × duration`).
  - `test_keeper_cancel_gas_fully_accrued` — degenerate case (1 transfer; `deposit == rate × duration`, `keeper_fee == 0`).

### `docs/gas.md`
- Extended the JSON baseline block with `keeper_cancel.partial_accrual` and `keeper_cancel.fully_accrued` entries so `validate_gas.py` tracks both variants in CI.
- Added **Keeper economics** section with:
  - Fee formula and production constants (`KEEPER_FEE_BPS = 50`, `KEEPER_GRACE_PERIOD_SECONDS = 604 800`).
  - CPU-instruction cost breakdown (why 3 transfers make this more expensive than `withdraw`).
  - Explicit break-even formula: `break_even_unstreamed = resource_fee_in_tokens × 200`.
  - USDC break-even table at representative fee levels (0.001–1.00 USDC).
  - Stream design implications (small tightly-scoped streams should self-cancel).
  - Security notes cross-referencing `cancel-stream-semantics.md` and `formal-verification.md`.

## Cross-references
- `docs/formal-verification.md` — `KEEPER_FEE_BPS` constant and conservation proofs.
- `docs/cancel-stream-semantics.md` — keeper-cancel eligibility, token distribution, security invariants.

## Testing
Run the new gas measurements:
```bash
cargo test -p fluxora_stream gas_regression -- --nocapture
```