### PR TITLE
feat: extend FactoryConfig and add InvalidRateBounds error

### DIFF
--- a/contracts/factory/src/lib.rs
+++ b/contracts/factory/src/lib.rs
@@ -72,6 +72,11 @@ pub enum FactoryError {
     /// Returned by `init` and `set_stream_contract` instead of letting an
     /// invalid address be persisted and later host-trap inside `create_stream`.
     InvalidStreamContract = 17,
+    /// `set_rate_bounds` received an invalid rate-bounds configuration
+    /// (negative bound, or min > max). Distinct from
+    /// [`StreamContractError`] so callers can distinguish admin input
+    /// validation failures from genuine downstream cross-contract errors.
+    InvalidRateBounds = 18,
 }
 
 #[contracttype]
@@ -240,6 +245,10 @@ fn validate_min_duration(min_duration: u64) -> Result<(), FactoryError> {
 }
 
 /// Read-only snapshot of the factory policy stored in instance storage.
+///
+/// Mirrors every field in [`FactoryPolicy`] plus `admin`, so a single
+/// `get_factory_config()` call returns the complete effective factory
+/// configuration without requiring additional view calls.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct FactoryConfig {
@@ -248,6 +257,12 @@ pub struct FactoryConfig {
     pub max_deposit: i128,
     pub min_duration: u64,
     pub batch_cap_enforced: bool,
+    /// Whether factory stream creation is currently paused.
+    pub creation_paused: bool,
+    /// Optional inclusive lower bound on `rate_per_second`. `None` is permissive.
+    pub min_rate_per_second: Option<i128>,
+    /// Optional inclusive upper bound on `rate_per_second`. `None` is permissive.
+    pub max_rate_per_second: Option<i128>,
 }
 
 /// Full snapshot of the factory policy required by both creation paths.
@@ -683,8 +698,7 @@ impl FluxoraFactory {
 
         if let Some(min_v) = min_rate {
             if min_v < 0 {
-                // rates are non-negative by domain convention; reject negative explicitly
-                return Err(FactoryError::StreamContractError); // reuse or could add new, but keep minimal
+                return Err(FactoryError::InvalidRateBounds);
             }
             env.storage()
                 .instance()
@@ -692,7 +706,7 @@ impl FluxoraFactory {
         }
         if let Some(max_v) = max_rate {
             if max_v < 0 {
-                return Err(FactoryError::StreamContractError);
+                return Err(FactoryError::InvalidRateBounds);
             }
             env.storage()
                 .instance()
@@ -704,7 +718,7 @@ impl FluxoraFactory {
         let current_max: Option<i128> = env.storage().instance().get(&DataKey::MaxRatePerSecond);
         if let (Some(mn), Some(mx)) = (current_min, current_max) {
             if mn > mx {
-                return Err(FactoryError::StreamContractError);
+                return Err(FactoryError::InvalidRateBounds);
             }
         }
 
@@ -769,33 +783,26 @@ impl FluxoraFactory {
     }
 
     /// Return the current factory policy configuration.
+    ///
+    /// Returns every field tracked by [`FactoryPolicy`] plus `admin`, so a
+    /// single call reconstructs the complete effective policy without
+    /// additional calls to `is_factory_paused()` or probing rate bounds.
     pub fn get_factory_config(env: Env) -> Result<FactoryConfig, FactoryError> {
+        let policy = load_policy(&env)?;
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(FactoryError::NotInitialized)?;
         Ok(FactoryConfig {
-            admin: env
-                .storage()
-                .instance()
-                .get(&DataKey::Admin)
-                .ok_or(FactoryError::NotInitialized)?,
-            stream_contract: env
-                .storage()
-                .instance()
-                .get(&DataKey::StreamContract)
-                .ok_or(FactoryError::NotInitialized)?,
-            max_deposit: env
-                .storage()
-                .instance()
-                .get(&DataKey::MaxDepositCap)
-                .ok_or(FactoryError::NotInitialized)?,
-            min_duration: env
-                .storage()
-                .instance()
-                .get(&DataKey::MinDuration)
-                .ok_or(FactoryError::NotInitialized)?,
-            batch_cap_enforced: env
-                .storage()
-                .instance()
-                .get(&DataKey::BatchCapEnforced)
-                .ok_or(FactoryError::NotInitialized)?,
+            admin,
+            stream_contract: policy.stream_contract,
+            max_deposit: policy.max_deposit,
+            min_duration: policy.min_duration,
+            batch_cap_enforced: policy.batch_cap_enforced,
+            creation_paused: policy.creation_paused,
+            min_rate_per_second: policy.min_rate_per_second,
+            max_rate_per_second: policy.max_rate_per_second,
         })
     }
 

--- a/contracts/factory/tests/factory_setters.rs
+++ b/contracts/factory/tests/factory_setters.rs
@@ -36,6 +36,9 @@ fn test_init_happy_path() {
     assert_eq!(cfg.stream_contract, sc);
     assert_eq!(cfg.max_deposit, 5_000);
     assert_eq!(cfg.min_duration, 200);
+    assert!(!cfg.creation_paused, "creation_paused defaults to false");
+    assert_eq!(cfg.min_rate_per_second, None);
+    assert_eq!(cfg.max_rate_per_second, None);
 }
 
 /// Calling `init` a second time returns `AlreadyInitialized`.
@@ -574,6 +577,38 @@ fn test_idle_factory_recovers_on_first_setter() {
 
 /// Test that set_rate_bounds bumps instance TTL.
 #[test]
+/// `set_rate_bounds(Some(-1), None)` returns `InvalidRateBounds` (not
+/// `StreamContractError`).
+#[test]
+fn test_set_rate_bounds_rejects_negative_min_rate() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let fid = env.register_contract(None, FluxoraFactory);
+    let factory = FluxoraFactoryClient::new(&env, &fid);
+    let admin = Address::generate(&env);
+    let sc = Address::generate(&env);
+    factory.init(&admin, &sc, &10_000, &100);
+
+    let result = factory.try_set_rate_bounds(&Some(-1_i128), &None);
+    assert_eq!(result, Err(Ok(FactoryError::InvalidRateBounds)));
+}
+
+/// `set_rate_bounds(Some(100), Some(50))` with `min > max` returns
+/// `InvalidRateBounds`.
+#[test]
+fn test_set_rate_bounds_rejects_min_greater_than_max() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let fid = env.register_contract(None, FluxoraFactory);
+    let factory = FluxoraFactoryClient::new(&env, &fid);
+    let admin = Address::generate(&env);
+    let sc = Address::generate(&env);
+    factory.init(&admin, &sc, &10_000, &100);
+
+    let result = factory.try_set_rate_bounds(&Some(100_i128), &Some(50_i128));
+    assert_eq!(result, Err(Ok(FactoryError::InvalidRateBounds)));
+}
+
 fn test_set_rate_bounds_bumps_instance_ttl() {
     let env = Env::default();
     env.mock_all_auths();

--- a/docs/error.md
+++ b/docs/error.md
@@ -885,12 +885,14 @@ must be appended at the end so existing on-chain error mappings stay byte-identi
 | 8 | `InvalidCliff` | `cliff_time < start_time` OR `cliff_time > end_time` (cliff must be inside the inclusive start/end window) | `create_stream`, `create_streams` |
 | 9 | `CreationPaused` | `DataKey::CreationPaused == true` (factory-level pause); checked first, before any policy/allowlist read | `create_stream`, `create_streams` |
 | 10 | `StreamContractPaused` | Downstream `FluxoraStream` returned `ContractError::ContractPaused` (creation pause active on the stream contract) | `create_stream` |
-| 11 | `StreamContractError` | **Cross-contract failure wrapper**: downstream `FluxoraStream` rejected creation for any other reason (typed error OR transport-level panic). Also reused by `set_rate_bounds` when `min`/`max` are negative or `min > max`. See [Wrapper Semantics](#streamcontracterror-11-wrapper-semantics) below. | `create_stream` (catch-all), `set_rate_bounds` |
+| 11 | `StreamContractError` | **Cross-contract failure wrapper**: downstream `FluxoraStream` rejected creation for any other reason (typed error OR transport-level panic). See [Wrapper Semantics](#streamcontracterror-11-wrapper-semantics) below. | `create_stream` (catch-all) |
 | 12 | `RateBelowMin` | `rate_per_second < MinRatePerSecond` and a min bound is configured (bounds are inclusive) | `create_stream`, `create_streams` |
 | 13 | `RateAboveMax` | `rate_per_second > MaxRatePerSecond` and a max bound is configured (bounds are inclusive) | `create_stream`, `create_streams` |
 | 14 | `InvalidCap` | `max_deposit <= 0`; accepted range is `1..=i128::MAX` | `init`, `set_cap` |
 | 15 | `InvalidMinDuration` | `min_duration > MAX_MIN_DURATION_SECONDS` (≈ 3_153_600_000, i.e. 100 years × 365 days); accepted range is `0..=MAX_MIN_DURATION_SECONDS` | `init`, `set_min_duration` |
 | 16 | `InvalidMemo` | `memo.len() > fluxora_stream::MAX_MEMO_BYTES` | `create_stream`, `create_streams` |
+| 17 | `InvalidStreamContract` | Supplied `stream_contract` address did not respond to `FluxoraStream::version()` smoke check | `init`, `set_stream_contract` |
+| 18 | `InvalidRateBounds` | `set_rate_bounds` received an invalid configuration (negative bound, or `min > max`) | `set_rate_bounds` |
 
 **Range constants referenced above:**
 

--- a/docs/factory.md
+++ b/docs/factory.md
@@ -89,7 +89,7 @@ The factory exposes read-only views so UIs, operators, and indexers can inspect 
 
 | View | Returns | Notes |
 |------|---------|-------|
-| `get_factory_config()` | `FactoryConfig { admin, stream_contract, max_deposit, min_duration, batch_cap_enforced }` | Reads all instance policy fields. Returns `FactoryError::NotInitialized` before `init`. |
+| `get_factory_config()` | `FactoryConfig { admin, stream_contract, max_deposit, min_duration, batch_cap_enforced, creation_paused, min_rate_per_second, max_rate_per_second }` | Reads all instance policy fields. Returns every field tracked by `FactoryPolicy` plus `admin`, matching the single-call completeness of `load_policy`. Returns `FactoryError::NotInitialized` before `init`. |
 | `is_allowlisted(recipient)` | `bool` | Returns `true` only when the recipient currently has an allowlist entry. Missing entries return `false`. |
 
 These views are permissionless and do not mutate factory state.


### PR DESCRIPTION
## Summary

Two related factory contract improvements:

### #1134 — Extend `FactoryConfig` with missing fields

`get_factory_config()` now returns the complete policy snapshot in a single call:
- Added `creation_paused: bool`
- Added `min_rate_per_second: Option<i128>`
- Added `max_rate_per_second: Option<i128>`

Refactored `get_factory_config()` to reuse `load_policy()` internally, deduplicating 5 storage reads into one policy load + admin read.

### #1131 — Dedicated `InvalidRateBounds` error

`set_rate_bounds` was misusing `FactoryError::StreamContractError` ("downstream contract failure") for input validation. Added:
- `InvalidRateBounds = 18` to `FactoryError` (appended, no renumbering)
- Replaced all 3 `StreamContractError` returns with `InvalidRateBounds`
- Tests for `min_rate = Some(-1)` and `min > max`

## What changed

| File | Change |
|------|--------|
| `contracts/factory/src/lib.rs` | 3 new FactoryConfig fields, refactored get_factory_config, InvalidRateBounds variant, 3 error replacements |
| `contracts/factory/tests/factory_setters.rs` | 2 new InvalidRateBounds tests, updated init assertions |
| `docs/error.md` | Added InvalidRateBounds=18 and InvalidStreamContract=17 rows, cleaned StreamContractError description |
| `docs/factory.md` | Updated get_factory_config() return shape |

## Acceptance criteria

- [x] `get_factory_config()` returns `creation_paused`, `min_rate_per_second`, `max_rate_per_second`
- [x] Single `get_factory_config()` call is sufficient to reconstruct full policy
- [x] `set_rate_bounds(Some(-1), None)` returns distinct error from `StreamContractError`
- [x] `set_rate_bounds(Some(100), Some(50))` returns same distinct error
- [x] No existing `FactoryError` discriminant changed
- [x] Docs updated

Closes #1134
Closes #1131