### PR TITLE
feat(Fluxora-Contracts): rewrite-docs-audit-md-s-entrypoint-table-to-cove

### DIFF
--- a/docs/audit.md
+++ b/docs/audit.md
@@ -2,35 +2,90 @@
 
 This document lists all public entrypoints and core invariants of the Fluxora stream contract to help external auditors scope the review. It is accurate as of the current codebase; no code changes are implied.
 
+The public entrypoint table below is kept in sync with every `pub fn` on the `FluxoraStream` `#[contractimpl]` block in `contracts/stream/src/lib.rs`. CI runs `script/validate-doc-alignment.py` to fail on missing or stale rows.
+
 ---
 
 ## Public entrypoints
 
-| Entrypoint                | Parameters                                                                                                                                                  | Return type | Authorization                                 | Description                                                                                                                |
-| ------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- | --------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
-| `init`                    | `env: Env`, `token: Address`, `admin: Address`                                                                                                              | —           | Bootstrap admin only (`admin.require_auth()`) | One-time setup: store token and admin. Panics if already initialised.                                                      |
-| `create_stream`           | `env: Env`, `sender: Address`, `recipient: Address`, `deposit_amount: i128`, `rate_per_second: i128`, `start_time: u64`, `cliff_time: u64`, `end_time: u64` | `u64`       | Sender                                        | Create stream, transfer deposit to contract, return new stream ID.                                                         |
-| `pause_stream`            | `env: Env`, `stream_id: u64`                                                                                                                                | —           | Sender                                        | Set stream status to Paused. Only Active streams.                                                                          |
-| `resume_stream`           | `env: Env`, `stream_id: u64`                                                                                                                                | —           | Sender                                        | Set stream status to Active. Only Paused streams.                                                                          |
-| `cancel_stream`           | `env: Env`, `stream_id: u64`                                                                                                                                | —           | Sender                                        | Refund unstreamed tokens to sender, set status to Cancelled. Active or Paused only.                                        |
-| `withdraw`                | `env: Env`, `stream_id: u64`                                                                                                                                | `i128`      | Recipient only                                | Transfer accrued-but-not-withdrawn tokens to recipient; update withdrawn_amount; set Completed if full.                    |
-| `calculate_accrued`       | `env: Env`, `stream_id: u64`                                                                                                                                | `i128`      | None (view)                                   | Total accrued so far (time-based). Withdrawable = accrued − withdrawn_amount.                                              |
-| `get_config`              | `env: Env`                                                                                                                                                  | `Config`    | None (view)                                   | Return token and admin addresses.                                                                                          |
-| `get_stream_state`        | `env: Env`, `stream_id: u64`                                                                                                                                | `Stream`    | None (view)                                   | Return full stream state.                                                                                                  |
-| `cancel_stream_as_admin`  | `env: Env`, `stream_id: u64`                                                                                                                                | —           | Admin only                                    | Same behaviour as cancel_stream; admin auth instead of sender.                                                             |
-| `pause_stream_as_admin`   | `env: Env`, `stream_id: u64`                                                                                                                                | —           | Admin only                                    | Same behaviour as pause_stream; admin auth.                                                                                |
-| `resume_stream_as_admin`  | `env: Env`, `stream_id: u64`                                                                                                                                | —           | Admin only                                    | Same behaviour as resume_stream; admin auth.                                                                               |
-| `update_rate_per_second`  | `env: Env`, `stream_id: u64`, `new_rate_per_second: i128`                                                                                                   | —           | Sender                                        | Increase rate (forward-only). Deposit must still cover `new_rate × duration`. Active or Paused only.                       |
-| `shorten_stream_end_time` | `env: Env`, `stream_id: u64`, `new_end_time: u64`                                                                                                           | —           | Sender                                        | Reduce `end_time`; refund unstreamed tokens to sender. Active or Paused only.                                              |
-| `extend_stream_end_time`  | `env: Env`, `stream_id: u64`, `new_end_time: u64`                                                                                                           | —           | Sender                                        | Increase `end_time`. Existing `deposit_amount` must cover `rate × new_duration`. No token transfer. Active or Paused only. |
-| `top_up_stream`           | `env: Env`, `stream_id: u64`, `funder: Address`, `amount: i128`                                                                                             | —           | Funder                                        | Pull additional tokens into the stream deposit. Active or Paused only.                                                     |
-| `close_completed_stream`  | `env: Env`, `stream_id: u64`                                                                                                                                | —           | Anyone                                        | Remove storage for a Completed stream. Permissionless cleanup.                                                             |
-| `set_admin`               | `env: Env`, `new_admin: Address`                                                                                                                            | —           | Admin                                         | Rotate admin key.                                                                                                          |
-| `version`                 | `env: Env`                                                                                                                                                  | `u32`       | None (view)                                   | Return compile-time contract version.                                                                                      |
-| `delegated_withdraw`      | `env: Env`, `stream_id: u64`, `relayer: Address`, `recipient_public_key: Bytes`, `nonce: u64`, `deadline: u64`, `expected_minimum_amount: i128`, `signature: Bytes` | `i128` | Relayer (`relayer.require_auth()`) + ed25519 sig from recipient | Withdraw on behalf of recipient. Signature commits to `(stream_id, nonce, deadline, expected_minimum_amount)`. Reverts if `withdrawable < expected_minimum_amount`. |
-| `get_delegated_nonce`     | `env: Env`, `recipient: Address`                                                                                                                            | `u64`       | None (view)                                   | Return current replay-protection nonce for a recipient.                                                                    |
-
-There is no `version` entrypoint in the contract.
+| Entrypoint | Parameters | Return type | Authorization | Description |
+| --- | --- | --- | --- | --- |
+| `accept_recipient_update` | `env: Env`, `stream_id: u64` | — | Current recipient | Finalize a pending recipient rotation proposed by the sender. |
+| `batch_withdraw` | `env: Env`, `recipient: Address`, `stream_ids: Vec<u64>` | `Vec<BatchWithdrawResult>` | Recipient | Withdraw accrued tokens from multiple streams atomically; duplicate IDs revert the batch. |
+| `batch_withdraw_to` | `env: Env`, `recipient: Address`, `withdrawals: Vec<WithdrawToParam>` | `Vec<BatchWithdrawResult>` | Recipient | Batch withdraw with per-stream destination addresses; recipient auth once per batch. |
+| `bulk_cancel_streams` | `env: Env`, `sender: Address`, `stream_ids: Vec<u64>` | — | Sender | Atomically cancel multiple owned streams and refund aggregate unstreamed balance. |
+| `bulk_resume_streams_as_admin` | `env: Env`, `stream_ids: Vec<u64>` | — | Admin | Atomically resume multiple paused streams; all-or-nothing validation. |
+| `calculate_accrued` | `env: Env`, `stream_id: u64` | `i128` | None (view) | Total accrued amount at current ledger time; clamped to deposit. |
+| `cancel_recipient_update` | `env: Env`, `stream_id: u64` | — | Sender | Cancel a pending recipient rotation before acceptance. |
+| `cancel_stream` | `env: Env`, `stream_id: u64` | — | Sender | Refund unstreamed tokens to sender; freeze accrual at cancellation time. Active or Paused only. |
+| `cancel_stream_as_admin` | `env: Env`, `stream_id: u64` | — | Admin | Same cancellation semantics as `cancel_stream` with admin authorization. |
+| `clone_stream` | `env: Env`, `stream_id: u64`, `new_recipient: Address`, `start_time: u64`, `end_time: u64`, `deposit: i128`, `force: bool` | `u64` | Source stream sender | Create a new stream copying rate/cliff offset from an existing stream. |
+| `close_cancelled_stream` | `env: Env`, `stream_id: u64` | — | Anyone | Permissionless storage cleanup for Cancelled streams with zero claimable balance. |
+| `close_completed_stream` | `env: Env`, `stream_id: u64` | — | Anyone | Permissionless storage cleanup for Completed streams. |
+| `create_stream` | `env: Env`, `sender: Address`, `recipient: Address`, `deposit_amount: i128`, `rate_per_second: i128`, `start_time: u64`, `cliff_time: u64`, `end_time: u64`, `withdraw_dust_threshold: i128`, `memo: Option<Bytes>`, `kind: StreamKind` | `u64` | Sender | Create a stream, pull deposit into the contract, return new stream ID. |
+| `create_stream_from_template` | `env: Env`, `sender: Address`, `template_id: u64`, `recipient: Address`, `deposit_amount: i128`, `rate_per_second: i128`, `withdraw_dust_threshold: i128`, `memo: Option<Bytes>`, `metadata: Option<Map<Bytes, Bytes>>`, `kind: StreamKind` | `u64` | Sender | Create a stream using a registered schedule template plus caller-funded amounts. |
+| `create_stream_relative` | `env: Env`, `sender: Address`, `params: CreateStreamRelativeParams` | `u64` | Sender | Create a stream with timing expressed relative to the current ledger timestamp. |
+| `create_streams` | `env: Env`, `sender: Address`, `streams: Vec<CreateStreamParams>` | `Vec<u64>` | Sender | Atomically create multiple streams with a single sender authorization and deposit pull. |
+| `create_streams_partial` | `env: Env`, `sender: Address`, `streams: Vec<CreateStreamParams>` | `Vec<CreateStreamResult>` | Sender | Batch create with per-entry success/failure results instead of all-or-nothing semantics. |
+| `create_streams_relative` | `env: Env`, `sender: Address`, `streams_relative: Vec<CreateStreamRelativeParams>` | `Vec<u64>` | Sender | Batch create using relative timing parameters converted to absolute timestamps. |
+| `decrease_rate_per_second` | `env: Env`, `stream_id: u64`, `new_rate_per_second: i128` | — | Sender | Decrease stream rate and refund excess deposit to sender; Active or Paused only. |
+| `delegated_withdraw` | `env: Env`, `stream_id: u64`, `relayer: Address`, `recipient_public_key: BytesN<32>`, `nonce: u64`, `deadline: u64`, `expected_minimum_amount: i128`, `signature: BytesN<64>` | `i128` | Relayer + ed25519 sig from recipient | Withdraw on behalf of recipient; signature commits to stream, nonce, deadline, and minimum amount. |
+| `delete_stream_template` | `env: Env`, `owner: Address`, `template_id: u64` | — | Template owner | Delete a schedule template registered by the caller. |
+| `extend_stream_end_time` | `env: Env`, `stream_id: u64`, `new_end_time: u64` | — | Sender | Increase `end_time`; existing deposit must cover extended duration. Active or Paused only. |
+| `get_auto_claim_destination` | `env: Env`, `stream_id: u64` | `Option<Address>` | None (view) | Return the permissionless auto-claim destination registered by the recipient, if any. |
+| `get_auto_claim_status` | `env: Env`, `stream_id: u64` | `AutoClaimStatus` | None (view) | Return whether auto-claim is configured and currently triggerable for the stream. |
+| `get_claimable_at` | `env: Env`, `stream_id: u64`, `timestamp: u64` | `i128` | None (view) | Preview withdrawable amount at an arbitrary timestamp without mutating state. |
+| `get_config` | `env: Env` | `Config` | None (view) | Return token and admin addresses from instance storage. |
+| `get_delegated_nonce` | `env: Env`, `recipient: Address` | `u64` | None (view) | Return current replay-protection nonce for delegated withdrawals. |
+| `get_global_emergency_paused` | `env: Env` | `bool` | None (view) | Return whether the global emergency pause flag is set. |
+| `get_id_reservation` | `env: Env`, `caller: Address` | `Option<IdReservation>` | None (view) | Return the active stream-ID reservation for a caller, if any. |
+| `get_keeper_fee_split` | `env: Env`, `stream_id: u64` | `(i128, i128)` | None (view) | Preview keeper fee and sender refund that `keeper_cancel` would pay. |
+| `get_pause_info` | `env: Env` | `PauseInfo` | None (view) | Return protocol pause state including reason, timestamp, and admin audit trail. |
+| `get_paused_stream_count` | `env: Env` | `u64` | None (view) | Return count of streams currently in Paused status. |
+| `get_pending_recipient_update` | `env: Env`, `stream_id: u64` | `Option<PendingRecipientUpdate>` | None (view) | Return a pending recipient rotation awaiting acceptance, if any. |
+| `get_protocol_fees_accrued` | `env: Env` | `i128` | None (view) | Return cumulative keeper/protocol fees collected by the contract. |
+| `get_recipient_stream_count` | `env: Env`, `recipient: Address` | `u64` | None (view) | Return number of active stream IDs indexed for a recipient. |
+| `get_recipient_streams` | `env: Env`, `recipient: Address` | `Vec<u64>` | None (view) | Return all stream IDs for a recipient (bounded for large portfolios). |
+| `get_recipient_streams_paginated` | `env: Env`, `recipient: Address`, `cursor: u64`, `limit: u32` | `Page` | None (view) | Cursor-paginated recipient stream export capped at `RECIPIENT_STREAMS_PAGE_LIMIT`. |
+| `get_stream_count` | `env: Env` | `u64` | None (view) | Return total streams created (`NextStreamId` counter). |
+| `get_stream_health` | `env: Env`, `stream_id: u64` | `StreamHealth` | None (view) | Return underfunding and remaining-balance health metrics for a stream. |
+| `get_stream_memo` | `env: Env`, `stream_id: u64` | `Option<Bytes>` | None (view) | Return immutable memo bytes attached at stream creation. |
+| `get_stream_metadata` | `env: Env`, `stream_id: u64` | `Option<Map<Bytes, Bytes>>` | None (view) | Return immutable metadata map attached at stream creation. |
+| `get_stream_state` | `env: Env`, `stream_id: u64` | `Stream` | None (view) | Return full on-chain stream state. |
+| `get_stream_template` | `env: Env`, `template_id: u64` | `StreamScheduleTemplate` | None (view) | Read a registered schedule template by ID. |
+| `get_streams_by_id_range` | `env: Env`, `start_id: u64`, `end_id: u64`, `limit: u64` | `Vec<Stream>` | None (view) | Paginated export of streams in an ID range; capped at `MAX_PAGE_SIZE`. |
+| `get_total_liabilities` | `env: Env` | `i128` | None (view) | Return aggregate outstanding deposit liabilities across all streams. |
+| `get_withdrawable` | `env: Env`, `stream_id: u64` | `i128` | None (view) | Return accrued minus withdrawn at current ledger time. |
+| `global_resume` | `env: Env` | — | Admin | Clear the global emergency pause after an incident; emits `GlobalResumed`. |
+| `init` | `env: Env`, `token: Address`, `admin: Address` | — | Bootstrap admin | One-time setup: store token and admin; panics if already initialized. |
+| `is_paused` | `env: Env` | `bool` | None (view) | Return whether protocol-level stream creation is paused. |
+| `keeper_cancel` | `env: Env`, `stream_id: u64`, `keeper: Address` | — | Keeper | Permissionless cancel after grace period; pays keeper fee from sender refund. |
+| `pause_protocol` | `env: Env`, `admin: Address`, `reason: Option<String>` | — | Admin | Pause new stream creation with audit trail (reason, timestamp, admin). |
+| `pause_stream` | `env: Env`, `stream_id: u64`, `reason: PauseReason` | — | Sender | Set stream status to Paused; Active streams only. |
+| `pause_stream_as_admin` | `env: Env`, `stream_id: u64`, `reason: PauseReason` | — | Admin | Admin override to pause any Active stream. |
+| `reclaim_expired_id_reservation` | `env: Env`, `holder: Address` | — | Anyone | Permissionlessly release an expired ID reservation and reclaim counter space. |
+| `register_stream_template` | `env: Env`, `owner: Address`, `start_delay: u64`, `cliff_delay: u64`, `duration: u64` | `u64` | Owner | Register a reusable relative schedule template; subject to per-owner and global caps. |
+| `release_id_reservation` | `env: Env`, `caller: Address` | — | Reservation holder | Voluntarily abandon an unconsumed ID reservation. |
+| `reserve_stream_ids` | `env: Env`, `caller: Address`, `count: u32`, `expiry: Option<u64>` | `Vec<u64>` | Caller | Pre-allocate contiguous stream IDs for off-chain orchestration. |
+| `resume_protocol` | `env: Env`, `admin: Address` | — | Admin | Resume protocol-level stream creation and clear pause audit trail. |
+| `resume_stream` | `env: Env`, `stream_id: u64` | — | Sender | Set stream status to Active; Paused streams only. |
+| `resume_stream_as_admin` | `env: Env`, `stream_id: u64` | — | Admin | Admin override to resume any Paused stream. |
+| `revoke_auto_claim` | `env: Env`, `stream_id: u64` | — | Recipient | Remove a previously registered auto-claim destination. |
+| `set_admin` | `env: Env`, `new_admin: Address` | — | Admin | Rotate contract admin address. |
+| `set_auto_claim` | `env: Env`, `stream_id: u64`, `destination: Address` | — | Recipient | Register a fixed destination for permissionless `trigger_auto_claim`. |
+| `set_contract_paused` | `env: Env`, `paused: bool` | — | Admin | Toggle creation-only pause (`CreationPaused`); does not block withdrawals. |
+| `set_global_emergency_paused` | `env: Env`, `paused: bool` | — | Admin | Toggle global emergency pause blocking operational mutations. |
+| `set_max_rate_per_second` | `env: Env`, `max_rate: i128` | — | Admin | Set maximum allowed stream rate for future rate updates. |
+| `shorten_stream_end_time` | `env: Env`, `stream_id: u64`, `new_end_time: u64` | — | Sender | Reduce `end_time` and refund unstreamed tokens to sender; Active or Paused only. |
+| `sweep_excess` | `env: Env`, `recipient: Address` | `i128` | Admin | Recover token balance exceeding tracked liabilities to an admin-chosen address. |
+| `top_up_stream` | `env: Env`, `stream_id: u64`, `funder: Address`, `amount: i128` | — | Funder | Pull additional tokens into stream deposit; Active or Paused only. |
+| `trigger_auto_claim` | `env: Env`, `stream_id: u64` | `i128` | Anyone | Permissionlessly withdraw to recipient's registered auto-claim destination. |
+| `update_rate` | `env: Env`, `stream_id: u64`, `new_rate_per_second: i128`, `caller: Address` | — | Sender or admin | Update stream rate without deposit adjustment; caller must be sender or admin. |
+| `update_rate_per_second` | `env: Env`, `stream_id: u64`, `new_rate_per_second: i128` | — | Sender | Increase rate forward-only; deposit must cover new rate × duration. |
+| `update_recipient` | `env: Env`, `stream_id: u64`, `new_recipient: Address` | — | Sender | Propose recipient rotation; finalized by `accept_recipient_update`. |
+| `version` | `env: Env` | `u32` | None (view) | Return compile-time contract version (`CONTRACT_VERSION`). |
+| `withdraw` | `env: Env`, `stream_id: u64` | `i128` | Recipient | Transfer accrued-but-not-withdrawn tokens to recipient; may set Completed. |
+| `withdraw_to` | `env: Env`, `stream_id: u64`, `destination: Address` | `i128` | Recipient | Withdraw accrued tokens to a specified destination address. |
 
 ---
 

--- a/script/validate-doc-alignment.py
+++ b/script/validate-doc-alignment.py
@@ -5,12 +5,14 @@ validate-doc-alignment.py
 Validates that integration-critical identifiers defined in Rust contract source
 files are documented in the corresponding Markdown documentation files.
 
-Checks three categories:
+Checks four categories:
   1. Public entrypoints  (pub fn <name>) in contracts/stream/src/lib.rs
      -> must appear in docs/streaming.md
-  2. Event symbols       (Symbol::short/new) in contracts/core/src/events.rs
+  2. Contractimpl entrypoints (pub fn inside #[contractimpl] impl FluxoraStream)
+     -> must appear in the docs/audit.md entrypoint table (bidirectional)
+  3. Event symbols       (Symbol::short/new) in contracts/stream/src/lib.rs
      -> must appear in docs/events.md
-  3. Error enum variants in contracts/core/src/error.rs
+  4. Error enum variants in contracts/stream/src/lib.rs
      -> must appear in docs/error.md
 """
 
@@ -56,6 +58,10 @@ MAPPING = {
     "DOC_ERROR": (
         REPO_ROOT / "docs" / "error.md",
         "**/docs/error.md",
+    ),
+    "DOC_AUDIT": (
+        REPO_ROOT / "docs" / "audit.md",
+        "**/docs/audit.md",
     ),
 }
 
@@ -154,9 +160,54 @@ _RE_CONTRACT_ERROR_BODY = re.compile(
     re.DOTALL,
 )
 
+_RE_CONTRACTIMPL_BLOCK = re.compile(
+    r"#\[contractimpl\]\s*\nimpl\s+FluxoraStream\s*\{",
+    re.MULTILINE,
+)
+
+_RE_AUDIT_TABLE_ROW = re.compile(r"^\| `([^`]+)`\s+\|", re.MULTILINE)
+
+_VERSION_CONTRADICTION = "There is no `version` entrypoint"
+
 def extract_entrypoints(source: str) -> set:
     names = set(_RE_ENTRYPOINT.findall(source))
     return names - ENTRYPOINT_ALLOWLIST
+
+def extract_contractimpl_entrypoints(source: str) -> set:
+    """Return pub fn names declared inside the FluxoraStream #[contractimpl] block."""
+    match = _RE_CONTRACTIMPL_BLOCK.search(source)
+    if not match:
+        return set()
+
+    brace_start = source.find("{", match.start())
+    if brace_start == -1:
+        return set()
+
+    depth = 0
+    for index in range(brace_start, len(source)):
+        char = source[index]
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                block = source[brace_start:index + 1]
+                names = set(_RE_ENTRYPOINT.findall(block))
+                return names - ENTRYPOINT_ALLOWLIST
+    return set()
+
+def extract_audit_table_entrypoints(doc_text: str) -> set:
+    """Return entrypoint names listed in the docs/audit.md public entrypoints table."""
+    section_start = doc_text.find("## Public entrypoints")
+    if section_start == -1:
+        return set()
+
+    section = doc_text[section_start:]
+    table_end = section.find("\n---")
+    if table_end != -1:
+        section = section[:table_end]
+
+    return set(_RE_AUDIT_TABLE_ROW.findall(section))
 
 def extract_event_symbols(source: str) -> set:
     out: set[str] = set()
@@ -204,6 +255,7 @@ def validate(
     streaming_doc: Path,
     events_doc: Path,
     error_doc: Path,
+    audit_doc: Path,
 ) -> int:
     """Run all alignment checks. Returns 0 on success, 1 on any drift."""
     source = contract_path.read_text(encoding="utf-8")
@@ -212,6 +264,7 @@ def validate(
     streaming_text = streaming_doc.read_text(encoding="utf-8")
     events_text = events_doc.read_text(encoding="utf-8")
     error_text = error_doc.read_text(encoding="utf-8")
+    audit_text = audit_doc.read_text(encoding="utf-8")
 
     checks = [
         (extract_entrypoints(source), streaming_text, streaming_doc, "entrypoint"),
@@ -229,6 +282,38 @@ def validate(
                 display = doc_path
             print(f"MISSING DOC: '{ident}' ({kind}) found in code but not in '{display}'")
             drift_found = True
+
+    contractimpl_entrypoints = extract_contractimpl_entrypoints(source)
+    audit_table_entrypoints = extract_audit_table_entrypoints(audit_text)
+
+    for ident in sorted(contractimpl_entrypoints - audit_table_entrypoints):
+        try:
+            display = audit_doc.relative_to(REPO_ROOT)
+        except ValueError:
+            display = audit_doc
+        print(
+            f"MISSING DOC: '{ident}' (audit entrypoint) found in contractimpl "
+            f"but not in '{display}' table"
+        )
+        drift_found = True
+
+    for ident in sorted(audit_table_entrypoints - contractimpl_entrypoints):
+        try:
+            display = audit_doc.relative_to(REPO_ROOT)
+        except ValueError:
+            display = audit_doc
+        print(
+            f"STALE DOC: '{ident}' (audit entrypoint) listed in '{display}' "
+            "but not in contractimpl"
+        )
+        drift_found = True
+
+    if _VERSION_CONTRADICTION in audit_text:
+        print(
+            "AUDIT CONTRADICTION: docs/audit.md contains the deprecated "
+            f"'{_VERSION_CONTRADICTION}' sentence"
+        )
+        drift_found = True
 
     if check_duplicate_discriminants(error_source):
         drift_found = True
@@ -250,6 +335,7 @@ def main() -> int:
         resolved["DOC_STREAMING"],
         resolved["DOC_EVENTS"],
         resolved["DOC_ERROR"],
+        resolved["DOC_AUDIT"],
     )
 
 if __name__ == "__main__":

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -33,13 +33,27 @@ vda = _load_module()
 
 MINIMAL_LIB_RS = """\
 #[contractimpl]
-impl MyContract {
+impl FluxoraStream {
     pub fn init(env: Env) -> Result<(), Error> { Ok(()) }
     pub fn create_stream(env: Env) -> Result<u64, Error> { Ok(0) }
     pub fn withdraw(env: Env) -> Result<i128, Error> { Ok(0) }
 }
 pub fn save_stream(env: &Env) {}
 fn private_helper() {}
+"""
+
+MINIMAL_AUDIT_DOC = """\
+# Audit
+
+## Public entrypoints
+
+| Entrypoint | Parameters | Return type | Authorization | Description |
+| --- | --- | --- | --- | --- |
+| `init` | `env: Env` | — | Admin | Init |
+| `create_stream` | `env: Env` | `u64` | Sender | Create |
+| `withdraw` | `env: Env` | `i128` | Recipient | Withdraw |
+
+---
 """
 
 MINIMAL_EVENTS_RS = """\
@@ -78,8 +92,9 @@ def _write_files(
     streaming: str = STREAMING_DOC,
     events: str = EVENTS_DOC,
     error: str = ERROR_DOC,
+    audit: str = MINIMAL_AUDIT_DOC,
 ):
-    """Write all six files to tmp_path and return their paths as a tuple."""
+    """Write all seven files to tmp_path and return their paths as a tuple."""
     data = {
         "lib.rs": lib_rs,
         "events.rs": events_rs,
@@ -87,6 +102,7 @@ def _write_files(
         "streaming.md": streaming,
         "events.md": events,
         "error.md": error,
+        "audit.md": audit,
     }
     paths = {}
     for name, content in data.items():
@@ -100,15 +116,16 @@ def _write_files(
         paths["streaming.md"],
         paths["events.md"],
         paths["error.md"],
+        paths["audit.md"],
     )
 
 
 def _fake_mapping(tmp_path: Path, files: tuple, missing_key: str = None) -> dict:
     """Build a MAPPING dict pointing at real tmp_path files."""
     keys = ["CONTRACT_SRC", "EVENTS_SRC", "ERROR_SRC",
-            "DOC_STREAMING", "DOC_EVENTS", "DOC_ERROR"]
+            "DOC_STREAMING", "DOC_EVENTS", "DOC_ERROR", "DOC_AUDIT"]
     names = ["lib.rs", "events.rs", "error.rs",
-             "streaming.md", "events.md", "error.md"]
+             "streaming.md", "events.md", "error.md", "audit.md"]
     mapping = {}
     for key, name, path in zip(keys, names, files):
         if key == missing_key:
@@ -175,7 +192,7 @@ class TestResolveAll:
         monkeypatch.setattr(vda, "REPO_ROOT", tmp_path)
         resolved, ok = vda.resolve_all()
         assert ok is True
-        assert len(resolved) == 6
+        assert len(resolved) == 7
 
     def test_missing_file_returns_not_ok(self, tmp_path, monkeypatch):
         files = _write_files(tmp_path)
@@ -294,6 +311,54 @@ class TestExtractEntrypoints:
 # extract_event_symbols
 # ---------------------------------------------------------------------------
 
+class TestExtractContractimplEntrypoints:
+    CONTRACTIMPL_SRC = """\
+#[contractimpl]
+impl FluxoraStream {
+    pub fn init(env: Env) -> Result<(), Error> { Ok(()) }
+    pub fn withdraw(env: Env) -> Result<i128, Error> { Ok(0) }
+}
+pub fn upgrade(env: Env) -> Result<(), Error> { Ok(()) }
+pub fn save_stream(env: &Env) {}
+"""
+
+    def test_finds_contractimpl_entrypoints(self):
+        result = vda.extract_contractimpl_entrypoints(self.CONTRACTIMPL_SRC)
+        assert result == {"init", "withdraw"}
+
+    def test_ignores_outside_contractimpl(self):
+        result = vda.extract_contractimpl_entrypoints(self.CONTRACTIMPL_SRC)
+        assert "upgrade" not in result
+        assert "save_stream" not in result
+
+    def test_missing_contractimpl_returns_empty(self):
+        assert vda.extract_contractimpl_entrypoints("pub fn foo() {}") == set()
+
+
+class TestExtractAuditTableEntrypoints:
+    AUDIT_DOC = """\
+## Public entrypoints
+
+| Entrypoint | Parameters | Return type | Authorization | Description |
+| --- | --- | --- | --- | --- |
+| `init` | `env: Env` | — | Admin | Init |
+| `withdraw` | `env: Env` | `i128` | Recipient | Withdraw |
+
+---
+
+## Invariants
+"""
+
+    def test_parses_table_rows(self):
+        assert vda.extract_audit_table_entrypoints(self.AUDIT_DOC) == {
+            "init",
+            "withdraw",
+        }
+
+    def test_missing_section_returns_empty(self):
+        assert vda.extract_audit_table_entrypoints("# No table") == set()
+
+
 class TestExtractEventSymbols:
     def test_finds_symbol_short(self):
         assert "created" in vda.extract_event_symbols(
@@ -390,6 +455,66 @@ class TestCheckMissing:
 class TestValidate:
     def test_passes_on_full_alignment(self, tmp_path):
         assert vda.validate(*_write_files(tmp_path)) == 0
+
+    def test_fails_on_missing_audit_entrypoint(self, tmp_path):
+        paths = _write_files(
+            tmp_path,
+            audit="""\
+## Public entrypoints
+
+| Entrypoint | Parameters | Return type | Authorization | Description |
+| --- | --- | --- | --- | --- |
+| `init` | `env: Env` | — | Admin | Init |
+
+---
+""",
+        )
+        assert vda.validate(*paths) == 1
+
+    def test_fails_on_stale_audit_entrypoint(self, tmp_path):
+        paths = _write_files(
+            tmp_path,
+            audit="""\
+## Public entrypoints
+
+| Entrypoint | Parameters | Return type | Authorization | Description |
+| --- | --- | --- | --- | --- |
+| `init` | `env: Env` | — | Admin | Init |
+| `create_stream` | `env: Env` | `u64` | Sender | Create |
+| `withdraw` | `env: Env` | `i128` | Recipient | Withdraw |
+| `removed_fn` | `env: Env` | — | Anyone | Stale |
+
+---
+""",
+        )
+        assert vda.validate(*paths) == 1
+
+    def test_fails_on_version_contradiction(self, tmp_path):
+        paths = _write_files(
+            tmp_path,
+            audit=MINIMAL_AUDIT_DOC
+            + "\nThere is no `version` entrypoint in the contract.\n",
+        )
+        assert vda.validate(*paths) == 1
+
+    def test_prints_stale_audit_message(self, tmp_path, capsys):
+        paths = _write_files(
+            tmp_path,
+            audit="""\
+## Public entrypoints
+
+| Entrypoint | Parameters | Return type | Authorization | Description |
+| --- | --- | --- | --- | --- |
+| `init` | `env: Env` | — | Admin | Init |
+| `create_stream` | `env: Env` | `u64` | Sender | Create |
+| `withdraw` | `env: Env` | `i128` | Recipient | Withdraw |
+| `removed_fn` | `env: Env` | — | Anyone | Stale |
+
+---
+""",
+        )
+        vda.validate(*paths)
+        assert "STALE DOC:" in capsys.readouterr().out
 
     def test_fails_on_missing_entrypoint(self, tmp_path):
         paths = _write_files(
@@ -514,6 +639,10 @@ class TestMain:
         self._patch(monkeypatch, tmp_path, "DOC_ERROR")
         assert vda.main() == 1
 
+    def test_missing_audit_doc_returns_1(self, tmp_path, monkeypatch):
+        self._patch(monkeypatch, tmp_path, "DOC_AUDIT")
+        assert vda.main() == 1
+
     def test_missing_file_prints_file_missing_tag(
             self, tmp_path, monkeypatch, capsys):
         self._patch(monkeypatch, tmp_path, "CONTRACT_SRC")
@@ -573,6 +702,24 @@ class TestEntrypointAllowlistFullCoverage:
         assert "require_not_globally_paused" not in vda.extract_entrypoints(
             "pub fn require_not_globally_paused(env: &Env) {}"
         )
+
+
+class TestRealRepoAuditAlignment:
+    """Integration guard: docs/audit.md must mirror the live contractimpl surface."""
+
+    def test_audit_table_matches_contractimpl(self):
+        repo_root = Path(__file__).resolve().parent.parent
+        lib_rs = (repo_root / "contracts" / "stream" / "src" / "lib.rs").read_text(
+            encoding="utf-8"
+        )
+        audit_md = (repo_root / "docs" / "audit.md").read_text(encoding="utf-8")
+
+        contractimpl = vda.extract_contractimpl_entrypoints(lib_rs)
+        audit_table = vda.extract_audit_table_entrypoints(audit_md)
+
+        assert len(contractimpl) >= 70
+        assert contractimpl == audit_table
+        assert vda._VERSION_CONTRADICTION not in audit_md
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #1050

## Summary
- Rewrite docs/audit.md's entrypoint table to cover the full 70+ pub fn surface and remove the version-entrypoint contradiction

## Test plan
- [ ] Relevant tests pass locally
- [ ] Manual verification on affected UI or API paths