### PR TITLE
feat: update outdated deployment checklist

### DIFF
--- a/docs/mainnet-deployment-checklist-alignment.md
+++ b/docs/mainnet-deployment-checklist-alignment.md
@@ -10,7 +10,19 @@ Everything materially related to mainnet deployment: initialization parameters, 
 
 ## Verification Status
 
-✅ **Complete alignment verified** between deployment procedures and protocol semantics as of 2026-07-26.
+> **⚠️ CAVEAT — Alignment unverified since 2026-07-26.** `cargo check -p fluxora_stream`
+> currently fails (compile errors involving pooled-stream fields, delegation-depth
+> scaffolding, rate-cooldown scaffolding, the CliffSlope stream-kind variant, duplicate
+> `DataKey`/`Stream` fields, and other issues tracked in this repo). A workspace that
+> cannot produce a WASM artifact cannot simultaneously have "complete alignment" between
+> its deployment checklist and its protocol semantics. The 2026-07-26 date below marks the
+> **last** date on which a manual re-walk was performed; it does **not** cover any changes
+> merged after that date. Do **not** treat this document as authoritative evidence of
+> alignment until the build is restored and each checklist item is re-walked against the
+> current contract surface.
+
+❌ **Complete alignment NOT verified** as of today. Last verified: 2026-07-26 (pre-dates
+current compile-breaking state).
 
 ---
 


### PR DESCRIPTION
# docs: add compile-broken caveat to deployment checklist alignment

## Problem

`docs/mainnet-deployment-checklist-alignment.md` displayed an unconditional
"Complete alignment verified" badge dated 2026-07-26, but `cargo check -p
fluxora_stream` currently fails with 26 compile errors (pooled-stream fields,
delegation-depth scaffolding, rate-cooldown scaffolding, CliffSlope variant,
duplicate `DataKey`/`Stream` fields, and other issues tracked in this repo).

A workspace that cannot produce a WASM artifact cannot simultaneously have
"complete alignment" between its deployment checklist and protocol semantics.
The stale badge actively misreads the document's intended audience — treasury
operators, recipient applications, and auditors who rely on this document as
authoritative evidence of alignment.

## Changes

- Replaced the unconditional ✅ "Complete alignment verified" badge with a ❌
  "Complete alignment NOT verified" status.
- Added a prominent caveat blockquote explaining:
  - The compile-broken state of the workspace.
  - The categories of errors involved.
  - That the 2026-07-26 date marks the *last* verified date and does not cover
    any changes merged after that date.
  - Explicit instruction not to treat the document as authoritative until the
    build is restored and each checklist item is re-walked against the current
    contract surface.

## Next steps (blocked on other issues)

Once the compile errors are resolved and the workspace produces a clean WASM
artifact again, each checklist item should be re-walked against the current
contract behavior (including the new `Stream` fields and `DataKey` surface
added by the pooled-stream, delegation, and rate-cooldown scaffolding), and the
verification date should be updated to reflect the re-walk.

Closes #1168 