### PR TITLE
ci: report per-PR WASM size delta against previous release tag

### DIFF
--- a/docs/gas.md
+++ b/docs/gas.md
@@ -47,6 +47,39 @@ If a deliberate, reviewed feature addition requires more space:
 4. Update the table above with the new value and a note explaining the change.
 5. Include the change in the PR description.
 
+### Per-PR Delta Reporting
+
+Every build also compares the current WASM sizes against the **previous release tag**
+(most recent `v*` tag) and prints a byte-delta for each contract. This makes incremental
+bloat from individual PRs visible immediately, without waiting for the absolute ceiling
+to be approached.
+
+**How it works:**
+
+1. The script finds the most recent `v*` tag in the repository.
+2. For each contract, it reads the WASM file size at that tag from git history.
+3. It computes `current_size - previous_size` and prints the result.
+4. In GitHub Actions CI, `::warning::` annotations are emitted when a contract grows
+   and `::notice::` annotations when it shrinks. These annotations appear on the PR
+   timeline **without failing the build** (budget enforcement still runs independently).
+
+**Example output:**
+
+```
+Previous release tag: v0.9.0
+  vs v0.9.0: +1234 bytes (+1.2 KiB) (was 200000 / 195.3 KiB)
+fluxora_stream: 201234 bytes (196.5 KiB) — OK (headroom: 60.9 KiB)
+```
+
+**Edge cases:**
+
+- **No release tag exists**: Delta reporting is skipped with an informational message.
+- **Previous tag has no WASM file**: The delta is reported as "baseline unavailable".
+- **Budget exceeded**: Delta is still reported even when the contract fails the budget check.
+
+**Step summary:** When running in CI (`GITHUB_STEP_SUMMARY` is set), the script writes
+a delta table to the GitHub Actions step summary alongside the budget report.
+
 ### Optimize step
 
 `stellar contract optimize` runs `wasm-opt -Oz` on the artifact, typically reducing binary

--- a/script/check-wasm-size.sh
+++ b/script/check-wasm-size.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# check-wasm-size.sh — Enforce per-contract WASM byte budgets.
+# check-wasm-size.sh — Enforce per-contract WASM byte budgets and report
+# per-PR byte-delta against the previous release tag.
 #
 # Usage: bash script/check-wasm-size.sh [--optimized]
 #
@@ -19,14 +20,24 @@
 #   fluxora_factory   — 131 072  (128 KiB)
 #   fluxora_governance— 131 072  (128 KiB)
 #
+# Delta reporting:
+#   The script fetches the previous release tag's WASM sizes from git history
+#   and prints the byte-delta for each contract. In CI, a ::warning:: or
+#   ::notice:: annotation is emitted per contract to surface the change in PR
+#   builds without failing the job (unless the absolute budget is crossed).
+#
 # Update these budgets when a deliberate feature addition is landed; document
 # the change in docs/gas.md and in the PR description.
 
 set -euo pipefail
 
-# Allow tests (and CI) to override the artifact directory via environment.
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
 WASM_DIR="${WASM_DIR:-target/wasm32-unknown-unknown/release}"
 OPTIMIZED=0
+# GIT_REPO allows tests to override the repository root for git operations.
+GIT_REPO="${GIT_REPO:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
 
 for arg in "$@"; do
   case "$arg" in
@@ -44,8 +55,90 @@ declare -A BUDGETS=(
   [fluxora_governance]=131072   # 128 KiB
 )
 
+# ---------------------------------------------------------------------------
+# Helper: find the previous release tag (most recent v* tag before HEAD)
+# ---------------------------------------------------------------------------
+find_previous_release_tag() {
+  # List tags matching v* sorted by version, newest first, skip HEAD's tag.
+  local tag
+  tag=$(git -C "$GIT_REPO" tag -l 'v*' --sort=-version:refname 2>/dev/null | head -n 1)
+  if [ -n "$tag" ]; then
+    echo "$tag"
+  else
+    echo ""
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Helper: get WASM file size at a given git ref
+# Returns the size in bytes, or empty string if unavailable.
+# ---------------------------------------------------------------------------
+get_wasm_size_at_ref() {
+  local ref="$1"
+  local contract="$2"
+  local suffix=".wasm"
+
+  if [ "$OPTIMIZED" -eq 1 ]; then
+    suffix=".optimized.wasm"
+  fi
+
+  local path="target/wasm32-unknown-unknown/release/${contract}${suffix}"
+
+  # Try to retrieve the blob size from git history.
+  local size
+  size=$(git -C "$GIT_REPO" cat-file -s "${ref}:${path}" 2>/dev/null) || true
+
+  # If the exact path isn't in the tree, try alternative common locations.
+  if [ -z "$size" ]; then
+    # Some tags may store WASM in a different directory structure.
+    size=$(git -C "$GIT_REPO" ls-tree -r -l "${ref}" 2>/dev/null \
+      | awk -v pat="${contract}${suffix}" '$4 == pat { print $4 }' \
+      | head -n 1) || true
+  fi
+
+  echo "$size"
+}
+
+# ---------------------------------------------------------------------------
+# Helper: get blob size from ls-tree output (fallback when cat-file fails)
+# ---------------------------------------------------------------------------
+get_blob_size_from_ls_tree() {
+  local ref="$1"
+  local contract="$2"
+  local suffix=".wasm"
+
+  if [ "$OPTIMIZED" -eq 1 ]; then
+    suffix=".optimized.wasm"
+  fi
+
+  local pattern="${contract}${suffix}"
+  local line
+  line=$(git -C "$GIT_REPO" ls-tree -r -l "${ref}" 2>/dev/null \
+    | grep -E "${pattern}$" | head -n 1) || true
+
+  if [ -n "$line" ]; then
+    # ls-tree -r -l output: <mode> <type> <object hash> <size> <path>
+    echo "$line" | awk '{ print $4 }'
+  else
+    echo ""
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Main size check and delta computation
+# ---------------------------------------------------------------------------
 FAILED=0
 SUMMARY_ROWS=()
+DELTA_ROWS=()
+HAS_DELTA_DATA=0
+
+# Find the previous release tag for delta comparison.
+PREV_TAG=$(find_previous_release_tag)
+if [ -n "$PREV_TAG" ]; then
+  echo "Previous release tag: ${PREV_TAG}"
+else
+  echo "No previous release tag found — delta reporting disabled."
+fi
 
 for CONTRACT in "${!BUDGETS[@]}"; do
   BUDGET="${BUDGETS[$CONTRACT]}"
@@ -60,6 +153,9 @@ for CONTRACT in "${!BUDGETS[@]}"; do
     echo "::error::Artifact not found: ${WASM_FILE}" >&2
     FAILED=1
     SUMMARY_ROWS+=("| ${CONTRACT} | missing | ${BUDGET} | ❌ MISSING |")
+    if [ -n "$PREV_TAG" ]; then
+      DELTA_ROWS+=("| ${CONTRACT} | — | — | — |")
+    fi
     continue
   fi
 
@@ -67,6 +163,47 @@ for CONTRACT in "${!BUDGETS[@]}"; do
   BUDGET_KIB=$(( BUDGET / 1024 ))
   SIZE_KIB=$(awk "BEGIN { printf \"%.1f\", ${SIZE}/1024 }")
 
+  # Compute delta against previous release tag.
+  DELTA_INFO=""
+  if [ -n "$PREV_TAG" ]; then
+    PREV_SIZE=$(get_blob_size_from_ls_tree "$PREV_TAG" "$CONTRACT")
+    if [ -n "$PREV_SIZE" ] && [ "$PREV_SIZE" -gt 0 ] 2>/dev/null; then
+      DELTA=$(( SIZE - PREV_SIZE ))
+      DELTA_KIB=$(awk "BEGIN { printf \"%.1f\", ${DELTA}/1024 }")
+      PREV_KIB=$(awk "BEGIN { printf \"%.1f\", ${PREV_SIZE}/1024 }")
+      HAS_DELTA_DATA=1
+
+      if [ "$DELTA" -gt 0 ]; then
+        DELTA_INFO="+${DELTA} bytes (+${DELTA_KIB} KiB)"
+      elif [ "$DELTA" -lt 0 ]; then
+        ABS_DELTA=$(( -DELTA ))
+        DELTA_INFO="-${ABS_DELTA} bytes (-${DELTA_KIB} KiB)"
+      else
+        DELTA_INFO="0 bytes (no change)"
+      fi
+
+      echo "  vs ${PREV_TAG}: ${DELTA_INFO} (was ${PREV_SIZE} / ${PREV_KIB} KiB)"
+      DELTA_ROWS+=("| ${CONTRACT} | ${SIZE} (${SIZE_KIB} KiB) | ${PREV_SIZE} (${PREV_KIB} KiB) | ${DELTA_INFO} |")
+
+      # Emit CI annotation for the delta (does NOT fail the build).
+      if [ -n "${GITHUB_STEP_SUMMARY:-}" ] || [ -n "${GITHUB_ACTIONS:-}" ]; then
+        if [ "$DELTA" -gt 0 ]; then
+          # Positive delta (bloat) → warning annotation.
+          echo "::warning::${CONTRACT}.wasm grew by ${DELTA_INFO} since ${PREV_TAG}"
+        elif [ "$DELTA" -lt 0 ]; then
+          # Negative delta (shrink) → notice annotation.
+          echo "::notice::${CONTRACT}.wasm shrank by ${DELTA_INFO} since ${PREV_TAG}"
+        else
+          echo "::notice::${CONTRACT}.wasm unchanged since ${PREV_TAG}"
+        fi
+      fi
+    else
+      echo "  vs ${PREV_TAG}: baseline not available for ${CONTRACT}"
+      DELTA_ROWS+=("| ${CONTRACT} | ${SIZE} (${SIZE_KIB} KiB) | — | baseline unavailable |")
+    fi
+  fi
+
+  # Budget enforcement.
   if [ "$SIZE" -gt "$BUDGET" ]; then
     echo "::error::${CONTRACT}.wasm is ${SIZE} bytes (${SIZE_KIB} KiB) — exceeds budget of ${BUDGET} bytes (${BUDGET_KIB} KiB)." >&2
     FAILED=1
@@ -91,9 +228,23 @@ if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
     for ROW in "${SUMMARY_ROWS[@]}"; do
       echo "$ROW"
     done
+
+    if [ "$HAS_DELTA_DATA" -eq 1 ]; then
+      echo ""
+      echo "## WASM Size Delta (vs ${PREV_TAG})"
+      echo ""
+      echo "| Contract | Current | Previous (${PREV_TAG}) | Delta |"
+      echo "|----------|---------|----------------------|-------|"
+      for ROW in "${DELTA_ROWS[@]}"; do
+        echo "$ROW"
+      done
+    fi
   } >> "$GITHUB_STEP_SUMMARY"
 fi
 
+# ---------------------------------------------------------------------------
+# Exit with failure if any contract exceeded its budget.
+# ---------------------------------------------------------------------------
 if [ "$FAILED" -ne 0 ]; then
   echo ""
   echo "One or more contracts exceeded their WASM size budget." >&2

--- a/tests/test_gas_validation.py
+++ b/tests/test_gas_validation.py
@@ -231,3 +231,472 @@ class TestCheckWasmSizeScript:
             capture_output=True, text=True, env=env,
         )
         assert result.returncode == 1
+
+
+# ---------------------------------------------------------------------------
+# WASM size delta reporting tests — exercise delta logic in check-wasm-size.sh
+# ---------------------------------------------------------------------------
+
+
+def _init_git_repo(directory: str) -> None:
+    """Initialize a git repo and configure user for commits."""
+    subprocess.run(["git", "init"], cwd=directory, capture_output=True, check=True)
+    subprocess.run(
+        ["git", "config", "user.email", "test@test.com"],
+        cwd=directory, capture_output=True, check=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test"],
+        cwd=directory, capture_output=True, check=True,
+    )
+
+
+def _git_commit(directory: str, message: str) -> None:
+    """Stage all and commit."""
+    subprocess.run(["git", "add", "-A"], cwd=directory, capture_output=True, check=True)
+    subprocess.run(
+        ["git", "commit", "-m", message, "--allow-empty"],
+        cwd=directory, capture_output=True, check=True,
+    )
+
+
+def _git_tag(directory: str, tag: str) -> None:
+    """Create an annotated tag."""
+    subprocess.run(
+        ["git", "tag", "-a", tag, "-m", f"Release {tag}"],
+        cwd=directory, capture_output=True, check=True,
+    )
+
+
+class TestWasmSizeDeltaReporting:
+    """Tests for per-PR WASM size delta reporting in check-wasm-size.sh."""
+
+    def _invoke(
+        self, wasm_dir: str, git_dir: str, optimized: bool = False,
+        github_actions: str = "",
+    ) -> subprocess.CompletedProcess:
+        args = ["--optimized"] if optimized else []
+        env = {
+            **os.environ,
+            "GITHUB_STEP_SUMMARY": "",
+            "WASM_DIR": wasm_dir,
+            "GIT_REPO": git_dir,
+        }
+        if github_actions:
+            env["GITHUB_ACTIONS"] = github_actions
+        return subprocess.run(
+            ["bash", SCRIPT] + args,
+            capture_output=True, text=True, env=env,
+            cwd=git_dir,
+        )
+
+    def test_delta_positive_growth(self, tmp_path):
+        """Positive delta (bloat) is reported when WASM grew since last tag."""
+        # Create a git repo with a tagged release containing smaller WASM.
+        git_dir = str(tmp_path / "repo")
+        os.makedirs(git_dir)
+        _init_git_repo(git_dir)
+
+        # Create initial commit and tag with smaller WASM files.
+        wasm_dir = os.path.join(git_dir, "target", "wasm32-unknown-unknown", "release")
+        os.makedirs(wasm_dir)
+        for contract, size in [
+            ("fluxora_stream", 200000),
+            ("fluxora_factory", 100000),
+            ("fluxora_governance", 100000),
+        ]:
+            _make_wasm(wasm_dir, f"{contract}.wasm", size)
+        _git_commit(git_dir, "baseline")
+        _git_tag(git_dir, "v1.0.0")
+
+        # Now create larger WASM files (simulate PR bloat).
+        for contract, size in [
+            ("fluxora_stream", 210000),   # +10000 bytes
+            ("fluxora_factory", 105000),  # +5000 bytes
+            ("fluxora_governance", 102000),  # +2000 bytes
+        ]:
+            _make_wasm(wasm_dir, f"{contract}.wasm", size)
+        _git_commit(git_dir, "feature: add bloat")
+
+        result = self._invoke(wasm_dir, git_dir)
+        assert result.returncode == 0
+        assert "Previous release tag: v1.0.0" in result.stdout
+        assert "+10000 bytes" in result.stdout or "+9.8 KiB" in result.stdout
+        assert "+5000 bytes" in result.stdout or "+4.9 KiB" in result.stdout
+
+    def test_delta_negative_shrink(self, tmp_path):
+        """Negative delta (shrink) is reported when WASM shrunk since last tag."""
+        git_dir = str(tmp_path / "repo")
+        os.makedirs(git_dir)
+        _init_git_repo(git_dir)
+
+        wasm_dir = os.path.join(git_dir, "target", "wasm32-unknown-unknown", "release")
+        os.makedirs(wasm_dir)
+        for contract, size in [
+            ("fluxora_stream", 250000),
+            ("fluxora_factory", 120000),
+            ("fluxora_governance", 120000),
+        ]:
+            _make_wasm(wasm_dir, f"{contract}.wasm", size)
+        _git_commit(git_dir, "baseline")
+        _git_tag(git_dir, "v2.0.0")
+
+        # Now create smaller WASM files (simulate optimization).
+        for contract, size in [
+            ("fluxora_stream", 240000),   # -10000 bytes
+            ("fluxora_factory", 115000),  # -5000 bytes
+            ("fluxora_governance", 118000),  # -2000 bytes
+        ]:
+            _make_wasm(wasm_dir, f"{contract}.wasm", size)
+        _git_commit(git_dir, "refactor: optimize")
+
+        result = self._invoke(wasm_dir, git_dir)
+        assert result.returncode == 0
+        assert "Previous release tag: v2.0.0" in result.stdout
+        assert "-10000 bytes" in result.stdout or "-9.8 KiB" in result.stdout
+
+    def test_delta_no_change(self, tmp_path):
+        """Zero delta is reported when WASM is unchanged since last tag."""
+        git_dir = str(tmp_path / "repo")
+        os.makedirs(git_dir)
+        _init_git_repo(git_dir)
+
+        wasm_dir = os.path.join(git_dir, "target", "wasm32-unknown-unknown", "release")
+        os.makedirs(wasm_dir)
+        for contract, size in [
+            ("fluxora_stream", 200000),
+            ("fluxora_factory", 100000),
+            ("fluxora_governance", 100000),
+        ]:
+            _make_wasm(wasm_dir, f"{contract}.wasm", size)
+        _git_commit(git_dir, "baseline")
+        _git_tag(git_dir, "v3.0.0")
+
+        # Create identical WASM files (no change).
+        for contract, size in [
+            ("fluxora_stream", 200000),
+            ("fluxora_factory", 100000),
+            ("fluxora_governance", 100000),
+        ]:
+            _make_wasm(wasm_dir, f"{contract}.wasm", size)
+        _git_commit(git_dir, "chore: no-op")
+
+        result = self._invoke(wasm_dir, git_dir)
+        assert result.returncode == 0
+        assert "no change" in result.stdout
+
+    def test_no_previous_tag(self, tmp_path):
+        """Graceful handling when no release tag exists."""
+        git_dir = str(tmp_path / "repo")
+        os.makedirs(git_dir)
+        _init_git_repo(git_dir)
+
+        wasm_dir = os.path.join(git_dir, "target", "wasm32-unknown-unknown", "release")
+        os.makedirs(wasm_dir)
+        for contract, budget in [
+            ("fluxora_stream", 262144),
+            ("fluxora_factory", 131072),
+            ("fluxora_governance", 131072),
+        ]:
+            _make_wasm(wasm_dir, f"{contract}.wasm", budget - 1)
+        _git_commit(git_dir, "initial")
+
+        result = self._invoke(wasm_dir, git_dir)
+        assert result.returncode == 0
+        assert "No previous release tag found" in result.stdout
+
+    def test_previous_tag_no_baseline(self, tmp_path):
+        """Graceful handling when previous tag doesn't have WASM file."""
+        git_dir = str(tmp_path / "repo")
+        os.makedirs(git_dir)
+        _init_git_repo(git_dir)
+
+        wasm_dir = os.path.join(git_dir, "target", "wasm32-unknown-unknown", "release")
+        os.makedirs(wasm_dir)
+
+        # Create a commit with only a README (no WASM files).
+        with open(os.path.join(git_dir, "README.md"), "w") as f:
+            f.write("# Test\n")
+        _git_commit(git_dir, "initial")
+        _git_tag(git_dir, "v0.1.0")
+
+        # Now create WASM files for current build.
+        for contract, budget in [
+            ("fluxora_stream", 262144),
+            ("fluxora_factory", 131072),
+            ("fluxora_governance", 131072),
+        ]:
+            _make_wasm(wasm_dir, f"{contract}.wasm", budget - 1)
+        _git_commit(git_dir, "add wasm")
+
+        result = self._invoke(wasm_dir, git_dir)
+        assert result.returncode == 0
+        assert "baseline not available" in result.stdout
+
+    def test_ci_annotations_positive_delta(self, tmp_path):
+        """CI annotations are emitted for positive delta in GitHub Actions."""
+        git_dir = str(tmp_path / "repo")
+        os.makedirs(git_dir)
+        _init_git_repo(git_dir)
+
+        wasm_dir = os.path.join(git_dir, "target", "wasm32-unknown-unknown", "release")
+        os.makedirs(wasm_dir)
+        for contract, size in [
+            ("fluxora_stream", 200000),
+            ("fluxora_factory", 100000),
+            ("fluxora_governance", 100000),
+        ]:
+            _make_wasm(wasm_dir, f"{contract}.wasm", size)
+        _git_commit(git_dir, "baseline")
+        _git_tag(git_dir, "v1.0.0")
+
+        for contract, size in [
+            ("fluxora_stream", 210000),
+            ("fluxora_factory", 105000),
+            ("fluxora_governance", 102000),
+        ]:
+            _make_wasm(wasm_dir, f"{contract}.wasm", size)
+        _git_commit(git_dir, "bloat")
+
+        result = self._invoke(wasm_dir, git_dir, github_actions="true")
+        assert result.returncode == 0
+        assert "::warning::" in result.stdout
+
+    def test_ci_annotations_negative_delta(self, tmp_path):
+        """CI notice annotations are emitted for negative delta."""
+        git_dir = str(tmp_path / "repo")
+        os.makedirs(git_dir)
+        _init_git_repo(git_dir)
+
+        wasm_dir = os.path.join(git_dir, "target", "wasm32-unknown-unknown", "release")
+        os.makedirs(wasm_dir)
+        for contract, size in [
+            ("fluxora_stream", 250000),
+            ("fluxora_factory", 120000),
+            ("fluxora_governance", 120000),
+        ]:
+            _make_wasm(wasm_dir, f"{contract}.wasm", size)
+        _git_commit(git_dir, "baseline")
+        _git_tag(git_dir, "v1.0.0")
+
+        for contract, size in [
+            ("fluxora_stream", 240000),
+            ("fluxora_factory", 115000),
+            ("fluxora_governance", 118000),
+        ]:
+            _make_wasm(wasm_dir, f"{contract}.wasm", size)
+        _git_commit(git_dir, "optimize")
+
+        result = self._invoke(wasm_dir, git_dir, github_actions="true")
+        assert result.returncode == 0
+        assert "::notice::" in result.stdout
+
+    def test_step_summary_includes_delta_table(self, tmp_path):
+        """Step summary includes the delta table when baseline is available."""
+        git_dir = str(tmp_path / "repo")
+        os.makedirs(git_dir)
+        _init_git_repo(git_dir)
+
+        wasm_dir = os.path.join(git_dir, "target", "wasm32-unknown-unknown", "release")
+        os.makedirs(wasm_dir)
+        for contract, size in [
+            ("fluxora_stream", 200000),
+            ("fluxora_factory", 100000),
+            ("fluxora_governance", 100000),
+        ]:
+            _make_wasm(wasm_dir, f"{contract}.wasm", size)
+        _git_commit(git_dir, "baseline")
+        _git_tag(git_dir, "v1.0.0")
+
+        for contract, size in [
+            ("fluxora_stream", 210000),
+            ("fluxora_factory", 105000),
+            ("fluxora_governance", 102000),
+        ]:
+            _make_wasm(wasm_dir, f"{contract}.wasm", size)
+        _git_commit(git_dir, "bloat")
+
+        summary_file = os.path.join(git_dir, "summary.md")
+        env = {
+            **os.environ,
+            "GITHUB_STEP_SUMMARY": summary_file,
+            "WASM_DIR": wasm_dir,
+            "GIT_REPO": git_dir,
+        }
+        subprocess.run(
+            ["bash", SCRIPT],
+            capture_output=True, text=True, env=env, cwd=git_dir,
+        )
+
+        assert os.path.exists(summary_file)
+        with open(summary_file) as f:
+            content = f.read()
+        assert "WASM Size Delta" in content
+        assert "v1.0.0" in content
+
+    def test_step_summary_no_delta_without_tag(self, tmp_path):
+        """Step summary omits delta table when no release tag exists."""
+        git_dir = str(tmp_path / "repo")
+        os.makedirs(git_dir)
+        _init_git_repo(git_dir)
+
+        wasm_dir = os.path.join(git_dir, "target", "wasm32-unknown-unknown", "release")
+        os.makedirs(wasm_dir)
+        for contract, budget in [
+            ("fluxora_stream", 262144),
+            ("fluxora_factory", 131072),
+            ("fluxora_governance", 131072),
+        ]:
+            _make_wasm(wasm_dir, f"{contract}.wasm", budget - 1)
+        _git_commit(git_dir, "initial")
+
+        summary_file = os.path.join(git_dir, "summary.md")
+        env = {
+            **os.environ,
+            "GITHUB_STEP_SUMMARY": summary_file,
+            "WASM_DIR": wasm_dir,
+            "GIT_REPO": git_dir,
+        }
+        subprocess.run(
+            ["bash", SCRIPT],
+            capture_output=True, text=True, env=env, cwd=git_dir,
+        )
+
+        assert os.path.exists(summary_file)
+        with open(summary_file) as f:
+            content = f.read()
+        assert "WASM Size Delta" not in content
+
+    def test_optimized_delta_uses_optimized_files(self, tmp_path):
+        """--optimized flag compares optimized WASM files for delta."""
+        git_dir = str(tmp_path / "repo")
+        os.makedirs(git_dir)
+        _init_git_repo(git_dir)
+
+        wasm_dir = os.path.join(git_dir, "target", "wasm32-unknown-unknown", "release")
+        os.makedirs(wasm_dir)
+        for contract, size in [
+            ("fluxora_stream", 180000),
+            ("fluxora_factory", 90000),
+            ("fluxora_governance", 90000),
+        ]:
+            _make_wasm(wasm_dir, f"{contract}.optimized.wasm", size)
+        _git_commit(git_dir, "baseline")
+        _git_tag(git_dir, "v1.0.0")
+
+        for contract, size in [
+            ("fluxora_stream", 190000),
+            ("fluxora_factory", 95000),
+            ("fluxora_governance", 92000),
+        ]:
+            _make_wasm(wasm_dir, f"{contract}.optimized.wasm", size)
+        _git_commit(git_dir, "optimized bloat")
+
+        result = self._invoke(wasm_dir, git_dir, optimized=True)
+        assert result.returncode == 0
+        assert "Previous release tag: v1.0.0" in result.stdout
+        assert "+10000 bytes" in result.stdout or "+9.8 KiB" in result.stdout
+
+    def test_over_budget_still_reports_delta(self, tmp_path):
+        """Delta is reported even when contract exceeds budget."""
+        git_dir = str(tmp_path / "repo")
+        os.makedirs(git_dir)
+        _init_git_repo(git_dir)
+
+        wasm_dir = os.path.join(git_dir, "target", "wasm32-unknown-unknown", "release")
+        os.makedirs(wasm_dir)
+        for contract, size in [
+            ("fluxora_stream", 200000),
+            ("fluxora_factory", 100000),
+            ("fluxora_governance", 100000),
+        ]:
+            _make_wasm(wasm_dir, f"{contract}.wasm", size)
+        _git_commit(git_dir, "baseline")
+        _git_tag(git_dir, "v1.0.0")
+
+        # Stream exceeds budget.
+        for contract, size in [
+            ("fluxora_stream", 262145),
+            ("fluxora_factory", 105000),
+            ("fluxora_governance", 102000),
+        ]:
+            _make_wasm(wasm_dir, f"{contract}.wasm", size)
+        _git_commit(git_dir, "over budget")
+
+        result = self._invoke(wasm_dir, git_dir)
+        assert result.returncode == 1
+        # Delta should still be reported even though budget failed.
+        assert "vs v1.0.0" in result.stdout
+
+    def test_multiple_tags_uses_latest(self, tmp_path):
+        """Delta is computed against the most recent release tag."""
+        git_dir = str(tmp_path / "repo")
+        os.makedirs(git_dir)
+        _init_git_repo(git_dir)
+
+        wasm_dir = os.path.join(git_dir, "target", "wasm32-unknown-unknown", "release")
+        os.makedirs(wasm_dir)
+
+        # Create first tag with small WASM.
+        for contract, size in [
+            ("fluxora_stream", 100000),
+            ("fluxora_factory", 50000),
+            ("fluxora_governance", 50000),
+        ]:
+            _make_wasm(wasm_dir, f"{contract}.wasm", size)
+        _git_commit(git_dir, "v1")
+        _git_tag(git_dir, "v1.0.0")
+
+        # Create second tag with medium WASM.
+        for contract, size in [
+            ("fluxora_stream", 150000),
+            ("fluxora_factory", 75000),
+            ("fluxora_governance", 75000),
+        ]:
+            _make_wasm(wasm_dir, f"{contract}.wasm", size)
+        _git_commit(git_dir, "v2")
+        _git_tag(git_dir, "v2.0.0")
+
+        # Current build has larger WASM than v2.0.0.
+        for contract, size in [
+            ("fluxora_stream", 160000),
+            ("fluxora_factory", 80000),
+            ("fluxora_governance", 80000),
+        ]:
+            _make_wasm(wasm_dir, f"{contract}.wasm", size)
+        _git_commit(git_dir, "current")
+
+        result = self._invoke(wasm_dir, git_dir)
+        assert result.returncode == 0
+        # Should compare against v2.0.0, not v1.0.0.
+        assert "Previous release tag: v2.0.0" in result.stdout
+        # Delta should be +10000 from v2.0.0, not +60000 from v1.0.0.
+        assert "+10000 bytes" in result.stdout or "+9.8 KiB" in result.stdout
+
+    def test_missing_artifact_with_delta(self, tmp_path):
+        """Missing artifact shows error in output and delta for other contracts."""
+        git_dir = str(tmp_path / "repo")
+        os.makedirs(git_dir)
+        _init_git_repo(git_dir)
+
+        wasm_dir = os.path.join(git_dir, "target", "wasm32-unknown-unknown", "release")
+        os.makedirs(wasm_dir)
+        for contract, size in [
+            ("fluxora_stream", 200000),
+            ("fluxora_factory", 100000),
+            ("fluxora_governance", 100000),
+        ]:
+            _make_wasm(wasm_dir, f"{contract}.wasm", size)
+        _git_commit(git_dir, "baseline")
+        _git_tag(git_dir, "v1.0.0")
+
+        # Remove governance WASM.
+        os.remove(os.path.join(wasm_dir, "fluxora_governance.wasm"))
+        _git_commit(git_dir, "remove governance")
+
+        result = self._invoke(wasm_dir, git_dir)
+        assert result.returncode == 1
+        # Error should mention the missing artifact.
+        assert "not found" in result.stderr or "Artifact not found" in result.stderr
+        # Delta for present contracts should still be reported.
+        assert "vs v1.0.0" in result.stdout


### PR DESCRIPTION
Closes #1221 

## PR Summary

### Changes Made

#### 1. `script/check-wasm-size.sh` (Extended)
- Added **per-PR WASM size delta reporting** against the previous release tag
- **New helper functions:**
  - `find_previous_release_tag()`: Finds the most recent `v*` tag in the repository
  - `get_blob_size_from_ls_tree()`: Retrieves WASM file size from git history at a specific ref
- Added `GIT_REPO` environment variable override for testing flexibility
- **CI annotations:** `::warning::` for size increases (bloat), `::notice::` for decreases or no change
- **Step summary delta table:** Automatically written to `GITHUB_STEP_SUMMARY` when in CI
- **Graceful handling of edge cases:** no tags, missing baselines, missing artifacts

#### 2. `tests/test_gas_validation.py` (Extended)
Added 13 new tests in `TestWasmSizeDeltaReporting` class:
- `test_delta_positive_growth`: Verifies positive delta (bloat) reporting
- `test_delta_negative_shrink`: Verifies negative delta (shrink) reporting
- `test_delta_no_change`: Verifies zero delta reporting
- `test_no_previous_tag`: Graceful handling when no release tag exists
- `test_previous_tag_no_baseline`: Graceful handling when previous tag has no WASM
- `test_ci_annotations_positive_delta`: Verifies `::warning::` annotations in CI
- `test_ci_annotations_negative_delta`: Verifies `::notice::` annotations in CI
- `test_step_summary_includes_delta_table`: Verifies step summary includes delta table
- `test_step_summary_no_delta_without_tag`: Verifies no delta table without tag
- `test_optimized_delta_uses_optimized_files`: Verifies `--optimized` flag works for delta
- `test_over_budget_still_reports_delta`: Verifies delta reported even when budget exceeded
- `test_multiple_tags_uses_latest`: Verifies latest tag is used for comparison
- `test_missing_artifact_with_delta`: Verifies error handling with missing artifacts

#### 3. `docs/gas.md` (Updated)
Added new **"Per-PR Delta Reporting"** section documenting:
- How delta reporting works
- Example output
- Edge cases handled
- Step summary integration

---

### Test Results
- **32/32 tests pass** in `test_gas_validation.py`
- All existing tests continue to pass
- No regressions introduced

---

### Security Notes
- No untrusted code execution
- Git operations use only local repository data
- No external network calls
- `GIT_REPO` override is safe for testing (requires explicit environment variable)