### PR TITLE
feat: add rustup target/component checks to verify_rust_version.py

### DIFF
--- a/script/verify_rust_version.py
+++ b/script/verify_rust_version.py
@@ -9,6 +9,11 @@ import subprocess
 import sys
 from pathlib import Path
 
+try:
+    import tomllib  # type: ignore[import-not-found]
+except ImportError:
+    tomllib = None  # type: ignore[assignment]
+
 # `rust-toolchain.toml` is a tiny single-key file in this repo, so we read
 # `channel = "..."` directly without depending on a TOML library. This keeps
 # the script portable across Python versions (3.10 runners used by CI don't
@@ -38,6 +43,58 @@ def _channel_from_toolchain_text(text: str) -> str:
     return channel
 
 
+REPO_ROOT = Path(__file__).resolve().parents[1]
+TOOLCHAIN_FILE = REPO_ROOT / "rust-toolchain.toml"
+
+
+def _parse_toml_simple(text: str) -> dict:
+    """Minimal TOML parser for rust-toolchain.toml — handles the subset we need.
+
+    Extracts [toolchain].channel, [toolchain].targets (array), and
+    [toolchain].components (array). Raises ValueError on invalid input.
+    """
+    result: dict = {"toolchain": {}}
+    in_toolchain = False
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if stripped == "[toolchain]":
+            in_toolchain = True
+            continue
+        if stripped.startswith("[") and stripped.endswith("]"):
+            in_toolchain = False
+            continue
+        if in_toolchain:
+            # Parse key = value or key = [array]
+            kv_match = re.match(r'^(\w+)\s*=\s*(.+)$', stripped)
+            if kv_match:
+                key = kv_match.group(1)
+                value_str = kv_match.group(2).strip()
+                if value_str.startswith("[") and value_str.endswith("]"):
+                    # Array value
+                    inner = value_str[1:-1].strip()
+                    if not inner:
+                        result["toolchain"][key] = []
+                    else:
+                        items = []
+                        for item in re.findall(r'"([^"]*)"', inner):
+                            items.append(item)
+                        result["toolchain"][key] = items
+                elif value_str.startswith('"') and value_str.endswith('"'):
+                    result["toolchain"][key] = value_str[1:-1]
+                else:
+                    result["toolchain"][key] = value_str
+    return result
+
+
+def _load_toolchain(toolchain_file: Path) -> dict:
+    """Load and parse the toolchain file, preferring tomllib."""
+    if tomllib is not None:
+        return tomllib.loads(toolchain_file.read_text(encoding="utf-8"))
+    return _parse_toml_simple(toolchain_file.read_text(encoding="utf-8"))
+
+
 def pinned_channel_via_toml(toolchain_file: Path) -> str | None:
     """Best-effort TOML parse with the stdlib `tomllib` (3.11+) or `tomli`.
 
@@ -46,21 +103,13 @@ def pinned_channel_via_toml(toolchain_file: Path) -> str | None:
     legacy Python 3.10 CI runner path stays green.
     """
     try:
-        import tomllib as _tomllib  # type: ignore[import-not-found]
-    except ImportError:
-        try:
-            import tomli as _tomllib  # type: ignore[no-redef]
-        except ImportError:
-            return None
-    data = _tomllib.loads(toolchain_file.read_text(encoding="utf-8"))
+        data = _load_toolchain(toolchain_file)
+    except Exception:
+        return None
     channel = data.get("toolchain", {}).get("channel")
     if not isinstance(channel, str) or not channel:
-        raise ValueError(f"missing [toolchain].channel in {toolchain_file}")
+        return None
     return channel
-
-
-REPO_ROOT = Path(__file__).resolve().parents[1]
-TOOLCHAIN_FILE = REPO_ROOT / "rust-toolchain.toml"
 
 
 def pinned_channel(toolchain_file: Path = TOOLCHAIN_FILE) -> str:
@@ -72,6 +121,66 @@ def pinned_channel(toolchain_file: Path = TOOLCHAIN_FILE) -> str:
     if via_toml is not None:
         return via_toml
     return _channel_from_toolchain_text(toolchain_file.read_text(encoding="utf-8"))
+
+
+def pinned_targets(toolchain_file: Path = TOOLCHAIN_FILE) -> list[str]:
+    """Return the list of targets declared in rust-toolchain.toml."""
+    data = _load_toolchain(toolchain_file)
+    targets = data.get("toolchain", {}).get("targets")
+    if targets is None:
+        return []
+    if not isinstance(targets, list):
+        raise ValueError(
+            f"invalid targets in {toolchain_file}: expected list, got {type(targets).__name__}"
+        )
+    return targets
+
+
+def pinned_components(toolchain_file: Path = TOOLCHAIN_FILE) -> list[str]:
+    """Return the list of components declared in rust-toolchain.toml."""
+    data = _load_toolchain(toolchain_file)
+    components = data.get("toolchain", {}).get("components")
+    if components is None:
+        return []
+    if not isinstance(components, list):
+        raise ValueError(
+            f"invalid components in {toolchain_file}: expected list, got {type(components).__name__}"
+        )
+    return components
+
+
+def installed_targets() -> list[str]:
+    """Return the list of installed rustup targets.
+
+    Honours the RUSTUP_TARGET_LIST_OUTPUT env-var override for testability.
+    """
+    override = os.environ.get("RUSTUP_TARGET_LIST_OUTPUT")
+    if override is not None:
+        return [t.strip() for t in override.splitlines() if t.strip()]
+    completed = subprocess.run(
+        ["rustup", "target", "list", "--installed"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return [t.strip() for t in completed.stdout.splitlines() if t.strip()]
+
+
+def installed_components() -> list[str]:
+    """Return the list of installed rustup components.
+
+    Honours the RUSTUP_COMPONENT_LIST_OUTPUT env-var override for testability.
+    """
+    override = os.environ.get("RUSTUP_COMPONENT_LIST_OUTPUT")
+    if override is not None:
+        return [c.strip() for c in override.splitlines() if c.strip()]
+    completed = subprocess.run(
+        ["rustup", "component", "list", "--installed"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return [c.strip() for c in completed.stdout.splitlines() if c.strip()]
 
 
 def parse_rustc_version(version_output: str) -> str:
@@ -111,6 +220,33 @@ def main() -> int:
         return 1
 
     print(f"Rust version matches pinned {expected}")
+
+    # Check required targets
+    required_targets = pinned_targets()
+    if required_targets:
+        have_targets = installed_targets()
+        missing_targets = [t for t in required_targets if t not in have_targets]
+        if missing_targets:
+            print(
+                f"::error::Missing required targets: {', '.join(missing_targets)}",
+                file=sys.stderr,
+            )
+            return 1
+        print("Installed targets match requirements")
+
+    # Check required components
+    required_components = pinned_components()
+    if required_components:
+        have_components = installed_components()
+        missing_components = [c for c in required_components if c not in have_components]
+        if missing_components:
+            print(
+                f"::error::Missing required components: {', '.join(missing_components)}",
+                file=sys.stderr,
+            )
+            return 1
+        print("Installed components match requirements")
+
     return 0
 
 


### PR DESCRIPTION
## Summary

Adds verification of installed rustup targets and components declared in `rust-toolchain.toml`.

## Changes

- Add `pinned_targets()` and `pinned_components()` to parse targets/components from toolchain file
- Add `installed_targets()` and `installed_components()` to query rustup
- Update `main()` to check installed targets/components match requirements
- Add env-var overrides (`RUSTUP_TARGET_LIST_OUTPUT`, `RUSTUP_COMPONENT_LIST_OUTPUT`) for testability
- Add simple TOML fallback parser (`_parse_toml_simple`, `_load_toolchain`) for Python 3.10 compatibility

## Closes

#1198