### PR TITLE
fix(factory): emit BatchCapEnforcementUpdated event from set_batch_cap_enforcement (closes #1133)

### DIFF
--- a/contracts/factory/src/lib.rs
+++ b/contracts/factory/src/lib.rs
@@ -415,6 +415,13 @@ pub struct RateBoundsUpdated {
     pub max_rate: Option<i128>,
 }
 
+/// Emitted when the aggregate batch-cap enforcement is toggled (`batch_cap`).
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct BatchCapEnforcementUpdated {
+    pub enabled: bool,
+}
+
 /// Emitted when a stream is successfully created through the factory (`fct_strm`).
 /// Provides enough context for indexers to attribute stream creation to a policy-gated path.
 #[contracttype]
@@ -653,6 +660,10 @@ impl FluxoraFactory {
         // Bump instance TTL after successful update.
         bump_instance(&env);
 
+        env.events().publish(
+            (symbol_short!("batch_cap"),),
+            BatchCapEnforcementUpdated { enabled },
+        );
         Ok(())
     }
 

--- a/contracts/factory/tests/factory_setters.rs
+++ b/contracts/factory/tests/factory_setters.rs
@@ -971,3 +971,55 @@ fn test_set_admin_same_ledger_multiple_setters() {
     factory.set_batch_cap_enforcement(&false);
     assert_eq!(factory.get_factory_config().batch_cap_enforced, false);
 }
+
+// ---------------------------------------------------------------------------
+// issue #1133 — set_batch_cap_enforcement must emit BatchCapEnforcementUpdated
+// ---------------------------------------------------------------------------
+
+/// `set_batch_cap_enforcement(true)` emits a typed `BatchCapEnforcementUpdated`
+/// event with `enabled == true`.
+#[test]
+fn test_set_batch_cap_enforcement_emits_event_true() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let fid = env.register_contract(None, FluxoraFactory);
+    let factory = FluxoraFactoryClient::new(&env, &fid);
+    let admin = Address::generate(&env);
+    let sc = Address::generate(&env);
+
+    factory.init(&admin, &sc, &5_000, &200);
+
+    factory.set_batch_cap_enforcement(&true);
+
+    let events = env.events().all();
+    let (_, topics, data) = events.get(events.len() - 1).unwrap();
+    let topic0: soroban_sdk::Symbol = topics.get(0).unwrap().try_into_val(&env).unwrap();
+    assert_eq!(topic0, soroban_sdk::symbol_short!("batch_cap"));
+    let payload: fluxora_factory::BatchCapEnforcementUpdated =
+        data.try_into_val(&env).unwrap();
+    assert_eq!(payload.enabled, true);
+}
+
+/// `set_batch_cap_enforcement(false)` emits the same event with `enabled == false`.
+#[test]
+fn test_set_batch_cap_enforcement_emits_event_false() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let fid = env.register_contract(None, FluxoraFactory);
+    let factory = FluxoraFactoryClient::new(&env, &fid);
+    let admin = Address::generate(&env);
+    let sc = Address::generate(&env);
+
+    factory.init(&admin, &sc, &5_000, &200);
+    factory.set_batch_cap_enforcement(&true);
+
+    factory.set_batch_cap_enforcement(&false);
+
+    let events = env.events().all();
+    let (_, topics, data) = events.get(events.len() - 1).unwrap();
+    let topic0: soroban_sdk::Symbol = topics.get(0).unwrap().try_into_val(&env).unwrap();
+    assert_eq!(topic0, soroban_sdk::symbol_short!("batch_cap"));
+    let payload: fluxora_factory::BatchCapEnforcementUpdated =
+        data.try_into_val(&env).unwrap();
+    assert_eq!(payload.enabled, false);
+}

--- a/docs/factory.md
+++ b/docs/factory.md
@@ -268,6 +268,7 @@ the `symbol_short!` constraint.
 | `set_cap` | `cap_upd` | `CapUpdated { old_cap, new_cap }` | Both old and new values are included. |
 | `set_min_duration` | `dur_upd` | `MinDurationUpdated { old_min_duration, new_min_duration }` | Both old and new values are included. |
 | `set_rate_bounds` | `rate_bnd` | `RateBoundsUpdated { min_rate, max_rate }` | Carries the arguments passed by the caller; `None` means "unchanged". |
+| `set_batch_cap_enforcement` | `batch_cap` | `BatchCapEnforcementUpdated { enabled }` | Emits `true` or `false` as set by the admin. |
 | `set_factory_paused` | `factory` + `paused`/`resumed` | `bool` | Pre-existing event, unchanged. |
 | `create_stream` (success) | `fct_strm` | `FactoryStreamCreated { stream_id, sender, recipient, deposit_amount, rate_per_second }` | Emitted only after the cross-contract call succeeds. Lets indexers attribute a stream to the policy-gated factory path. |
 


### PR DESCRIPTION
## Summary

Fixes #1133 — set_batch_cap_enforcement was the only state-changing factory setter that did not emit an event, contradicting docs/factory.md's "every state-changing entrypoint emits an event" claim. Disabling batch_cap_enforced (which gates the aggregate deposit cap on create_streams) left no on-chain audit trail.

### Changes
- Added BatchCapEnforcementUpdated { enabled: bool } event struct (#[contracttype]).
- Emit it from set_batch_cap_enforcement with symbol_short!("batch_cap") topic, consistent with sibling setters.
- Added the row to the events table in docs/factory.md.
- Added 2 unit tests in contracts/factory/tests/factory_setters.rs asserting the event payload for enabled = true and false.

### Verification
- cargo +1.94.1 check -p fluxora_factory --tests is clean for this package.
- New tests compile and pass when run in isolation (cargo test -p fluxora_factory --test factory_setters --features testutils).

### CI blocker (not from this PR)
cargo test --all currently fails on origin/main because the stream crate does not compile (37 errors from unrelated WIP features: PooledStreamShares, RateCooldownActive, StreamKind::CliffSlope, claim_owner/witness/irrevocable fields, etc. — see open issues #1205, #1206, #1208, #1212). This PR only touches the factory crate and cannot make the workspace build until those stream errors are resolved. Requesting maintainer to either merge after the stream crate is fixed, or run factory-scoped CI.

Closes #1133