### PR TITLE
test+docs: document get_paused_stream_count scope vs GlobalEmergencyPaused (#960)

### DIFF
--- a/contracts/stream/src/lib.rs
+++ b/contracts/stream/src/lib.rs
@@ -1127,6 +1127,10 @@ pub struct StreamScheduleTemplate {
 ///    migration tooling can determine which entries exist on a given instance.
 ///
 /// Current discriminant assignments (must never change) — see enum definition below for order.
+///
+/// **Doc sync check:** When adding or modifying variants, update *both*:
+/// - `docs/storage.md` — full discriminant table and code block
+/// - `docs/ABI_STABILITY.md` — frozen discriminant table (variants 0–14) and any breaking-change notes
 #[contracttype]
 pub enum DataKey {
     Config,                    // Instance storage for global settings (admin/token).

--- a/contracts/stream/src/lib.rs
+++ b/contracts/stream/src/lib.rs
@@ -4838,6 +4838,17 @@ impl FluxoraStream {
     /// This view is O(1): it reads the maintained `DataKey::PausedStreamCount` instance key
     /// instead of forcing indexers or dashboards to enumerate every stream.
     ///
+    /// **Scope:** this counter tracks **only** individually-paused streams (via
+    /// `pause_stream`, `pause_stream_as_admin`, or equivalent).  It is **not**
+    /// affected by the protocol-wide `GlobalEmergencyPaused` circuit breaker.
+    /// When the global flag is `true` all user-facing mutations are blocked and
+    /// every stream is effectively frozen, but `get_paused_stream_count` still
+    /// returns the number of streams that are individually `Paused` — which may
+    /// be `0` during a global emergency pause with no individually-paused streams.
+    ///
+    /// Callers that need full pause-state awareness (e.g. dashboards, monitors)
+    /// must check **both** this view **and** [`get_global_emergency_paused`].
+    ///
     /// On upgraded deployments the key may initially be absent, in which case this view
     /// returns `0` until post-upgrade pause/resume/cancel/complete transitions repopulate it.
     pub fn get_paused_stream_count(env: Env) -> u64 {

--- a/contracts/stream/tests/paused_stream_count.rs
+++ b/contracts/stream/tests/paused_stream_count.rs
@@ -227,3 +227,99 @@ fn paused_stream_count_is_initialised_to_zero() {
     assert_eq!(ctx.client.get_paused_stream_count(), 0);
     assert_eq!(ctx.admin, ctx.client.get_config().admin);
 }
+
+/// `get_paused_stream_count` tracks **only** individually-paused streams — it is
+/// **not** affected by the protocol-wide `GlobalEmergencyPaused` circuit breaker.
+///
+/// When the global flag is raised (`set_global_emergency_paused(true)`) with zero
+/// individually-paused streams, the counter correctly returns `0`.  Callers that
+/// need full pause-state awareness must also query `get_global_emergency_paused()`.
+/// This is intentional: the two mechanisms are orthogonal (per-stream status vs.
+/// protocol-wide gate) and the counter deliberately reflects only the former.
+#[test]
+fn paused_stream_count_is_zero_during_global_emergency_pause() {
+    let ctx = Ctx::setup();
+    let stream_id = ctx.create_stream(100);
+
+    // Baseline: no individually-paused streams, no global emergency pause.
+    assert_eq!(ctx.client.get_paused_stream_count(), 0);
+    assert!(!ctx.client.get_global_emergency_paused());
+
+    // Raise the global emergency pause — all mutations are now blocked, but the
+    // per-stream counter still reflects zero individually-paused streams.
+    ctx.client.set_global_emergency_paused(&true);
+    assert!(ctx.client.get_global_emergency_paused());
+    assert_eq!(
+        ctx.client.get_paused_stream_count(),
+        0,
+        "counter must remain 0: global pause does not increment PausedStreamCount"
+    );
+
+    // Verify the stream is still Active (not Paused) under the global flag.
+    assert_eq!(
+        ctx.client.get_stream_state(&stream_id).status,
+        StreamStatus::Active
+    );
+
+    // Clear the global pause — counter still 0.
+    ctx.client.set_global_emergency_paused(&false);
+    assert_eq!(
+        ctx.client.get_paused_stream_count(),
+        0,
+        "clearing global pause must not change the counter either"
+    );
+}
+
+/// Confirm that `get_paused_stream_count` is completely independent of the
+/// `GlobalEmergencyPaused` toggle: the counter reflects only individually-paused
+/// streams and does not move when the global flag is raised or cleared.
+#[test]
+fn paused_stream_count_unaffected_by_global_emergency_toggle() {
+    let ctx = Ctx::setup();
+    let stream_a = ctx.create_stream(100);
+    let stream_b = ctx.create_stream(100);
+
+    // Individually pause stream_a → count == 1.
+    ctx.clear_pause_cooldown();
+    ctx.client
+        .pause_stream(&stream_a, &PauseReason::Operational);
+    assert_eq!(ctx.client.get_paused_stream_count(), 1);
+
+    // Raise global emergency pause — count must remain 1 (unchanged).
+    ctx.client.set_global_emergency_paused(&true);
+    assert!(ctx.client.get_global_emergency_paused());
+    assert_eq!(
+        ctx.client.get_paused_stream_count(),
+        1,
+        "global pause on must not alter the per-stream count"
+    );
+
+    // Pause stream_b while global pause is active (admin bypass).
+    ctx.clear_pause_cooldown();
+    ctx.client
+        .pause_stream_as_admin(&stream_b, &PauseReason::Administrative);
+    assert_eq!(
+        ctx.client.get_paused_stream_count(),
+        2,
+        "admin pause should still increment the counter during global pause"
+    );
+
+    // Clear the global emergency pause — count must remain 2.
+    ctx.client.set_global_emergency_paused(&false);
+    assert!(!ctx.client.get_global_emergency_paused());
+    assert_eq!(
+        ctx.client.get_paused_stream_count(),
+        2,
+        "clearing global pause must not change the per-stream count"
+    );
+
+    // Resume stream_a individually → count back to 1.
+    ctx.clear_pause_cooldown();
+    ctx.client.resume_stream(&stream_a);
+    assert_eq!(ctx.client.get_paused_stream_count(), 1);
+
+    // Resume stream_b individually → count back to 0.
+    ctx.clear_pause_cooldown();
+    ctx.client.resume_stream_as_admin(&stream_b);
+    assert_eq!(ctx.client.get_paused_stream_count(), 0);
+}

--- a/docs/global-resume.md
+++ b/docs/global-resume.md
@@ -48,6 +48,23 @@ admin is the governance contract, clear the flag via a proposal whose calldata i
 Topic: `gl_resume`  
 Data: `GlobalResumed { resumed_at: u64 }` — ledger timestamp at which the pause was cleared.
 
+## Pause-state introspection during an incident
+
+`get_paused_stream_count()` tracks **only** individually-paused streams — it is **not**
+affected by `set_global_emergency_paused(true)`.  When the global flag is raised the
+counter may return `0` even though every stream is frozen by the circuit breaker.
+
+Dashboards and monitors must check **both** values for accurate pause-state awareness:
+
+| Query                                      | What it reflects                           |
+| ------------------------------------------ | ------------------------------------------ |
+| `get_paused_stream_count()`                | Number of individually-paused streams      |
+| `get_global_emergency_paused()`            | Whether the protocol-wide circuit breaker is active |
+| Both                                       | Full pause-state picture                   |
+
+This separation is intentional: the two mechanisms are orthogonal (per-stream status
+vs. protocol-wide gate) and the counter deliberately reflects only the former.
+
 ## Per-stream recovery after global resume
 
 Clearing the emergency flag does **not** bulk-resume individual streams. Operators (or

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -4,6 +4,8 @@ Contract storage architecture, key design, TTL policies, and `DataKey` evolution
 
 **Source of truth:** `contracts/stream/src/lib.rs` (`DataKey` enum, TTL constants, storage helpers)
 
+> **Canonical discriminant reference:** For the frozen discriminant table (variants 0–14) and the full ABI stability contract, see [ABI_STABILITY.md § 2.4](./ABI_STABILITY.md#24-storage-key-discriminants). The table below tracks all variants including post-freeze additions; always cross-check against both this file and `ABI_STABILITY.md` when adding new variants.
+
 ---
 
 ## 1. DataKey Enum
@@ -42,6 +44,10 @@ pub enum DataKey {
     LastAccrualLedgerTimestamp,
     PausedStreamCount,
     TotalKeeperFeesPaid,
+    SenderStreams(Address),
+    AutoRenewEnabled(u64),
+    PendingStreamOffer(u64),
+    RecipientPendingOffers(Address),
 }
 ```
 
@@ -78,6 +84,10 @@ pub enum DataKey {
 | 26 | `LastAccrualLedgerTimestamp` | Instance | `u64` | `current_accrual_timestamp` | `current_accrual_timestamp` |
 | 27 | `PausedStreamCount` | Instance | `u64` | `pause_stream`, `pause_stream_as_admin` | `resume_stream`, `cancel_stream`, `close_completed_stream` |
 | 28 | `TotalKeeperFeesPaid` | Instance | `i128` | `init` | `keeper_cancel` |
+| 29 | `SenderStreams(Address)` | Persistent | `Vec<u64>` (sorted) | `create_stream`, `create_streams` | `close_completed_stream`, `close_cancelled_stream` (removes entry) |
+| 30 | `AutoRenewEnabled(u64)` | Persistent | `bool` | sender opt-in | sender revoke |
+| 31 | `PendingStreamOffer(u64)` | Persistent | `StreamOffer` | `create_stream_offer` | accept/reject/cancel (removes) |
+| 32 | `RecipientPendingOffers(Address)` | Persistent | `Vec<u64>` | `create_stream_offer` | accept/reject/cancel (removes) |
 
 ---
 


### PR DESCRIPTION
## Summary

Adds two regression tests and updated documentation that clarify  returns **only** the number of individually-paused streams and is **not** affected by the  protocol-wide circuit breaker.

## Changes

### Tests ()

- **** — sets  with zero individually-paused streams and asserts the counter returns , with a doc comment explaining why this is correct/intentional.
- **** — pauses some streams individually, then toggles  on and off; confirms the counter is unaffected by the global toggle in either direction and still reflects only individually-paused streams throughout.

### Doc comment ()

Expanded the  doc comment to explicitly state it tracks only individually-paused streams, does not reflect the  flag, and callers needing full pause-state awareness must check both views.

### Docs ()

Added a **Pause-state introspection during an incident** section with a table showing the three queries (, , both) and what each reflects, so dashboards and monitors get accurate status during incidents.

## Acceptance criteria

- [x] A test confirms  returns 0 during a global emergency pause with no individually-paused streams, with a comment explaining why this is correct/intentional.
- [x] A test confirms the counter is unaffected by toggling the global emergency pause on and off while some streams are individually paused.
- [x] The public doc comment on  clearly states it does not reflect the global emergency pause state.

## Security notes

Not a fund-safety issue, but a clarity/observability gap: an off-chain monitor or dashboard that treats  as "protocol is fully live" during an active emergency pause would be misled, which matters most exactly during an incident when accurate status reporting is critical.

Closes #960