### PR TITLE
test: add Kani proofs for clock monotonicity and CliffOnly accrual

### DIFF
--- a/contracts/stream/tests/formal_verification_smoke.rs
+++ b/contracts/stream/tests/formal_verification_smoke.rs
@@ -1,7 +1,11 @@
 #![cfg(test)]
 extern crate std;
 
-use crate::accrual::calculate_accrued_amount;
+use crate::accrual::{
+    assert_ledger_time_monotonic, calculate_accrued_amount, calculate_accrued_amount_checkpointed,
+    CheckpointState,
+};
+use crate::StreamKind;
 
 /// Smoke test for accrual (existing)
 #[test]
@@ -11,6 +15,68 @@ fn smoke_accrual_examples() {
 
     let r2 = calculate_accrued_amount(0, 100, 200, 1, 100, 150);
     assert_eq!(r2, 50);
+}
+
+// ---------------------------------------------------------------------------
+// Kani harnesses for clock monotonicity and CliffOnly accrual (gated)
+// ---------------------------------------------------------------------------
+
+#[cfg(kani)]
+mod kani_accrual_security {
+    use super::*;
+    use crate::ContractError;
+
+    /// Kani proof: the ledger-time guard reports ClockRegression exactly when
+    /// the current timestamp is earlier than the previous timestamp.
+    #[kani::proof]
+    fn ledger_time_monotonic_guard() {
+        let prev_ts: u64 = kani::any();
+        let current_ts: u64 = kani::any();
+
+        let result = assert_ledger_time_monotonic(prev_ts, current_ts);
+
+        if current_ts < prev_ts {
+            assert_eq!(result, Err(ContractError::ClockRegression));
+        } else {
+            assert_eq!(result, Ok(()));
+        }
+    }
+
+    /// Kani proof: a CliffOnly stream pays its full nonnegative deposit at or
+    /// after the cliff, pays nothing before it, and never leaves the deposit
+    /// bounds regardless of the other symbolic stream parameters.
+    #[kani::proof]
+    fn cliff_only_accrual_exact_and_bounded() {
+        let checkpointed_amount: i128 = kani::any();
+        let checkpointed_at: u64 = kani::any();
+        let cliff_time: u64 = kani::any();
+        let end_time: u64 = kani::any();
+        let deposit_amount: i128 = kani::any();
+        let rate_per_second: i128 = kani::any();
+        let now: u64 = kani::any();
+
+        kani::assume(deposit_amount >= 0);
+
+        let state = CheckpointState {
+            checkpointed_amount,
+            checkpointed_at,
+            cliff_time,
+            end_time,
+            deposit_amount,
+            kind: StreamKind::CliffOnly,
+        };
+
+        let accrued = calculate_accrued_amount_checkpointed(state, rate_per_second, now);
+
+        if now >= cliff_time {
+            assert_eq!(accrued, deposit_amount);
+        } else {
+            assert_eq!(accrued, 0);
+        }
+
+        assert!(accrued >= 0);
+        assert!(accrued <= deposit_amount);
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/docs/formal-verification.md
+++ b/docs/formal-verification.md
@@ -6,6 +6,14 @@ This document describes the Kani proof harnesses in Fluxora Contracts.
 - Located in `contracts/stream/src/accrual.rs` (and exercised via tests).
 - Proofs cover result bounds, monotonicity, and clamping.
 
+## Clock monotonicity and CliffOnly proofs (new)
+- Harnesses in `contracts/stream/tests/formal_verification_smoke.rs` under `kani_accrual_security`.
+  - `ledger_time_monotonic_guard`
+    - Proves `assert_ledger_time_monotonic` returns `Err(ClockRegression)` if and only if `current_ts < prev_ts` across the full symbolic `u64` domain.
+  - `cliff_only_accrual_exact_and_bounded`
+    - Proves a `StreamKind::CliffOnly` stream returns exactly `deposit_amount` at or after `cliff_time` and `0` before it across the full symbolic `i128`/`u64` domain.
+    - Proves the result remains within `[0, deposit_amount]` for every nonnegative symbolic deposit.
+
 ## Keeper-fee conservation proofs (new)
 - Pure helper: `compute_keeper_fee_split(gross, bps)` in `lib.rs`.
 - Harness: `keeper_fee_conservation` (in `formal_verification_smoke.rs` under `#[cfg(kani)]`).
@@ -34,6 +42,10 @@ This document describes the Kani proof harnesses in Fluxora Contracts.
 ```bash
 # Accrual (original)
 kani contracts/stream/src/accrual.rs --recursive
+
+# Clock monotonicity and CliffOnly accrual (via smoke harness)
+kani contracts/stream/tests/formal_verification_smoke.rs --harness ledger_time_monotonic_guard
+kani contracts/stream/tests/formal_verification_smoke.rs --harness cliff_only_accrual_exact_and_bounded
 
 # Fee + governance (via smoke harness)
 kani contracts/stream/tests/formal_verification_smoke.rs --harness keeper_fee_conservation


### PR DESCRIPTION
## Summary

Added formal Kani proofs for two security-relevant stream invariants that were previously missing from the formal verification coverage: ledger-time monotonicity and `StreamKind::CliffOnly` accrual behavior.

The new harnesses verify that clock regression is rejected correctly and that CliffOnly streams return exactly the full deposit at or after the cliff while remaining bounded within the valid accrual range.

Closes: #1019

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation
- [ ] Chore / Maintenance

## Checklist

- [x] Tests added/updated
- [ ] `npm run pr:check` passes locally
- [ ] Migration notes included (if applicable)
- [x] Docs updated (if applicable)

## How to test

Run the stream test suite:

```bash
cargo test -p fluxora_stream