### PR TITLE
fix: wasm32 cross-compile (Address TryFromVal) + remove continue-on-e…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,13 +198,8 @@ jobs:
       - name: Build release (native)
         run: cargo build --release -p fluxora_stream
 
-      # continue-on-error: fluxora_stream's wasm32 cross-compile is a known
-      # pre-existing break (soroban_sdk::Address TryFromVal trait mismatch,
-      # unrelated to today's CI restoration work). Native build above stays
-      # a hard gate. Needs a dedicated follow-up.
       - name: Build WASM
         run: cargo build --release -p fluxora_stream --target wasm32-unknown-unknown
-        continue-on-error: true
 
       - name: Install Stellar CLI (pinned)
         run: |
@@ -222,7 +217,6 @@ jobs:
       - name: Optimize WASM
         run: |
           stellar contract optimize --wasm target/wasm32-unknown-unknown/release/fluxora_stream.wasm
-        continue-on-error: true
 
       - name: Compute WASM SHA256 hash
         run: |
@@ -230,11 +224,9 @@ jobs:
           if [ -f target/wasm32-unknown-unknown/release/fluxora_stream.optimized.wasm ]; then
             sha256sum target/wasm32-unknown-unknown/release/fluxora_stream.optimized.wasm > target/wasm32-unknown-unknown/release/fluxora_stream.optimized.wasm.sha256
           fi
-        continue-on-error: true
 
       - name: Verify WASM build reproducibility
         run: bash script/verify-wasm-checksum.sh --no-build
-        continue-on-error: true
 
       - name: Upload WASM hash artifact
         uses: actions/upload-artifact@v4
@@ -533,10 +525,6 @@ jobs:
       (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
       (github.event_name == 'workflow_dispatch' && github.event.inputs.deploy_target == 'testnet')
     environment: testnet
-    # continue-on-error: cascades from the known pre-existing fluxora_stream
-    # wasm32 build break (see Build job) — no artifact is produced to
-    # deploy. Not blocking merges while that's fixed separately.
-    continue-on-error: true
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -609,6 +597,15 @@ jobs:
         with:
           name: fluxora_stream-wasm
           path: ./artifacts
+
+      - name: Verify WASM artifact exists
+        run: |
+          if [ -f ./artifacts/fluxora_stream.optimized.wasm ] || [ -f ./artifacts/fluxora_stream.wasm ]; then
+            echo "WASM artifact found"
+          else
+            echo "::error::No WASM artifact found — wasm32 build may have failed upstream in the Build job."
+            exit 1
+          fi
 
       - name: Install Stellar CLI (pinned)
         run: |

--- a/contracts/governance/src/lib.rs
+++ b/contracts/governance/src/lib.rs
@@ -384,10 +384,10 @@ fn dispatch_call(env: &Env, target: &Address, calldata: &Bytes) -> Result<(), Go
             set_threshold_internal(env, new_threshold)?;
         }
         CallData::GovAddSigner(signer) => {
-            FluxoraGovernance::add_signer_internal(env, signer)?;
+            add_signer_internal(env, signer)?;
         }
         CallData::GovRemoveSigner(signer) => {
-            FluxoraGovernance::remove_signer_internal(env, signer)?;
+            remove_signer_internal(env, signer)?;
         }
     }
     Ok(())

--- a/contracts/stream/src/checksum.rs
+++ b/contracts/stream/src/checksum.rs
@@ -189,6 +189,9 @@
 
 #[cfg(test)]
 mod tests {
+    extern crate std;
+    use std::string::ToString;
+
     /// Verify the module compiles and the doc-comment invariants are present.
     #[test]
     fn checksum_module_compiles() {}

--- a/contracts/stream/src/delegation.rs
+++ b/contracts/stream/src/delegation.rs
@@ -129,8 +129,8 @@ mod tests {
         let (env, client, stream_id, _recipient) = setup();
         env.ledger().set_timestamp(100);
 
-        let result = env.as_contract(&_client.address, || {
-            validate_delegation_params(&env, stream_id, 0, 100)
+        let result = env.as_contract(&client.address, || {
+            validate_delegation_params(&env, stream_id, 0, 100, 0)
         });
         assert_eq!(result, Ok(()));
     }
@@ -142,7 +142,7 @@ mod tests {
         env.ledger().set_timestamp(101);
 
         let result = env.as_contract(&_client.address, || {
-            validate_delegation_params(&env, stream_id, 0, 100)
+            validate_delegation_params(&env, stream_id, 0, 100, 0)
         });
         assert_eq!(result, Err(ContractError::SignatureDeadlineExpired));
     }
@@ -154,7 +154,7 @@ mod tests {
         env.ledger().set_timestamp(50);
 
         let result = env.as_contract(&_client.address, || {
-            validate_delegation_params(&env, stream_id, 0, 100)
+            validate_delegation_params(&env, stream_id, 0, 100, 0)
         });
         assert_eq!(result, Ok(()));
     }
@@ -166,7 +166,7 @@ mod tests {
         env.ledger().set_timestamp(50);
 
         let result = env.as_contract(&_client.address, || {
-            validate_delegation_params(&env, stream_id, 1, 100)
+            validate_delegation_params(&env, stream_id, 1, 100, 0)
         });
         assert_eq!(result, Err(ContractError::InvalidSignature));
     }
@@ -178,7 +178,7 @@ mod tests {
         env.ledger().set_timestamp(50);
 
         let result = env.as_contract(&_client.address, || {
-            validate_delegation_params(&env, 999, 0, 100)
+            validate_delegation_params(&env, 999, 0, 100, 0)
         });
         assert_eq!(result, Err(ContractError::StreamNotFound));
     }
@@ -192,7 +192,7 @@ mod tests {
         env.ledger().set_timestamp(1);
 
         let result = env.as_contract(&_client.address, || {
-            validate_delegation_params(&env, stream_id, 0, 0)
+            validate_delegation_params(&env, stream_id, 0, 0, 0)
         });
         assert_eq!(result, Err(ContractError::SignatureDeadlineExpired));
     }
@@ -204,7 +204,7 @@ mod tests {
         env.ledger().set_timestamp(100);
 
         let result = env.as_contract(&_client.address, || {
-            validate_delegation_params(&env, stream_id, 0, u64::MAX)
+            validate_delegation_params(&env, stream_id, 0, u64::MAX, 0)
         });
         assert_eq!(result, Ok(()));
     }
@@ -220,7 +220,7 @@ mod tests {
 
         // deadline=100 is expired, nonce=999 is wrong — deadline error first
         let result = env.as_contract(&_client.address, || {
-            validate_delegation_params(&env, stream_id, 999, 100)
+            validate_delegation_params(&env, stream_id, 999, 100, 0)
         });
         assert_eq!(result, Err(ContractError::SignatureDeadlineExpired));
     }
@@ -234,7 +234,7 @@ mod tests {
 
         // stream_id=999 doesn't exist, nonce=999 is wrong — StreamNotFound first
         let result = env.as_contract(&_client.address, || {
-            validate_delegation_params(&env, 999, 999, 100)
+            validate_delegation_params(&env, 999, 999, 100, 0)
         });
         assert_eq!(result, Err(ContractError::StreamNotFound));
     }
@@ -248,7 +248,7 @@ mod tests {
         env.ledger().set_timestamp(50);
 
         let result = env.as_contract(&_client.address, || {
-            validate_delegation_params(&env, stream_id, u64::MAX, 100)
+            validate_delegation_params(&env, stream_id, u64::MAX, 100, 0)
         });
         assert_eq!(result, Err(ContractError::InvalidSignature));
     }
@@ -320,13 +320,13 @@ mod tests {
         // Both recipients have default nonce=0; nonce 0 must pass for both
         assert_eq!(
             env.as_contract(&contract_id, || validate_delegation_params(
-                &env, stream_a, 0, 100
+                &env, stream_a, 0, 100, 0
             )),
             Ok(())
         );
         assert_eq!(
             env.as_contract(&contract_id, || validate_delegation_params(
-                &env, _stream_b, 0, 100
+                &env, _stream_b, 0, 100, 0
             )),
             Ok(())
         );
@@ -334,13 +334,13 @@ mod tests {
         // Nonce 1 must fail for both (stored is 0)
         assert_eq!(
             env.as_contract(&contract_id, || validate_delegation_params(
-                &env, stream_a, 1, 100
+                &env, stream_a, 1, 100, 0
             )),
             Err(ContractError::InvalidSignature)
         );
         assert_eq!(
             env.as_contract(&contract_id, || validate_delegation_params(
-                &env, _stream_b, 1, 100
+                &env, _stream_b, 1, 100, 0
             )),
             Err(ContractError::InvalidSignature)
         );
@@ -355,13 +355,13 @@ mod tests {
 
         // First call: wrong nonce → fails
         let result_fail = env.as_contract(&_client.address, || {
-            validate_delegation_params(&env, stream_id, 1, 100)
+            validate_delegation_params(&env, stream_id, 1, 100, 0)
         });
         assert_eq!(result_fail, Err(ContractError::InvalidSignature));
 
         // Second call: correct nonce → must still succeed
         let result_ok = env.as_contract(&_client.address, || {
-            validate_delegation_params(&env, stream_id, 0, 100)
+            validate_delegation_params(&env, stream_id, 0, 100, 0)
         });
         assert_eq!(result_ok, Ok(()));
     }

--- a/contracts/stream/src/lib.rs
+++ b/contracts/stream/src/lib.rs
@@ -13,6 +13,7 @@ mod types;
 pub use types::{ClaimOwnershipTransferred, CreateStreamRelativeParams, MAX_POOL_RECIPIENTS};
 
 use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, token, Address, Env, Map};
+use soroban_sdk::xdr::ToXdr;
 pub use storage::*;
 use token_check::verify_token_behavior;
 pub use reject_duplicate_ids;
@@ -2395,6 +2396,23 @@ impl FluxoraStream {
 
         Ok(stream_id)
     }
+
+    /// Extract the ed25519 public key bytes from an `Address` that is known
+    /// to be an account-type address (G... strkey).
+    ///
+    /// Uses `Address::to_xdr` which serializes via the host function
+    /// `serialize_to_bytes`. The XDR encoding of an account `Address` is:
+    ///   - bytes  0..3: ScVal tag (Address = 18, big-endian u32)
+    ///   - bytes  4..7: ScAddress tag (Account = 0, big-endian u32)
+    ///   - bytes  8..11: PublicKey tag (PublicKeyTypeEd25519 = 0, big-endian u32)
+    ///   - bytes 12..43: ed25519 public key (32 bytes)
+    fn ed25519_pubkey_from_address(env: &Env, addr: &Address) -> [u8; 32] {
+        let xdr = addr.to_xdr(env);
+        let pk_bytes = xdr.slice(12..44);
+        let mut pk = [0u8; 32];
+        pk_bytes.copy_into_slice(&mut pk);
+        pk
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -4389,20 +4407,11 @@ impl FluxoraStream {
             return Err(ContractError::WithdrawalTooFrequent);
         }
 
-        // 4. Bind the supplied public key to the stream recipient.
+        // 4. Verify the supplied public key matches the stream recipient.
+        if Self::ed25519_pubkey_from_address(&env, &stream.recipient)
+            != recipient_public_key.to_array()
         {
-            use soroban_sdk::{
-                xdr::{AccountId, PublicKey, ScAddress, Uint256},
-                TryIntoVal,
-            };
-            let pk_arr = recipient_public_key.to_array();
-            let derived: Result<Address, _> =
-                ScAddress::Account(AccountId(PublicKey::PublicKeyTypeEd25519(Uint256(pk_arr))))
-                    .try_into_val(&env);
-            match derived {
-                Ok(addr) if addr == stream.recipient => {}
-                _ => return Err(ContractError::InvalidSignature),
-            }
+            return Err(ContractError::InvalidSignature);
         }
 
         // 5. Build the signed message payload (56 bytes total):
@@ -6771,19 +6780,10 @@ impl FluxoraStream {
             .as_ref()
             .ok_or(ContractError::InvalidParams)?;
 
+        if Self::ed25519_pubkey_from_address(&env, witness_addr)
+            != witness_public_key.to_array()
         {
-            use soroban_sdk::{
-                xdr::{AccountId, PublicKey, ScAddress, Uint256},
-                TryIntoVal,
-            };
-            let pk_arr = witness_public_key.to_array();
-            let derived: Result<Address, _> =
-                ScAddress::Account(AccountId(PublicKey::PublicKeyTypeEd25519(Uint256(pk_arr))))
-                    .try_into_val(&env);
-            match derived {
-                Ok(addr) if addr == *witness_addr => {}
-                _ => return Err(ContractError::InvalidSignature),
-            }
+            return Err(ContractError::InvalidSignature);
         }
 
         let msg = delegation::build_witnessed_cancel_message(&env, stream_id, deadline);

--- a/contracts/stream/src/test.rs
+++ b/contracts/stream/src/test.rs
@@ -3,7 +3,7 @@ extern crate std;
 use soroban_sdk::{
     testutils::{Address as _, Events, Ledger},
     token::{Client as TokenClient, StellarAssetClient},
-    Address, Env, FromVal, IntoVal, Symbol, TryFromVal, Val, Vec,
+    xdr::ToXdr, Address, Env, FromVal, IntoVal, Symbol, TryFromVal, Val, Vec,
 };
 
 use crate::{
@@ -22489,4 +22489,54 @@ fn test_contract_error_discriminants_are_stable() {
         44,
         "DelegationDepthExceeded must be 44"
     );
+}
+
+#[test]
+fn xdr_pubkey_extraction_offset_is_correct() {
+    let env = Env::default();
+
+    // Create an account Address from a valid G... strkey.
+    // GCM5WPR4DDR24FSAX5LIEM4J7AI3KOWJYANSXEPKYXCSZOTAYXE75AFN is a
+    // well-known Stellar test strkey.
+    let addr = Address::from_string(&soroban_sdk::String::from_str(
+        &env,
+        "GCM5WPR4DDR24FSAX5LIEM4J7AI3KOWJYANSXEPKYXCSZOTAYXE75AFN",
+    ));
+
+    let xdr = addr.clone().to_xdr(&env);
+
+    // Account Address XDR should be exactly 44 bytes:
+    //   ScVal::Address disc (4B) + ScAddress::Account disc (4B)
+    //   + PublicKeyTypeEd25519 disc (4B) + ed25519 pubkey (32B)
+    assert_eq!(xdr.len(), 44);
+
+    // ScVal discriminant for the Address variant = 18 (u32 big-endian)
+    assert_eq!(xdr.get_unchecked(0), 0, "byte 0 = ScVal.Address tag high byte");
+    assert_eq!(xdr.get_unchecked(3), 18, "byte 3 = ScVal.Address tag low byte");
+
+    // ScAddress discriminant for Account = 0
+    assert_eq!(xdr.get_unchecked(4), 0);
+    assert_eq!(xdr.get_unchecked(7), 0);
+
+    // PublicKey discriminant for PublicKeyTypeEd25519 = 0
+    assert_eq!(xdr.get_unchecked(8), 0);
+    assert_eq!(xdr.get_unchecked(11), 0);
+
+    // Bytes 12..=43 should form a valid 32-byte ed25519 pubkey (non-zero).
+    for i in 12..44 {
+        assert!(
+            xdr.get_unchecked(i) != 0,
+            "pubkey byte at XDR offset {i} is unexpectedly zero"
+        );
+    }
+
+    // The helper must extract the same bytes as XDR indices 12..44.
+    let extracted = FluxoraStream::ed25519_pubkey_from_address(&env, &addr);
+    for (i, byte) in extracted.iter().enumerate() {
+        assert_eq!(
+            *byte,
+            xdr.get_unchecked((i as u32) + 12),
+            "mismatch at helper output index {i}"
+        );
+    }
 }


### PR DESCRIPTION

## Description

Fixes the `fluxora_stream` wasm32 cross-compilation failure caused by `Address` conversion code that relied on a native-only `TryFromVal<Env, ScAddress>` implementation. With the cross-target compatibility issue resolved, the CI pipeline now treats the WASM build as a required gate instead of allowing failures to pass silently.

The fix replaces the native-only address conversion path with a target-independent helper built on `Address::to_xdr()`, allowing both native and WASM builds to compile successfully without changing contract behavior.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] CI / Build system improvement
- [x] Refactoring (no functional changes)

## Related Issues

Closes #1150

## Changes Made

### Contract

- Added a private helper to extract an Ed25519 public key from an `Address` using `Address::to_xdr()` and the current XDR layout.
- Replaced the two native-only `ScAddress::Account(...).try_into_val(&env)` call sites with the new helper.
- Preserved existing contract behavior while restoring full `wasm32` compatibility.

### CI

- Removed `continue-on-error` from:
  - Build WASM
  - Optimize WASM
  - Compute WASM SHA256
  - Verify WASM reproducibility
  - `deploy-testnet`
- Changed artifact uploads from `if-no-files-found: warn` to `error`.
- Added an explicit WASM artifact existence check before `deploy-mainnet` so deployment fails with a clear error if the artifact is missing.

### Additional Fixes

- Resolved a pre-existing workspace compilation issue in the governance crate by removing obsolete `FluxoraGovernance::` prefixes from internal helper calls.
- Fixed the disabled `checksum` test compilation by restoring the required imports.
- Updated `delegation` tests to match the current API signatures.

## Testing

### Validation

- [x] Native build succeeds.
- [x] WASM build succeeds:

```bash
cargo build --release -p fluxora_stream --target wasm32-unknown-unknown
```

- [x] Added validation for XDR public-key extraction.
- [x] Existing library tests pass (excluding the two pre-existing failures already present on `main`).

## Documentation

- [ ] Documentation update required
- [x] No documentation changes required

## Security Considerations

- [x] No new security concerns introduced.
- [x] CI now fails if the deployable WASM artifact is not produced.
- [x] Mainnet deployment now performs an explicit artifact existence check before attempting deployment.

## Checklist

- [x] Code follows the project's style guidelines.
- [x] Self-review completed.
- [x] Changes compile successfully on both native and `wasm32` targets.
- [x] Existing tests updated where necessary.
- [x] CI hard gates restored for WASM builds.

## Additional Notes

- The governance and test fixes resolve pre-existing workspace compilation issues required to complete the full build successfully. They do not modify contract logic.
- This PR restores the intended CI behavior so a successful workflow now guarantees that the deployable WASM contract is actually produced before deployment-related jobs execute.

## Reviewer Checklist

- [ ] Code quality and style
- [ ] CI changes reviewed
- [ ] Test coverage adequate
- [ ] Security implications reviewed
- [ ] Breaking changes documented