### PR TITLE
test(factory): add regression tests for shared memo-length guard constant

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,9 +112,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.94.1
         with:
           components: rustfmt, clippy
+          targets: wasm32-unknown-unknown
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -157,8 +158,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.94.1
         with:
+          components: rustfmt, clippy
           targets: wasm32-unknown-unknown
 
       - name: Set up Python
@@ -265,7 +267,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.94.1
+        with:
+          components: rustfmt, clippy
+          targets: wasm32-unknown-unknown
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -420,7 +425,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.94.1
+        with:
+          components: rustfmt, clippy
+          targets: wasm32-unknown-unknown
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/backend/src/controllers/recommendation.controller.ts
+++ b/backend/src/controllers/recommendation.controller.ts
@@ -126,7 +126,7 @@ export async function dismissRecommendation(
 export async function logClick(
   req: Request,
   res: Response,
-  next: NextFunction
+  _next: NextFunction
 ): Promise<void> {
   try {
     // Extract learnerId from authenticated user

--- a/backend/src/controllers/user.controller.ts
+++ b/backend/src/controllers/user.controller.ts
@@ -34,7 +34,7 @@ export async function getCurrentUser(
  * PATCH /api/v1/users/me
  */
 export async function updateUser(
-  req: Request,
+  _req: Request,
   res: Response,
   next: NextFunction
 ): Promise<void> {
@@ -80,7 +80,7 @@ export async function getUserById(
  * DELETE /api/v1/users/me
  */
 export async function deleteUser(
-  req: Request,
+  _req: Request,
   res: Response,
   next: NextFunction
 ): Promise<void> {
@@ -102,7 +102,7 @@ export async function deleteUser(
  * PATCH /api/v1/users/me/learner-profile
  */
 export async function updateLearnerProfile(
-  req: Request,
+  _req: Request,
   res: Response,
   next: NextFunction
 ): Promise<void> {
@@ -124,7 +124,7 @@ export async function updateLearnerProfile(
  * GET /api/v1/users/me/budget
  */
 export async function getLearnerBudget(
-  req: Request,
+  _req: Request,
   res: Response,
   next: NextFunction
 ): Promise<void> {
@@ -147,7 +147,7 @@ export async function getLearnerBudget(
  * GET /api/v1/users
  */
 export async function listUsers(
-  req: Request,
+  _req: Request,
   res: Response,
   next: NextFunction
 ): Promise<void> {

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -26,7 +26,7 @@ app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 
 // Health check endpoint
-app.get('/health', (req, res) => {
+app.get('/health', (_req, res) => {
   res.status(200).json({ status: 'ok', timestamp: new Date().toISOString() });
 });
 
@@ -35,7 +35,7 @@ app.use('/api/v1/users', userRoutes);
 app.use('/api/v1/streams', streamRoutes);
 
 // 404 handler
-app.use((req, res) => {
+app.use((_req, res) => {
   res.status(404).json({
     success: false,
     error: {
@@ -46,7 +46,7 @@ app.use((req, res) => {
 });
 
 // Error handler
-app.use((err: Error, req: express.Request, res: express.Response, next: express.NextFunction) => {
+app.use((err: Error, _req: express.Request, res: express.Response, _next: express.NextFunction) => {
   logger.error('Unhandled error', { error: err.message, stack: err.stack });
   
   res.status(500).json({

--- a/backend/src/middleware/auth.middleware.ts
+++ b/backend/src/middleware/auth.middleware.ts
@@ -18,7 +18,7 @@ interface DecodedToken {
  */
 export function authenticate(
   req: Request,
-  res: Response,
+  _res: Response,
   next: NextFunction
 ): void {
   try {
@@ -71,7 +71,7 @@ export function authenticate(
  * Usage: authorize(['admin', 'mentor'])
  */
 export function authorize(roles: string[]) {
-  return (req: Request, res: Response, next: NextFunction): void => {
+  return (req: Request, _res: Response, next: NextFunction): void => {
     try {
       if (!req.user) {
         throw new UnauthorizedError('User not authenticated');

--- a/backend/src/middleware/validation.middleware.ts
+++ b/backend/src/middleware/validation.middleware.ts
@@ -134,7 +134,7 @@ export function validate(schemaName: string) {
     throw new Error(`Validation schema '${schemaName}' not found`);
   }
 
-  return (req: Request, res: Response, next: NextFunction): void => {
+  return (req: Request, _res: Response, next: NextFunction): void => {
     try {
       for (const rule of rules) {
         const value = rule.param

--- a/backend/src/utils/cache.ts
+++ b/backend/src/utils/cache.ts
@@ -69,7 +69,11 @@ class CacheWrapper {
   async set<T>(key: string, value: T, ttlSeconds: number): Promise<void> {
     try {
       const serialized = JSON.stringify(value);
-      await this.client.set(key, serialized, ttlSeconds);
+      if (this.useRedis) {
+        await (this.client as Redis).setex(key, ttlSeconds, serialized);
+      } else {
+        await (this.client as InMemoryCache).set(key, serialized, ttlSeconds);
+      }
     } catch (error) {
       logger.error('Cache set error', { key, error });
     }

--- a/backend/tests/websocket.test.ts
+++ b/backend/tests/websocket.test.ts
@@ -654,6 +654,16 @@ describe('WebSocket Integration', () => {
       let ws2Subscribed = false;
       let ws1ReceivedUpdate = false;
       let ws2ReceivedUpdate = false;
+      let broadcastTriggered = false;
+
+      function triggerBroadcastIfReady() {
+        if (ws1Subscribed && ws2Subscribed && !broadcastTriggered) {
+          broadcastTriggered = true;
+          setTimeout(() => {
+            streamChannel.notifyStreamUpdated(streamId, { test: 'broadcast' });
+          }, 100);
+        }
+      }
 
       ws1.on('open', () => {
         ws1.send(JSON.stringify({ type: 'subscribe', streamId }));
@@ -661,7 +671,10 @@ describe('WebSocket Integration', () => {
 
       ws1.on('message', (data) => {
         const message = JSON.parse(data.toString());
-        if (message.type === 'subscribed') ws1Subscribed = true;
+        if (message.type === 'subscribed') {
+          ws1Subscribed = true;
+          triggerBroadcastIfReady();
+        }
         if (message.type === 'stream_update') {
           expect(message.streamId).toBe(streamId);
           ws1ReceivedUpdate = true;
@@ -677,11 +690,7 @@ describe('WebSocket Integration', () => {
         const message = JSON.parse(data.toString());
         if (message.type === 'subscribed') {
           ws2Subscribed = true;
-          if (ws1Subscribed && ws2Subscribed) {
-            setTimeout(() => {
-              streamChannel.notifyStreamUpdated(streamId, { test: 'broadcast' });
-            }, 100);
-          }
+          triggerBroadcastIfReady();
         }
         if (message.type === 'stream_update') {
           expect(message.streamId).toBe(streamId);

--- a/contracts/factory/tests/adversarial_auth.rs
+++ b/contracts/factory/tests/adversarial_auth.rs
@@ -75,12 +75,7 @@ impl<'a> Ctx<'a> {
         // Init both contracts under mock_all_auths, then drop it.
         env.mock_all_auths();
         stellar_asset.mint(&sender, &SENDER_FUNDING);
-        TokenClient::new(&env, &token_addr).approve(
-            &sender,
-            &stream_id,
-            &SENDER_FUNDING,
-            &100_000,
-        );
+        TokenClient::new(&env, &token_addr).approve(&sender, &stream_id, &SENDER_FUNDING, &100_000);
         stream.init(&token_addr, &stream_id);
         factory.init(&admin, &stream_id, &MAX_DEPOSIT, &MIN_DURATION);
         factory.set_allowlist(&recipient, &true);
@@ -141,7 +136,14 @@ fn test_create_stream_no_auth_fails() {
     ctx.env.mock_auths(&[]);
 
     let start = ctx.start();
-    let params = make_params(&ctx.recipient, DEPOSIT, RATE, start, start, start + DURATION);
+    let params = make_params(
+        &ctx.recipient,
+        DEPOSIT,
+        RATE,
+        start,
+        start,
+        start + DURATION,
+    );
 
     let result = ctx.factory.try_create_stream(&ctx.sender, &params);
 
@@ -164,7 +166,14 @@ fn test_create_stream_spoofed_sender_fails() {
     let attacker = Address::generate(&ctx.env);
     let start = ctx.start();
 
-    let params = make_params(&ctx.recipient, DEPOSIT, RATE, start, start, start + DURATION);
+    let params = make_params(
+        &ctx.recipient,
+        DEPOSIT,
+        RATE,
+        start,
+        start,
+        start + DURATION,
+    );
 
     ctx.env.mock_auths(&[MockAuth {
         address: &attacker,
@@ -196,7 +205,14 @@ fn test_create_stream_missing_sub_invocation_auth_fails() {
     let ctx = Ctx::setup();
     let start = ctx.start();
 
-    let params = make_params(&ctx.recipient, DEPOSIT, RATE, start, start, start + DURATION);
+    let params = make_params(
+        &ctx.recipient,
+        DEPOSIT,
+        RATE,
+        start,
+        start,
+        start + DURATION,
+    );
 
     ctx.env.mock_auths(&[MockAuth {
         address: &ctx.sender,
@@ -227,7 +243,14 @@ fn test_create_stream_correct_dual_auth_succeeds() {
     let ctx = Ctx::setup();
     let start = ctx.start();
 
-    let params = make_params(&ctx.recipient, DEPOSIT, RATE, start, start, start + DURATION);
+    let params = make_params(
+        &ctx.recipient,
+        DEPOSIT,
+        RATE,
+        start,
+        start,
+        start + DURATION,
+    );
 
     ctx.env.mock_auths(&[MockAuth {
         address: &ctx.sender,
@@ -266,9 +289,22 @@ fn test_create_stream_auth_recipient_mismatch_fails() {
     let start = ctx.start();
     let wrong_recipient = Address::generate(&ctx.env);
 
-    let params = make_params(&ctx.recipient, DEPOSIT, RATE, start, start, start + DURATION);
-    let wrong_params =
-        make_params(&wrong_recipient, DEPOSIT, RATE, start, start, start + DURATION);
+    let params = make_params(
+        &ctx.recipient,
+        DEPOSIT,
+        RATE,
+        start,
+        start,
+        start + DURATION,
+    );
+    let wrong_params = make_params(
+        &wrong_recipient,
+        DEPOSIT,
+        RATE,
+        start,
+        start,
+        start + DURATION,
+    );
 
     ctx.env.mock_auths(&[MockAuth {
         address: &ctx.sender,
@@ -307,7 +343,14 @@ fn test_create_stream_third_party_relay_fails() {
     let attacker = Address::generate(&ctx.env);
     let start = ctx.start();
 
-    let params = make_params(&ctx.recipient, DEPOSIT, RATE, start, start, start + DURATION);
+    let params = make_params(
+        &ctx.recipient,
+        DEPOSIT,
+        RATE,
+        start,
+        start,
+        start + DURATION,
+    );
 
     ctx.env.mock_auths(&[MockAuth {
         address: &attacker,

--- a/contracts/factory/tests/factory_setters.rs
+++ b/contracts/factory/tests/factory_setters.rs
@@ -1030,8 +1030,7 @@ fn test_set_batch_cap_enforcement_emits_event_true() {
     let (_, topics, data) = events.get(events.len() - 1).unwrap();
     let topic0: soroban_sdk::Symbol = topics.get(0).unwrap().try_into_val(&env).unwrap();
     assert_eq!(topic0, soroban_sdk::symbol_short!("batch_cap"));
-    let payload: fluxora_factory::BatchCapEnforcementUpdated =
-        data.try_into_val(&env).unwrap();
+    let payload: fluxora_factory::BatchCapEnforcementUpdated = data.try_into_val(&env).unwrap();
     assert_eq!(payload.enabled, true);
 }
 
@@ -1054,7 +1053,6 @@ fn test_set_batch_cap_enforcement_emits_event_false() {
     let (_, topics, data) = events.get(events.len() - 1).unwrap();
     let topic0: soroban_sdk::Symbol = topics.get(0).unwrap().try_into_val(&env).unwrap();
     assert_eq!(topic0, soroban_sdk::symbol_short!("batch_cap"));
-    let payload: fluxora_factory::BatchCapEnforcementUpdated =
-        data.try_into_val(&env).unwrap();
+    let payload: fluxora_factory::BatchCapEnforcementUpdated = data.try_into_val(&env).unwrap();
     assert_eq!(payload.enabled, false);
 }

--- a/contracts/factory/tests/factory_stream_e2e.rs
+++ b/contracts/factory/tests/factory_stream_e2e.rs
@@ -90,20 +90,22 @@ impl<'a> FactoryClientWrapper<'a> {
         cliff_time: &u64,
         end_time: &u64,
         withdraw_dust_threshold: &i128,
+        stream_kind: &StreamKind,
+        memo: &Option<soroban_sdk::Bytes>,
     ) -> u64 {
         self.client.create_stream(
             sender,
             &fluxora_stream::CreateStreamParams {
                 recipient: recipient.clone(),
-                deposit_amount: deposit_amount,
-                rate_per_second: rate_per_second,
-                start_time: start_time,
-                cliff_time: cliff_time,
-                end_time: end_time,
-                withdraw_dust_threshold: Some(withdraw_dust_threshold),
-                memo: fluxora_stream::StreamKind::Linear,
+                deposit_amount: *deposit_amount,
+                rate_per_second: *rate_per_second,
+                start_time: *start_time,
+                cliff_time: *cliff_time,
+                end_time: *end_time,
+                withdraw_dust_threshold: Some(*withdraw_dust_threshold),
+                memo: memo.clone(),
                 metadata: None,
-                kind: None,
+                kind: *stream_kind,
                 irrevocable: None,
                 witness: None,
             },
@@ -120,21 +122,23 @@ impl<'a> FactoryClientWrapper<'a> {
         cliff_time: &u64,
         end_time: &u64,
         withdraw_dust_threshold: &i128,
+        stream_kind: &StreamKind,
+        memo: &Option<soroban_sdk::Bytes>,
     ) -> Result<Result<u64, soroban_sdk::Error>, Result<FactoryError, soroban_sdk::InvokeError>>
     {
         self.client.try_create_stream(
             sender,
             &fluxora_stream::CreateStreamParams {
                 recipient: recipient.clone(),
-                deposit_amount: deposit_amount,
-                rate_per_second: rate_per_second,
-                start_time: start_time,
-                cliff_time: cliff_time,
-                end_time: end_time,
-                withdraw_dust_threshold: Some(withdraw_dust_threshold),
-                memo: fluxora_stream::StreamKind::Linear,
+                deposit_amount: *deposit_amount,
+                rate_per_second: *rate_per_second,
+                start_time: *start_time,
+                cliff_time: *cliff_time,
+                end_time: *end_time,
+                withdraw_dust_threshold: Some(*withdraw_dust_threshold),
+                memo: memo.clone(),
                 metadata: None,
-                kind: None,
+                kind: *stream_kind,
                 irrevocable: None,
                 witness: None,
             },
@@ -293,14 +297,6 @@ fn test_create_stream_happy_path() {
         &cliff,
         &end,
         &dust,
-        &ctx.sender,
-        &ctx.recipient,
-        &deposit,
-        &rate,
-        &start,
-        &cliff,
-        &end,
-        &dust,
         &fluxora_stream::StreamKind::Linear,
         &None,
     );
@@ -359,14 +355,6 @@ fn test_create_stream_recipient_not_allowlisted() {
         &cliff,
         &end,
         &dust,
-        &ctx.sender,
-        &unknown,
-        &dep,
-        &rate,
-        &start,
-        &cliff,
-        &end,
-        &dust,
         &fluxora_stream::StreamKind::Linear,
         &None,
     );
@@ -392,14 +380,6 @@ fn test_create_stream_deposit_exceeds_cap() {
         &cliff,
         &end,
         &dust,
-        &ctx.sender,
-        &ctx.recipient,
-        &over_cap,
-        &rate,
-        &start,
-        &cliff,
-        &end,
-        &dust,
         &fluxora_stream::StreamKind::Linear,
         &None,
     );
@@ -413,14 +393,6 @@ fn test_create_stream_deposit_at_cap_ok() {
     let (_, rate, start, cliff, end, dust) = ctx.default_params();
 
     let result = ctx.factory.try_create_stream(
-        &ctx.sender,
-        &ctx.recipient,
-        &MAX_DEPOSIT,
-        &rate,
-        &start,
-        &cliff,
-        &end,
-        &dust,
         &ctx.sender,
         &ctx.recipient,
         &MAX_DEPOSIT,
@@ -1213,22 +1185,17 @@ fn test_single_create_stream_memo_over_limit_rejected_by_factory_guard() {
     over_limit_bytes.resize(fluxora_stream::MAX_MEMO_BYTES + 1, 0xAB);
     let over_limit_memo = soroban_sdk::Bytes::from_slice(&ctx.env, &over_limit_bytes);
 
-    let res = ctx.factory.client.try_create_stream(
+    let res = ctx.factory.try_create_stream(
         &ctx.sender,
-        &fluxora_stream::CreateStreamParams {
-            recipient: ctx.recipient.clone(),
-            deposit_amount: DEPOSIT_AMOUNT,
-            rate_per_second: RATE_PER_SECOND,
-            start_time: now,
-            cliff_time: now,
-            end_time: (now + STREAM_DURATION),
-            withdraw_dust_threshold: Some(0),
-            memo: fluxora_stream::StreamKind::Linear,
-            metadata: None,
-            kind: Some(over_limit_memo),
-            irrevocable: None,
-            witness: None,
-        },
+        &ctx.recipient,
+        &DEPOSIT_AMOUNT,
+        &RATE_PER_SECOND,
+        &now,
+        &now,
+        &(now + STREAM_DURATION),
+        &0,
+        &StreamKind::Linear,
+        &Some(soroban_sdk::Bytes::from_slice(&ctx.env, &over_limit_bytes)),
     );
 
     // Must return FactoryError::InvalidMemo from the factory itself
@@ -1257,22 +1224,17 @@ fn test_single_create_stream_exact_max_memo_bytes_accepted() {
     exact_bytes.resize(fluxora_stream::MAX_MEMO_BYTES, 0xCD);
     let exact_memo = soroban_sdk::Bytes::from_slice(&ctx.env, &exact_bytes);
 
-    let res = ctx.factory.client.try_create_stream(
+    let res = ctx.factory.try_create_stream(
         &ctx.sender,
-        &fluxora_stream::CreateStreamParams {
-            recipient: ctx.recipient.clone(),
-            deposit_amount: DEPOSIT_AMOUNT,
-            rate_per_second: RATE_PER_SECOND,
-            start_time: now,
-            cliff_time: now,
-            end_time: (now + STREAM_DURATION),
-            withdraw_dust_threshold: Some(0),
-            memo: fluxora_stream::StreamKind::Linear,
-            metadata: None,
-            kind: Some(exact_memo.clone()),
-            irrevocable: None,
-            witness: None,
-        },
+        &ctx.recipient,
+        &DEPOSIT_AMOUNT,
+        &RATE_PER_SECOND,
+        &now,
+        &now,
+        &(now + STREAM_DURATION),
+        &0,
+        &StreamKind::Linear,
+        &Some(exact_memo.clone()),
     );
 
     assert!(res.is_ok());

--- a/contracts/factory/tests/factory_stream_e2e.rs
+++ b/contracts/factory/tests/factory_stream_e2e.rs
@@ -179,8 +179,6 @@ impl<'a> FactoryClientWrapper<'a> {
 
 struct Ctx<'a> {
     env: Env,
-    factory: FluxoraFactoryClient<'a>,
-    stream: FluxoraStreamClient<'a>,
     #[expect(dead_code)]
     factory: FactoryClientWrapper<'a>,
     stream: FluxoraStreamClient<'a>,
@@ -426,14 +424,6 @@ fn test_create_stream_duration_too_short() {
         &start,
         &(start + short_duration),
         &0,
-        &ctx.sender,
-        &ctx.recipient,
-        &DEPOSIT_AMOUNT,
-        &RATE_PER_SECOND,
-        &start,
-        &start,
-        &(start + short_duration),
-        &0,
         &fluxora_stream::StreamKind::Linear,
         &None,
     );
@@ -447,14 +437,6 @@ fn test_create_stream_duration_at_minimum_ok() {
     let start = ctx.now();
 
     let result = ctx.factory.try_create_stream(
-        &ctx.sender,
-        &ctx.recipient,
-        &DEPOSIT_AMOUNT,
-        &RATE_PER_SECOND,
-        &start,
-        &start,
-        &(start + MIN_DURATION),
-        &0,
         &ctx.sender,
         &ctx.recipient,
         &DEPOSIT_AMOUNT,
@@ -487,14 +469,6 @@ fn test_create_stream_invalid_time_range_end_before_start() {
         &(now + 200),
         &(now + 100),
         &0,
-        &ctx.sender,
-        &ctx.recipient,
-        &DEPOSIT_AMOUNT,
-        &RATE_PER_SECOND,
-        &(now + 200),
-        &(now + 200),
-        &(now + 100),
-        &0,
         &fluxora_stream::StreamKind::Linear,
         &None,
     );
@@ -507,14 +481,6 @@ fn test_create_stream_invalid_time_range_end_equal_start() {
     let now = ctx.now();
 
     let result = ctx.factory.try_create_stream(
-        &ctx.sender,
-        &ctx.recipient,
-        &DEPOSIT_AMOUNT,
-        &RATE_PER_SECOND,
-        &now,
-        &now,
-        &now,
-        &0,
         &ctx.sender,
         &ctx.recipient,
         &DEPOSIT_AMOUNT,
@@ -543,14 +509,6 @@ fn test_create_stream_invalid_cliff_before_start() {
         &now,
         &(now + 300),
         &0,
-        &ctx.sender,
-        &ctx.recipient,
-        &DEPOSIT_AMOUNT,
-        &RATE_PER_SECOND,
-        &(now + 100),
-        &now,
-        &(now + 300),
-        &0,
         &fluxora_stream::StreamKind::Linear,
         &None,
     );
@@ -563,14 +521,6 @@ fn test_create_stream_invalid_cliff_after_end() {
     let now = ctx.now();
 
     let result = ctx.factory.try_create_stream(
-        &ctx.sender,
-        &ctx.recipient,
-        &DEPOSIT_AMOUNT,
-        &RATE_PER_SECOND,
-        &now,
-        &(now + 300),
-        &(now + 200),
-        &0,
         &ctx.sender,
         &ctx.recipient,
         &DEPOSIT_AMOUNT,
@@ -604,14 +554,6 @@ fn test_create_stream_cliff_at_start() {
         &now,
         &(now + STREAM_DURATION),
         &0,
-        &ctx.sender,
-        &ctx.recipient,
-        &DEPOSIT_AMOUNT,
-        &RATE_PER_SECOND,
-        &now,
-        &now,
-        &(now + STREAM_DURATION),
-        &0,
         &fluxora_stream::StreamKind::Linear,
         &None,
     );
@@ -629,14 +571,6 @@ fn test_create_stream_cliff_at_end() {
     let end = now + STREAM_DURATION;
 
     let stream_id = ctx.factory.create_stream(
-        &ctx.sender,
-        &ctx.recipient,
-        &DEPOSIT_AMOUNT,
-        &RATE_PER_SECOND,
-        &now,
-        &end,
-        &end,
-        &0,
         &ctx.sender,
         &ctx.recipient,
         &DEPOSIT_AMOUNT,
@@ -999,6 +933,8 @@ fn make_params(ctx: &Ctx, recipient: &Address, start_offset: u64) -> CreateStrea
         memo: None,
         metadata: None,
         kind: StreamKind::Linear,
+        irrevocable: None,
+        witness: None,
     }
 }
 
@@ -1144,15 +1080,16 @@ fn test_single_then_batch_registry_accumulates_in_order() {
 // Memo-length shared constant & early rejection test suite
 // ---------------------------------------------------------------------------
 
-/// Compile-time & runtime assertion proving the factory's memo-length guard is driven
-/// by `fluxora_stream::MAX_MEMO_BYTES` (the shared constant).
+/// Compile-time and runtime assertion proving the factory's memo-length guard
+/// is driven by `fluxora_stream::MAX_MEMO_BYTES` (the shared constant).
 ///
 /// # Security & Architectural Safeguard
-/// The factory contract directly imports `fluxora_stream::MAX_MEMO_BYTES` in both
-/// `create_stream` and `create_streams` (Guard 8). This test machine-checks that
-/// the constant imported and evaluated by the factory test suite is identical to
-/// `fluxora_stream::MAX_MEMO_BYTES`, guaranteeing that changes to the stream contract's
-/// memo limit will automatically drive factory validation without risk of stale copies or divergence.
+/// The factory contract directly imports `fluxora_stream::MAX_MEMO_BYTES` in
+/// both `create_stream` and `create_streams` (Guard 8). This test
+/// machine-checks that the constant imported and evaluated by the factory test
+/// suite is identical to `fluxora_stream::MAX_MEMO_BYTES`, guaranteeing that
+/// changes to the stream contract's memo limit will automatically drive
+/// factory validation without risk of stale copies or divergence.
 #[test]
 fn test_factory_memo_guard_tracks_shared_max_memo_bytes_constant() {
     // Direct compile-time constant alignment check
@@ -1165,16 +1102,19 @@ fn test_factory_memo_guard_tracks_shared_max_memo_bytes_constant() {
     assert_eq!(fluxora_stream::MAX_MEMO_BYTES, 256);
 }
 
-/// Proves that `create_stream` with a memo one byte over `fluxora_stream::MAX_MEMO_BYTES`
-/// (i.e. `MAX_MEMO_BYTES + 1` bytes) is rejected by the factory's own guard
-/// (`FactoryError::InvalidMemo`) BEFORE the cross-contract call is made to `FluxoraStream`.
+/// Proves that `create_stream` with a memo one byte over
+/// `fluxora_stream::MAX_MEMO_BYTES` (i.e. `MAX_MEMO_BYTES + 1` bytes) is
+/// rejected by the factory's own guard (`FactoryError::InvalidMemo`) BEFORE
+/// the cross-contract call is made to `FluxoraStream`.
 ///
 /// # Early Rejection Proof
-/// 1. `ctx.factory.client.try_create_stream(...)` returns `Err(Ok(FactoryError::InvalidMemo))`.
+/// 1. `ctx.factory.client.try_create_stream(...)` returns
+///    `Err(Ok(FactoryError::InvalidMemo))`.
 /// 2. The stream contract registry count and factory registry count remain 0.
 /// 3. The sender's token balance is untouched.
-/// 4. Distinguishes factory's Guard 8 early rejection (`FactoryError::InvalidMemo`) from
-///    downstream stream contract rejection (`ContractError::MemoTooLong`).
+/// 4. Distinguishes factory's Guard 8 early rejection
+///    (`FactoryError::InvalidMemo`) from downstream stream contract rejection
+///    (`ContractError::MemoTooLong`).
 #[test]
 fn test_single_create_stream_memo_over_limit_rejected_by_factory_guard() {
     let ctx = Ctx::setup();
@@ -1183,7 +1123,6 @@ fn test_single_create_stream_memo_over_limit_rejected_by_factory_guard() {
     // Construct a memo of length MAX_MEMO_BYTES + 1 (257 bytes)
     let mut over_limit_bytes = std::vec::Vec::with_capacity(fluxora_stream::MAX_MEMO_BYTES + 1);
     over_limit_bytes.resize(fluxora_stream::MAX_MEMO_BYTES + 1, 0xAB);
-    let over_limit_memo = soroban_sdk::Bytes::from_slice(&ctx.env, &over_limit_bytes);
 
     let res = ctx.factory.try_create_stream(
         &ctx.sender,
@@ -1207,13 +1146,15 @@ fn test_single_create_stream_memo_over_limit_rejected_by_factory_guard() {
         "Factory must reject over-length memo with FactoryError::InvalidMemo before calling stream contract"
     );
 
-    // Verify early rejection before cross-contract interaction (0 streams registered, sender balance untouched)
+    // Verify early rejection before cross-contract interaction (0 streams
+    // registered, sender balance untouched)
     assert_eq!(ctx.factory.get_factory_stream_count(), 0);
     assert_eq!(ctx.token.balance(&ctx.sender), SENDER_FUNDING);
 }
 
-/// Proves that `create_stream` with a memo of exactly `fluxora_stream::MAX_MEMO_BYTES`
-/// (256 bytes) is accepted by the factory's guard and successfully forwarded to `FluxoraStream`.
+/// Proves that `create_stream` with a memo of exactly
+/// `fluxora_stream::MAX_MEMO_BYTES` (256 bytes) is accepted by the factory's
+/// guard and successfully forwarded to `FluxoraStream`.
 #[test]
 fn test_single_create_stream_exact_max_memo_bytes_accepted() {
     let ctx = Ctx::setup();
@@ -1246,9 +1187,10 @@ fn test_single_create_stream_exact_max_memo_bytes_accepted() {
     assert_eq!(state.memo, Some(exact_memo));
 }
 
-/// Proves that batch stream creation (`create_streams`) with one stream entry containing
-/// a memo exceeding `fluxora_stream::MAX_MEMO_BYTES` is rejected by the factory
-/// (`FactoryError::InvalidMemo`) prior to making any cross-contract call.
+/// Proves that batch stream creation (`create_streams`) with one stream entry
+/// containing a memo exceeding `fluxora_stream::MAX_MEMO_BYTES` is rejected by
+/// the factory (`FactoryError::InvalidMemo`) prior to making any
+/// cross-contract call.
 #[test]
 fn test_batch_create_streams_memo_over_limit_rejected_by_factory_guard() {
     let ctx = Ctx::setup();
@@ -1311,6 +1253,8 @@ fn test_direct_stream_call_bypasses_recipient_allowlist() {
         &now,
         &(now + STREAM_DURATION),
         &0,
+        &StreamKind::Linear,
+        &None,
     );
     assert_eq!(res, Err(Ok(FactoryError::RecipientNotAllowlisted)));
 
@@ -1370,6 +1314,8 @@ fn test_direct_stream_call_bypasses_deposit_cap() {
         &now,
         &(now + STREAM_DURATION),
         &0,
+        &StreamKind::Linear,
+        &None,
     );
     assert_eq!(res, Err(Ok(FactoryError::DepositExceedsCap)));
 
@@ -1420,6 +1366,8 @@ fn test_direct_stream_call_bypasses_minimum_duration() {
         &now,
         &(now + short_duration),
         &0,
+        &StreamKind::Linear,
+        &None,
     );
     assert_eq!(res, Err(Ok(FactoryError::DurationTooShort)));
 
@@ -1555,4 +1503,3 @@ fn test_create_streams_negative_deposit_rejected() {
     assert_eq!(ctx.factory.get_factory_stream_count(), factory_count_before);
     assert_eq!(ctx.token.balance(&ctx.sender), sender_balance_before);
 }
-

--- a/contracts/governance/src/lib.rs
+++ b/contracts/governance/src/lib.rs
@@ -226,16 +226,24 @@ fn set_threshold_internal(env: &Env, new_threshold: u32) -> Result<(), Governanc
         return Err(GovernanceError::InvalidThreshold);
     }
     let old_threshold = get_threshold(env)?;
-    env.storage().instance().set(&DataKey::Threshold, &new_threshold);
+    env.storage()
+        .instance()
+        .set(&DataKey::Threshold, &new_threshold);
     bump_instance(env);
 
     env.events().publish(
         (symbol_short!("thr_upd"),),
-        ThresholdUpdated { old_threshold, new_threshold },
+        ThresholdUpdated {
+            old_threshold,
+            new_threshold,
+        },
     );
     env.events().publish(
         (symbol_short!("quor_cfg"),),
-        QuorumConfig { threshold: new_threshold, signer_count: signers.len() },
+        QuorumConfig {
+            threshold: new_threshold,
+            signer_count: signers.len(),
+        },
     );
     Ok(())
 }
@@ -258,11 +266,15 @@ fn add_signer_internal(env: &Env, signer: Address) -> Result<(), GovernanceError
     save_signer_index(env, &signer_index);
     bump_instance(env);
 
-    env.events().publish((symbol_short!("sgnr_add"),), SignerAdded { signer });
+    env.events()
+        .publish((symbol_short!("sgnr_add"),), SignerAdded { signer });
     let threshold = get_threshold(env)?;
     env.events().publish(
         (symbol_short!("quor_cfg"),),
-        QuorumConfig { threshold, signer_count: signers.len() },
+        QuorumConfig {
+            threshold,
+            signer_count: signers.len(),
+        },
     );
     Ok(())
 }
@@ -294,7 +306,8 @@ fn remove_signer_internal(env: &Env, signer: Address) -> Result<(), GovernanceEr
     save_signer_index(env, &signer_index);
     bump_instance(env);
 
-    env.events().publish((symbol_short!("sgnr_rm"),), SignerRemoved { signer });
+    env.events()
+        .publish((symbol_short!("sgnr_rm"),), SignerRemoved { signer });
     Ok(())
 }
 
@@ -2017,7 +2030,7 @@ mod tests {
         assert_eq!(ctx.client.get_threshold(), 2);
     }
 
-   /// Reproduces the exact attack sequence from issue #1136: a compromised
+    /// Reproduces the exact attack sequence from issue #1136: a compromised
     /// admin key adds itself as a co-signer, collapses the threshold to 1,
     /// then solo proposes+approves. Confirms the attack now FAILS because
     /// there is no public entrypoint for add_signer/set_threshold that
@@ -2050,7 +2063,9 @@ mod tests {
         // collapsing the threshold still requires a second signer's approval
         // and the 48h timelock — solo propose+approve is insufficient.
         let collapse_calldata = CallData::GovSetThreshold(1u32).to_xdr(&ctx.env);
-        let id = ctx.client.propose(&ctx.signer_a, &ctx.contract_id, &collapse_calldata);
+        let id = ctx
+            .client
+            .propose(&ctx.signer_a, &ctx.contract_id, &collapse_calldata);
         ctx.client.approve(&ctx.signer_a, &id);
         // Only 1 of 2 required approvals — quorum not reached.
         let executor = Address::generate(&ctx.env);
@@ -2066,12 +2081,12 @@ mod tests {
         ctx.client.execute(&executor, &id);
         assert_eq!(ctx.client.get_threshold(), 1);
     }
-    
+
     #[test]
     fn test_set_threshold_after_signer_removal_respects_current_count() {
         let ctx = Ctx::setup(); // 3 signers, threshold=2
         ctx.client.test_only_remove_signer(&ctx.signer_c); // Now 2 signers
-                                                 // Setting threshold to 2 should succeed (2 <= 2)
+                                                           // Setting threshold to 2 should succeed (2 <= 2)
         ctx.client.test_only_set_threshold(&2u32);
         assert_eq!(ctx.client.get_threshold(), 2);
         // Setting threshold to 3 should fail (3 > 2)
@@ -2098,7 +2113,7 @@ mod tests {
     fn test_remove_signer_below_threshold_errors() {
         let ctx = Ctx::setup(); // 3 signers, threshold=2
         ctx.client.test_only_remove_signer(&ctx.signer_c); // 2 signers left
-                                                 // Trying to remove another signer would leave 1 < threshold=2
+                                                           // Trying to remove another signer would leave 1 < threshold=2
         let result = ctx.client.try_test_only_remove_signer(&ctx.signer_b);
         assert_eq!(result, Err(Ok(GovernanceError::QuorumWouldBreak)));
         // Verify signer set is unchanged.

--- a/contracts/stream/src/checksum.rs
+++ b/contracts/stream/src/checksum.rs
@@ -398,10 +398,9 @@ mod tests {
     #[test]
     fn doc_comment_toolchain_channel_matches_rust_toolchain_toml() {
         let manifest_dir = env!("CARGO_MANIFEST_DIR");
-        let toolchain_path =
-            std::path::Path::new(manifest_dir).join("../../rust-toolchain.toml");
-        let content = std::fs::read_to_string(&toolchain_path)
-            .expect("failed to read rust-toolchain.toml");
+        let toolchain_path = std::path::Path::new(manifest_dir).join("../../rust-toolchain.toml");
+        let content =
+            std::fs::read_to_string(&toolchain_path).expect("failed to read rust-toolchain.toml");
         let expected_channel = content
             .lines()
             .find_map(|line| {

--- a/contracts/stream/src/lib.rs
+++ b/contracts/stream/src/lib.rs
@@ -1706,7 +1706,9 @@ fn reconcile_paused_stream_count(env: &Env, previous: StreamStatus, next: Stream
 // IdReservation storage helpers — delegated to storage.rs
 // ---------------------------------------------------------------------------
 
-use storage::{load_id_reservation, next_stream_id_for, remove_id_reservation, save_id_reservation};
+use storage::{
+    load_id_reservation, next_stream_id_for, remove_id_reservation, save_id_reservation,
+};
 
 fn load_stream(env: &Env, stream_id: u64) -> Result<Stream, ContractError> {
     let key = DataKey::Stream(stream_id);
@@ -3684,13 +3686,7 @@ impl FluxoraStream {
         let effective_time = stream
             .cancelled_at
             .unwrap_or_else(|| env.ledger().timestamp());
-        withdrawable = apply_lookback_cap(
-            &env,
-            &stream,
-            effective_time,
-            accrued,
-            withdrawable,
-        );
+        withdrawable = apply_lookback_cap(&env, &stream, effective_time, accrued, withdrawable);
 
         // Cap by contract balance for safety (#39)
         let token_address = get_token(&env)?;
@@ -3944,13 +3940,7 @@ impl FluxoraStream {
         let effective_time = stream
             .cancelled_at
             .unwrap_or_else(|| env.ledger().timestamp());
-        withdrawable = apply_lookback_cap(
-            &env,
-            &stream,
-            effective_time,
-            accrued,
-            withdrawable,
-        );
+        withdrawable = apply_lookback_cap(&env, &stream, effective_time, accrued, withdrawable);
 
         // Cap by contract balance for safety (#39)
         let token_address = get_token(&env)?;
@@ -4373,8 +4363,6 @@ impl FluxoraStream {
         Ok(results)
     }
 
-
-
     /// Withdraw accrued tokens on behalf of a recipient using an ed25519 signature.
     ///
     /// A relayer (keeper, bot, or any third party) may call this entrypoint to
@@ -4415,12 +4403,8 @@ impl FluxoraStream {
     /// - `BelowMinimumAmount` (16): Withdrawable amount is below `expected_minimum_amount`.
     /// - `InvalidState`: Stream is paused (non-terminal) or completed.
     /// - `StreamNotFound`: `stream_id` does not exist.
-    
 
-
-
-
-  pub fn delegated_withdraw(
+    pub fn delegated_withdraw(
         env: Env,
         stream_id: u64,
         relayer: Address,
@@ -4781,13 +4765,7 @@ impl FluxoraStream {
         );
 
         let claimable = accrued - stream.withdrawn_amount;
-        let claimable = apply_lookback_cap(
-            &env,
-            &stream,
-            effective_time,
-            accrued,
-            claimable,
-        );
+        let claimable = apply_lookback_cap(&env, &stream, effective_time, accrued, claimable);
         Ok(if claimable > 0 { claimable } else { 0 })
     }
 
@@ -8061,13 +8039,7 @@ impl FluxoraStream {
                 );
 
                 let claimable = accrued.saturating_sub(stream.withdrawn_amount).max(0);
-                let claimable = apply_lookback_cap(
-                    &env,
-                    &stream,
-                    now,
-                    accrued,
-                    claimable,
-                );
+                let claimable = apply_lookback_cap(&env, &stream, now, accrued, claimable);
 
                 Ok(AutoClaimStatus::ValidDestination(AutoClaimValidPayload {
                     destination,
@@ -8381,8 +8353,7 @@ impl FluxoraStream {
     pub fn release_id_reservation(env: Env, caller: Address) -> Result<(), ContractError> {
         caller.require_auth();
 
-        let res =
-            load_id_reservation(&env, &caller).ok_or(ContractError::ReservationNotFound)?;
+        let res = load_id_reservation(&env, &caller).ok_or(ContractError::ReservationNotFound)?;
 
         Self::release_reservation(&env, &caller, &res);
         Ok(())

--- a/contracts/stream/tests/adversarial_auth.rs
+++ b/contracts/stream/tests/adversarial_auth.rs
@@ -2,7 +2,8 @@ extern crate std;
 
 use ed25519_dalek::{Signer, SigningKey};
 use fluxora_stream::{
-    ContractError, CreateStreamParams, FluxoraStream, FluxoraStreamClient, PauseReason, StreamStatus,
+    ContractError, CreateStreamParams, FluxoraStream, FluxoraStreamClient, PauseReason,
+    StreamStatus,
 };
 use soroban_sdk::{
     testutils::{Address as _, Ledger, MockAuth, MockAuthInvoke},

--- a/contracts/stream/tests/bulk_cancel.rs
+++ b/contracts/stream/tests/bulk_cancel.rs
@@ -7,8 +7,8 @@ use soroban_sdk::{
 };
 
 use fluxora_stream::{
-    ContractError, CreateStreamParams, FluxoraStream, FluxoraStreamClient, PauseReason,
-    StreamKind, StreamStatus,
+    ContractError, CreateStreamParams, FluxoraStream, FluxoraStreamClient, PauseReason, StreamKind,
+    StreamStatus,
 };
 
 // ── Test helpers ───────────────────────────────────────────────────────────
@@ -425,8 +425,7 @@ fn test_bulk_cancel_requires_sender_auth() {
 
     let (env, client, _admin, sender, recipient) = setup_env();
     env.ledger().set_timestamp(0);
-    let stream_id =
-        create_test_stream(&env, &client, &sender, &recipient, 1000, 1, 0, 0, 1000);
+    let stream_id = create_test_stream(&env, &client, &sender, &recipient, 1000, 1, 0, 0, 1000);
 
     let attacker = Address::generate(&env);
     let result = std::panic::catch_unwind(AssertUnwindSafe(|| {

--- a/contracts/stream/tests/close_guard_paths.rs
+++ b/contracts/stream/tests/close_guard_paths.rs
@@ -479,11 +479,9 @@ fn test_close_last_stream_empty_index_graceful() {
     assert_eq!(index_after.len(), 0);
 
     // Paginated query also returns empty with next_cursor == 0.
-    let page = ctx.client.get_recipient_streams_paginated(
-        &ctx.recipient,
-        &0,
-        &MAX_RECIPIENT_PAGE_SIZE,
-    );
+    let page =
+        ctx.client
+            .get_recipient_streams_paginated(&ctx.recipient, &0, &MAX_RECIPIENT_PAGE_SIZE);
     assert_eq!(page.stream_ids.len(), 0);
     assert_eq!(page.next_cursor, 0);
 }

--- a/contracts/stream/tests/event_snapshots_suite.rs
+++ b/contracts/stream/tests/event_snapshots_suite.rs
@@ -29,9 +29,10 @@
 extern crate std;
 
 use fluxora_stream::{
-    ContractPauseChanged, CreateStreamParams, DataKey, FluxoraStream, FluxoraStreamClient, PauseReason, RateUpdated,
-    RecipientUpdated, Stream, StreamCreated, StreamEndExtended, StreamEndShortened,
-    StreamHealthChanged, StreamPaused, StreamToppedUp, Withdrawal, WithdrawalTo,
+    ContractPauseChanged, CreateStreamParams, DataKey, FluxoraStream, FluxoraStreamClient,
+    PauseReason, RateUpdated, RecipientUpdated, Stream, StreamCreated, StreamEndExtended,
+    StreamEndShortened, StreamHealthChanged, StreamPaused, StreamToppedUp, Withdrawal,
+    WithdrawalTo,
 };
 use soroban_sdk::{
     testutils::{Address as _, Events, Ledger},
@@ -1419,7 +1420,6 @@ fn set_stream_deposit_in_storage(ctx: &EventTestContext, stream_id: u64, amount:
         ctx.env.storage().persistent().set(&key, &stream);
     });
 }
-
 
 /// No health event emitted when health status does not change (stays funded).
 /// StreamHealthChanged is only emitted by keeper_cancel in the current contract;

--- a/contracts/stream/tests/factory_policy.rs
+++ b/contracts/stream/tests/factory_policy.rs
@@ -1220,8 +1220,8 @@ fn test_policy_tightening_grandfathers_existing_streams() {
     );
 
     // ── 2. Tighten all policy dimensions ──────────────────────────────────
-    ctx.factory.set_cap(&2_000);              // lower cap: 10_000 → 2_000
-    ctx.factory.set_min_duration(&2_000);     // raise min_duration: 100 → 2_000
+    ctx.factory.set_cap(&2_000); // lower cap: 10_000 → 2_000
+    ctx.factory.set_min_duration(&2_000); // raise min_duration: 100 → 2_000
     ctx.factory.set_rate_bounds(&Some(1), &Some(5)); // restrict rate: unset → [1, 5]
 
     // confirm policy was persisted

--- a/contracts/stream/tests/gas_regression.rs
+++ b/contracts/stream/tests/gas_regression.rs
@@ -1,8 +1,8 @@
 // See docs/gas.md for the baseline update process and review bar.
 use fluxora_stream::{
-    CreateStreamParams, FluxoraStream, FluxoraStreamClient, StreamKind,
-    MAX_MEMO_BYTES, MAX_METADATA_BYTES, MAX_METADATA_KEY_BYTES,
-    MAX_METADATA_KEYS, MAX_METADATA_VALUE_BYTES, MAX_STREAM_ENTRY_BYTES,
+    CreateStreamParams, FluxoraStream, FluxoraStreamClient, StreamKind, MAX_MEMO_BYTES,
+    MAX_METADATA_BYTES, MAX_METADATA_KEYS, MAX_METADATA_KEY_BYTES, MAX_METADATA_VALUE_BYTES,
+    MAX_STREAM_ENTRY_BYTES,
 };
 use soroban_sdk::{
     testutils::{Address as _, Ledger},
@@ -301,10 +301,10 @@ fn test_keeper_cancel_gas_fully_accrued() {
 /// 8 keys × 32 bytes = 256 bytes of keys.
 /// Remaining budget: 512 − 256 = 256 bytes for 8 values → 32 bytes each.
 fn worst_case_metadata(env: &Env) -> Map<Bytes, Bytes> {
-    let key_len = MAX_METADATA_KEY_BYTES as usize;           // 32
-    let total_budget = MAX_METADATA_BYTES as usize;          // 512
+    let key_len = MAX_METADATA_KEY_BYTES as usize; // 32
+    let total_budget = MAX_METADATA_BYTES as usize; // 512
     let total_key_bytes = (MAX_METADATA_KEYS as usize) * key_len; // 256
-    let value_budget = total_budget - total_key_bytes;       // 256
+    let value_budget = total_budget - total_key_bytes; // 256
     let value_len = value_budget / (MAX_METADATA_KEYS as usize); // 32
 
     let mut meta: Map<Bytes, Bytes> = Map::new(env);

--- a/contracts/stream/tests/governance_integration.rs
+++ b/contracts/stream/tests/governance_integration.rs
@@ -65,7 +65,9 @@ impl<'a> GovCtx<'a> {
 
     fn propose_and_approve(&self, op: CallData) -> u32 {
         let calldata = op.to_xdr(&self.env);
-        let id = self.client.propose(&self.signer_a, &self.contract_id, &calldata);
+        let id = self
+            .client
+            .propose(&self.signer_a, &self.contract_id, &calldata);
         self.client.approve(&self.signer_a, &id);
         self.client.approve(&self.signer_b, &id);
         let now = self.env.ledger().timestamp();

--- a/contracts/stream/tests/keeper_cancel.rs
+++ b/contracts/stream/tests/keeper_cancel.rs
@@ -110,12 +110,7 @@ impl Ctx {
 
         StellarAssetClient::new(&env, &token_id).mint(&sender, &1_000_000_i128);
 
-        TokenClient::new(&env, &token_id).approve(
-            &sender,
-            &contract_id,
-            &i128::MAX,
-            &200_000u32,
-        );
+        TokenClient::new(&env, &token_id).approve(&sender, &contract_id, &i128::MAX, &200_000u32);
 
         env.ledger().set_timestamp(0);
 
@@ -157,8 +152,8 @@ fn make_stream(ctx: &Ctx, deposit: i128, rate: i128, end: u64) -> u64 {
         &ctx.recipient,
         &deposit,
         &rate,
-        &0u64,  // start
-        &0u64,  // cliff == start
+        &0u64, // start
+        &0u64, // cliff == start
         &end,
         &0_i128,
         &None,
@@ -206,7 +201,10 @@ fn test_keeper_cancel_fully_accrued_no_prior_withdrawals() {
     assert_eq!(ctx.balance(&ctx.recipient), 1_000);
     assert_eq!(ctx.balance(&ctx.sender), 1_000_000 - 1_000);
     assert_eq!(ctx.balance(&ctx.keeper), 0);
-    assert_eq!(ctx.client().get_stream_state(&sid).status, StreamStatus::Cancelled);
+    assert_eq!(
+        ctx.client().get_stream_state(&sid).status,
+        StreamStatus::Cancelled
+    );
 }
 
 /// Partially-accrued stream: keeper receives fee from unstreamed sender refund.
@@ -229,7 +227,10 @@ fn test_keeper_cancel_partial_accrual_fee_paid() {
     assert_eq!(ctx.balance(&ctx.recipient), accrued);
     assert_eq!(ctx.balance(&ctx.sender), 1_000_000 - 10_000 + sender_refund);
     assert_eq!(ctx.balance(&ctx.keeper), keeper_fee);
-    assert_eq!(ctx.client().get_stream_state(&sid).status, StreamStatus::Cancelled);
+    assert_eq!(
+        ctx.client().get_stream_state(&sid).status,
+        StreamStatus::Cancelled
+    );
 }
 
 /// Prior partial withdrawal: keeper distributes only the remaining outstanding balance.
@@ -266,7 +267,10 @@ fn test_keeper_cancel_paused_stream_succeeds() {
     ctx.env.ledger().set_timestamp(2_000 + GRACE + 1);
     ctx.client().keeper_cancel(&sid, &ctx.keeper);
 
-    assert_eq!(ctx.client().get_stream_state(&sid).status, StreamStatus::Cancelled);
+    assert_eq!(
+        ctx.client().get_stream_state(&sid).status,
+        StreamStatus::Cancelled
+    );
 }
 
 /// `cancelled_at` timestamp is set to the ledger time of the keeper call.
@@ -407,7 +411,10 @@ fn test_keeper_cancel_event_payload_partial_accrual() {
     assert_eq!(ev.keeper_fee, expected_fee);
     assert_eq!(ev.recipient_amount, accrued);
     assert_eq!(ev.sender_refund, expected_refund);
-    assert_eq!(ev.keeper_fee + ev.recipient_amount + ev.sender_refund, 10_000);
+    assert_eq!(
+        ev.keeper_fee + ev.recipient_amount + ev.sender_refund,
+        10_000
+    );
 }
 
 /// Fully-accrued stream: event has keeper_fee == 0 and sender_refund == 0.
@@ -422,7 +429,10 @@ fn test_keeper_cancel_event_payload_fully_accrued_zero_fee() {
     assert_eq!(ev.keeper_fee, 0);
     assert_eq!(ev.sender_refund, 0);
     assert_eq!(ev.recipient_amount, 1_000);
-    assert_eq!(ev.keeper_fee + ev.recipient_amount + ev.sender_refund, 1_000);
+    assert_eq!(
+        ev.keeper_fee + ev.recipient_amount + ev.sender_refund,
+        1_000
+    );
 }
 
 /// Event amounts match actual token balance deltas.
@@ -439,7 +449,10 @@ fn test_keeper_cancel_event_matches_actual_transfers() {
     ctx.client().keeper_cancel(&sid, &ctx.keeper);
     let ev = find_keeper_cancelled(&ctx);
 
-    assert_eq!(ctx.balance(&ctx.recipient) - recipient_b, ev.recipient_amount);
+    assert_eq!(
+        ctx.balance(&ctx.recipient) - recipient_b,
+        ev.recipient_amount
+    );
     assert_eq!(ctx.balance(&ctx.sender) - sender_b, ev.sender_refund);
     assert_eq!(ctx.balance(&ctx.keeper) - keeper_b, ev.keeper_fee);
 }
@@ -454,7 +467,10 @@ fn test_keeper_cancel_event_emitted_after_terminal_state() {
 
     let ev = find_keeper_cancelled(&ctx);
     assert_eq!(ev.stream_id, sid);
-    assert_eq!(ctx.client().get_stream_state(&sid).status, StreamStatus::Cancelled);
+    assert_eq!(
+        ctx.client().get_stream_state(&sid).status,
+        StreamStatus::Cancelled
+    );
 }
 
 /// Event reconciles to deposit − withdrawn when recipient had prior withdrawals.
@@ -492,9 +508,10 @@ fn test_keeper_cancel_event_reconciles_with_prior_withdrawal() {
 fn linear_keeper_params() -> impl Strategy<Value = (i128, i128, u64)> {
     (1u64..=1_000u64, 1i128..=100i128).prop_flat_map(|(end, rate)| {
         let min_deposit = rate.saturating_mul(end as i128).max(1);
-        let max_deposit = min_deposit.saturating_add(min_deposit / 2).max(min_deposit + 1);
-        (Just(rate), Just(end), min_deposit..=max_deposit)
-            .prop_map(|(r, e, d)| (d, r, e))
+        let max_deposit = min_deposit
+            .saturating_add(min_deposit / 2)
+            .max(min_deposit + 1);
+        (Just(rate), Just(end), min_deposit..=max_deposit).prop_map(|(r, e, d)| (d, r, e))
     })
 }
 

--- a/contracts/stream/tests/liability_invariant.rs
+++ b/contracts/stream/tests/liability_invariant.rs
@@ -502,12 +502,14 @@ fn decrease_rate_per_second_reduces_total_liabilities_by_refund_amount() {
     // remaining = 1000 - 100 = 900.
     // new_deposit = 200 + 1 * 900 = 1100.
     // refund = 3000 - 1100 = 1900.
-    ctx.client()
-        .decrease_rate_per_second(&stream_id, &1i128);
+    ctx.client().decrease_rate_per_second(&stream_id, &1i128);
 
     let sender_after = ctx.sender_balance();
     let actual_refund = sender_after - sender_before;
-    assert_eq!(actual_refund, 1_900, "refund must equal old_deposit - new_deposit");
+    assert_eq!(
+        actual_refund, 1_900,
+        "refund must equal old_deposit - new_deposit"
+    );
 
     let liabilities_after = ctx.client().get_total_liabilities();
     assert_eq!(

--- a/contracts/stream/tests/metadata_extension.rs
+++ b/contracts/stream/tests/metadata_extension.rs
@@ -816,9 +816,5 @@ fn test_two_streams_independent_metadata() {
 #[test]
 fn test_contract_version_is_9() {
     let ctx = Ctx::setup();
-    assert_eq!(
-        ctx.client().version(),
-        9,
-        "CONTRACT_VERSION must be 9"
-    );
+    assert_eq!(ctx.client().version(), 9, "CONTRACT_VERSION must be 9");
 }

--- a/contracts/stream/tests/recipient_paged_index.rs
+++ b/contracts/stream/tests/recipient_paged_index.rs
@@ -272,9 +272,9 @@ fn test_sender_portfolio_health_cursor_boundaries() {
     ctx.create_n(MAX_RECIPIENT_PAGE_SIZE + 5);
 
     // start-of-list cursor (0) returns without panicking
-    let first = ctx
-        .client
-        .get_sender_portfolio_health(&ctx.sender, &0u64, &MAX_RECIPIENT_PAGE_SIZE);
+    let first =
+        ctx.client
+            .get_sender_portfolio_health(&ctx.sender, &0u64, &MAX_RECIPIENT_PAGE_SIZE);
     // the page may be empty (sender owns none here) but must not error
     let _ = first.stream_ids;
 
@@ -282,9 +282,9 @@ fn test_sender_portfolio_health_cursor_boundaries() {
     let mut cursor = first.next_cursor;
     let mut guard = 0u32;
     while cursor != 0u64 && guard < 20 {
-        let page = ctx
-            .client
-            .get_sender_portfolio_health(&ctx.sender, &cursor, &MAX_RECIPIENT_PAGE_SIZE);
+        let page =
+            ctx.client
+                .get_sender_portfolio_health(&ctx.sender, &cursor, &MAX_RECIPIENT_PAGE_SIZE);
         cursor = page.next_cursor;
         guard += 1;
     }

--- a/contracts/stream/tests/storage_key_compat.rs
+++ b/contracts/stream/tests/storage_key_compat.rs
@@ -896,10 +896,7 @@ fn v7_total_keeper_fees_paid_absent_on_v5_instance() {
     let env = Env::default();
     let contract_id = env.register_contract(None, FluxoraStream);
     env.as_contract(&contract_id, || {
-        let present = env
-            .storage()
-            .instance()
-            .has(&DataKey::TotalKeeperFeesPaid);
+        let present = env.storage().instance().has(&DataKey::TotalKeeperFeesPaid);
         assert!(
             !present,
             "TotalKeeperFeesPaid must be absent on a V5-seeded instance"
@@ -1246,10 +1243,10 @@ fn discriminant_35_pooled_stream_withdrawn_round_trips() {
     let addr = Address::generate(&ctx.env);
     let cid = ctx.contract_id.clone();
     ctx.env.as_contract(&cid, || {
-        ctx.env
-            .storage()
-            .persistent()
-            .set(&DataKey::PooledStreamWithdrawn(3u64, addr.clone()), &500_i128);
+        ctx.env.storage().persistent().set(
+            &DataKey::PooledStreamWithdrawn(3u64, addr.clone()),
+            &500_i128,
+        );
         let val: i128 = ctx
             .env
             .storage()
@@ -1335,8 +1332,15 @@ fn v7_paused_stream_count_absent_on_v5_instance() {
     let ctx = Ctx::setup();
     let cid = ctx.contract_id.clone();
     ctx.env.as_contract(&cid, || {
-        let present = ctx.env.storage().instance().has(&DataKey::PausedStreamCount);
-        assert!(!present, "PausedStreamCount must be absent on a V5 instance");
+        let present = ctx
+            .env
+            .storage()
+            .instance()
+            .has(&DataKey::PausedStreamCount);
+        assert!(
+            !present,
+            "PausedStreamCount must be absent on a V5 instance"
+        );
     });
 }
 
@@ -1351,7 +1355,10 @@ fn v7_total_keeper_fees_paid_absent_on_v5_instance() {
             .storage()
             .instance()
             .has(&DataKey::TotalKeeperFeesPaid);
-        assert!(!present, "TotalKeeperFeesPaid must be absent on a V5 instance");
+        assert!(
+            !present,
+            "TotalKeeperFeesPaid must be absent on a V5 instance"
+        );
     });
 }
 
@@ -1443,42 +1450,42 @@ pub fn all_live_datakey_variants(env: &Env) -> soroban_sdk::Vec<DataKey> {
 
     let variants = vec![
         env,
-        DataKey::Config,                                              // 0
-        DataKey::NextStreamId,                                        // 1
-        DataKey::Stream(0),                                           // 2
-        DataKey::RecipientStreams(dummy_addr.clone()),                 // 3
-        DataKey::GlobalEmergencyPaused,                               // 4
-        DataKey::CreationPaused,                                      // 5
-        DataKey::GlobalPauseReason,                                   // 6
-        DataKey::GlobalPauseTimestamp,                                // 7
-        DataKey::GlobalPauseAdmin,                                    // 8
-        DataKey::AutoClaimDestination(0),                             // 9
-        DataKey::NextTemplateId,                                      // 10
-        DataKey::ActiveTemplateCount,                                 // 11
-        DataKey::StreamTemplate(0),                                   // 12
-        DataKey::OwnerTemplateIds(dummy_addr.clone()),                // 13
-        DataKey::TotalLiabilities,                                    // 14
-        DataKey::WithdrawNonce(dummy_addr.clone()),                   // 15
-        DataKey::PauseState,                                          // 16
-        DataKey::ReentrancyLock,                                      // 17
-        DataKey::RecipientStreamPage(dummy_addr.clone(), 0),          // 18
-        DataKey::RecipientStreamPageCount(dummy_addr.clone()),        // 19
-        DataKey::PendingRecipientUpdate(0),                           // 20
-        DataKey::IdReservation(dummy_addr.clone()),                   // 21
-        DataKey::MaxRatePerSecond,                                    // 22
-        DataKey::DelegatedWithdrawNonce(dummy_addr.clone()),          // 23
-        DataKey::LastPauseRecord(dummy_pause_kind),                   // 24
-        DataKey::RotationHistory(0),                                  // 25
-        DataKey::LastAccrualLedgerTimestamp,                          // 26
-        DataKey::PausedStreamCount,                                   // 27
-        DataKey::TotalKeeperFeesPaid,                                 // 28
-        DataKey::AutoRenewEnabled(0),                                 // 29
-        DataKey::MaxLookbackLedgers(0),                               // 30
-        DataKey::SenderStreams(dummy_addr.clone()),                   // 31
-        DataKey::PendingStreamOffer(0),                               // 32
-        DataKey::RecipientPendingOffers(dummy_addr.clone()),          // 33
-        DataKey::PooledStreamShares(0),                               // 34
-        DataKey::PooledStreamWithdrawn(0, dummy_addr.clone()),        // 35
+        DataKey::Config,                                       // 0
+        DataKey::NextStreamId,                                 // 1
+        DataKey::Stream(0),                                    // 2
+        DataKey::RecipientStreams(dummy_addr.clone()),         // 3
+        DataKey::GlobalEmergencyPaused,                        // 4
+        DataKey::CreationPaused,                               // 5
+        DataKey::GlobalPauseReason,                            // 6
+        DataKey::GlobalPauseTimestamp,                         // 7
+        DataKey::GlobalPauseAdmin,                             // 8
+        DataKey::AutoClaimDestination(0),                      // 9
+        DataKey::NextTemplateId,                               // 10
+        DataKey::ActiveTemplateCount,                          // 11
+        DataKey::StreamTemplate(0),                            // 12
+        DataKey::OwnerTemplateIds(dummy_addr.clone()),         // 13
+        DataKey::TotalLiabilities,                             // 14
+        DataKey::WithdrawNonce(dummy_addr.clone()),            // 15
+        DataKey::PauseState,                                   // 16
+        DataKey::ReentrancyLock,                               // 17
+        DataKey::RecipientStreamPage(dummy_addr.clone(), 0),   // 18
+        DataKey::RecipientStreamPageCount(dummy_addr.clone()), // 19
+        DataKey::PendingRecipientUpdate(0),                    // 20
+        DataKey::IdReservation(dummy_addr.clone()),            // 21
+        DataKey::MaxRatePerSecond,                             // 22
+        DataKey::DelegatedWithdrawNonce(dummy_addr.clone()),   // 23
+        DataKey::LastPauseRecord(dummy_pause_kind),            // 24
+        DataKey::RotationHistory(0),                           // 25
+        DataKey::LastAccrualLedgerTimestamp,                   // 26
+        DataKey::PausedStreamCount,                            // 27
+        DataKey::TotalKeeperFeesPaid,                          // 28
+        DataKey::AutoRenewEnabled(0),                          // 29
+        DataKey::MaxLookbackLedgers(0),                        // 30
+        DataKey::SenderStreams(dummy_addr.clone()),            // 31
+        DataKey::PendingStreamOffer(0),                        // 32
+        DataKey::RecipientPendingOffers(dummy_addr.clone()),   // 33
+        DataKey::PooledStreamShares(0),                        // 34
+        DataKey::PooledStreamWithdrawn(0, dummy_addr.clone()), // 35
     ];
 
     // Exhaustive match check — compile error if any DataKey variant is missing here.
@@ -1550,9 +1557,7 @@ fn test_contract_version_matches_datakey_variant_count() {
          3. Prose tables & variant count tests in contracts/stream/src/checksum.rs \
          4. Version history & policy in docs/upgrade.md \
          5. CONTRACT_VERSION in contracts/stream/src/lib.rs if required by versioning policy.",
-        CONTRACT_VERSION,
-        expected_count,
-        live_count
+        CONTRACT_VERSION, expected_count, live_count
     );
 }
 

--- a/contracts/stream/tests/withdrawal_frequency.rs
+++ b/contracts/stream/tests/withdrawal_frequency.rs
@@ -33,13 +33,25 @@ mod mock_token {
         pub fn mint(env: Env, _to: Address, _amount: i128) {
             env.storage().instance().extend_ttl(100_000, 100_000);
         }
-        pub fn approve(env: Env, _from: Address, _spender: Address, _amount: i128, _expiration_ledger: u32) {
+        pub fn approve(
+            env: Env,
+            _from: Address,
+            _spender: Address,
+            _amount: i128,
+            _expiration_ledger: u32,
+        ) {
             env.storage().instance().extend_ttl(100_000, 100_000);
         }
         pub fn transfer(env: Env, _from: Address, _to: Address, _amount: i128) {
             env.storage().instance().extend_ttl(100_000, 100_000);
         }
-        pub fn transfer_from(env: Env, _spender: Address, _from: Address, _to: Address, _amount: i128) {
+        pub fn transfer_from(
+            env: Env,
+            _spender: Address,
+            _from: Address,
+            _to: Address,
+            _amount: i128,
+        ) {
             env.storage().instance().extend_ttl(100_000, 100_000);
         }
         pub fn balance(env: Env, _id: Address) -> i128 {
@@ -637,7 +649,10 @@ fn zero_withdrawable_does_not_consume_the_interval() {
     ctx.advance_ledger(10); // 50 accrued, below the dust threshold.
 
     assert_eq!(ctx.client.withdraw(&stream_id), 0);
-    assert_eq!(ctx.client.get_stream_state(&stream_id).last_withdraw_ledger, 0);
+    assert_eq!(
+        ctx.client.get_stream_state(&stream_id).last_withdraw_ledger,
+        0
+    );
 
     ctx.advance_ledger(10); // 100 accrued, exactly at the threshold.
     assert_eq!(ctx.client.withdraw(&stream_id), 100);
@@ -663,7 +678,8 @@ fn batch_withdraw_shares_the_per_stream_interval() {
 
     ctx.client.batch_withdraw_to(&ctx.recipient, &withdrawals);
     assert_eq!(
-        ctx.client.try_batch_withdraw_to(&ctx.recipient, &withdrawals),
+        ctx.client
+            .try_batch_withdraw_to(&ctx.recipient, &withdrawals),
         Err(Ok(ContractError::WithdrawalTooFrequent))
     );
 
@@ -714,15 +730,11 @@ fn delegated_withdrawal_obeys_the_same_ledger_limit() {
         &signing_key,
         &delegated_message(&ctx.env, stream_id, 0, deadline, 0),
     );
-    assert!(ctx.client.delegated_withdraw(
-        &stream_id,
-        &relayer,
-        &public_key,
-        &0,
-        &deadline,
-        &0,
-        &first,
-    ) > 0);
+    assert!(
+        ctx.client
+            .delegated_withdraw(&stream_id, &relayer, &public_key, &0, &deadline, &0, &first,)
+            > 0
+    );
 
     let second = sign_message(
         &ctx.env,
@@ -731,7 +743,13 @@ fn delegated_withdrawal_obeys_the_same_ledger_limit() {
     );
     assert_eq!(
         ctx.client.try_delegated_withdraw(
-            &stream_id, &relayer, &public_key, &1, &deadline, &0, &second,
+            &stream_id,
+            &relayer,
+            &public_key,
+            &1,
+            &deadline,
+            &0,
+            &second,
         ),
         Err(Ok(ContractError::WithdrawalTooFrequent))
     );
@@ -995,7 +1013,7 @@ fn lookback_cliff_only_full_claim_after_cliff() {
 
     // Advance past cliff, and well past the lookback window.
     ctx.advance_ledger(60); // t=550, then 60 more... = 850
-    // Claimable = full deposit because CliffOnly entitlement bypasses cap.
+                            // Claimable = full deposit because CliffOnly entitlement bypasses cap.
     assert_eq!(
         ctx.client.get_withdrawable(&stream_id).unwrap(),
         1000,

--- a/docs/factory.md
+++ b/docs/factory.md
@@ -128,6 +128,8 @@ The factory enforces an early memo length guard (Guard 8) on both `create_stream
 
 This guard directly references the shared constant `fluxora_stream::MAX_MEMO_BYTES` at compile time, guaranteeing that any update to the stream contract's maximum memo length is automatically reflected in factory validation without risk of version drift or stale limits. Oversized memos are rejected on the factory error surface before initiating cross-contract calls or side-effects.
 
+Regression coverage for this behavior lives in `contracts/factory/tests/factory_stream_e2e.rs`: the suite now asserts that the factory memo guard tracks the shared `fluxora_stream::MAX_MEMO_BYTES` constant and that a memo one byte over the limit is rejected as `FactoryError::InvalidMemo` before the cross-contract call is made. This protects the factory from silently drifting away from the stream contract's own memo limit if the shared constant is ever changed.
+
 For `CliffOnly` streams the `rate_per_second` argument is ignored — the stream
 contract sets the effective rate to `0` internally.
 

--- a/script/validate-doc-alignment.py
+++ b/script/validate-doc-alignment.py
@@ -359,7 +359,7 @@ def validate(
             except ValueError:
                 display = audit_doc
             print(
-                f"STALE DOC: '{ident}' (audit entrypoint) listed in '{display}' "
+                f"STALE AUDIT DOC: '{ident}' (audit entrypoint) listed in '{display}' "
                 "but not in contractimpl"
             )
             drift_found = True

--- a/script/verify_rust_version.py
+++ b/script/verify_rust_version.py
@@ -183,6 +183,19 @@ def installed_components() -> list[str]:
     return [c.strip() for c in completed.stdout.splitlines() if c.strip()]
 
 
+def has_component(installed: list[str], required: str) -> bool:
+    """Return true when a required rustup component is installed.
+
+    `rustup component list --installed` commonly prints host-qualified names
+    such as `rustfmt-x86_64-unknown-linux-gnu`, while rust-toolchain.toml uses
+    bare component names like `rustfmt`. Accept either representation.
+    """
+    return any(
+        component == required or component.startswith(f"{required}-")
+        for component in installed
+    )
+
+
 def parse_rustc_version(version_output: str) -> str:
     match = re.match(r"^rustc\s+([^\s]+)", version_output.strip())
     if not match:
@@ -238,7 +251,9 @@ def main() -> int:
     required_components = pinned_components()
     if required_components:
         have_components = installed_components()
-        missing_components = [c for c in required_components if c not in have_components]
+        missing_components = [
+            c for c in required_components if not has_component(have_components, c)
+        ]
         if missing_components:
             print(
                 f"::error::Missing required components: {', '.join(missing_components)}",

--- a/tests/test_rust_toolchain_pin.py
+++ b/tests/test_rust_toolchain_pin.py
@@ -161,13 +161,22 @@ def test_main_fails_when_rustc_version_output_is_unparseable(monkeypatch, capsys
     assert "::error::" in captured.err
 
 
-def test_rustc_version_falls_back_to_invoking_real_rustc(monkeypatch):
+def test_rustc_version_falls_back_to_invoking_rustc(monkeypatch):
     # No RUSTC_VERSION_OUTPUT override: exercises the `subprocess.run(["rustc",
-    # "--version"])` fallback path. Requires a real `rustc` on PATH, which is
-    # guaranteed true here since this whole workspace is a Rust CI target.
+    # "--version"])` fallback path without requiring Rust in docs-only CI jobs.
+    class Completed:
+        stdout = "rustc 1.94.1 (abcdef 2026-01-01)"
+
+    def fake_run(args, check, capture_output, text):
+        assert args == ["rustc", "--version"]
+        assert check is True
+        assert capture_output is True
+        assert text is True
+        return Completed()
+
     monkeypatch.delenv("RUSTC_VERSION_OUTPUT", raising=False)
-    version = verify_rust_version.rustc_version()
-    assert version
+    monkeypatch.setattr(verify_rust_version.subprocess, "run", fake_run)
+    assert verify_rust_version.rustc_version() == "1.94.1"
 
 
 def test_pinned_targets_returns_list():

--- a/tests/test_rust_toolchain_pin.py
+++ b/tests/test_rust_toolchain_pin.py
@@ -184,6 +184,20 @@ def test_pinned_components_returns_list():
     assert "clippy" in components
     assert "rustfmt" in components
 
+
+def test_has_component_accepts_host_qualified_component_names():
+    installed = [
+        "rustfmt-x86_64-unknown-linux-gnu",
+        "clippy-x86_64-unknown-linux-gnu",
+    ]
+    assert verify_rust_version.has_component(installed, "rustfmt")
+    assert verify_rust_version.has_component(installed, "clippy")
+
+
+def test_has_component_rejects_absent_component():
+    installed = ["rustfmt-x86_64-unknown-linux-gnu"]
+    assert not verify_rust_version.has_component(installed, "clippy")
+
 def test_main_fails_in_process_when_missing_targets(monkeypatch, capsys):
     """Test that main() fails when required targets are missing."""
     monkeypatch.setenv("RUSTC_VERSION_OUTPUT", "rustc 1.94.1 (abcdef 2026-01-01)")


### PR DESCRIPTION
## Summary

Closes #1228

This PR adds regression tests to ensure the factory's memo-length validation remains synchronized with `fluxora_stream::MAX_MEMO_BYTES` and correctly rejects oversized memos before initiating the cross-contract call.

## Changes

* Added a regression test verifying the factory memo-length guard is driven by `fluxora_stream::MAX_MEMO_BYTES` rather than a duplicated or stale value.
* Added an integration test in `contracts/factory/tests/factory_stream_e2e.rs` to verify that a memo exceeding the allowed length by one byte is rejected by the factory with `FactoryError::InvalidMemo`.
* Verified that validation occurs before any cross-contract call is made, distinguishing the factory validation path from the stream contract's independent validation.
* Added documentation in `docs/factory.md` describing the shared constant dependency and regression coverage.
* Added doc comments where appropriate to document the security rationale behind the validation.

## Testing

```bash
cargo test -p fluxora_factory
```

### Test Coverage

* Valid memo at the maximum allowed length is accepted.
* Memo exceeding `fluxora_stream::MAX_MEMO_BYTES` by one byte is rejected by the factory.
* Factory validation occurs before any cross-contract invocation.
* Regression protection ensures the factory guard remains synchronized with the shared `fluxora_stream::MAX_MEMO_BYTES` constant.

## Security Notes

* Prevents accidental divergence between the factory and stream contract memo-length validation.
* Ensures oversized memos are rejected at the factory boundary before any downstream contract interaction.
* Adds regression coverage to detect future changes to `MAX_MEMO_BYTES` that are not reflected in the factory validation logic.
