### PR TITLE
test(factory): extend fuzz coverage for admin setters and pagination

### DIFF
--- a/contracts/factory/tests/FUZZ_GAP_ANALYSIS.md
+++ b/contracts/factory/tests/FUZZ_GAP_ANALYSIS.md
@@ -1,0 +1,107 @@
+# Fuzz Coverage Gap Analysis for FluxoraFactory
+
+## Issue #891: Add fuzz coverage for contracts/factory/tests/factory_fuzz.rs
+
+### Current Coverage (Original factory_fuzz.rs)
+
+The original `factory_fuzz.rs` contains a single proptest that fuzzes:
+- `create_stream` with randomized:
+  - `cap` (i128: 100..1_000_000)
+  - `min_duration` (u64: 10..3600)
+  - `deposit_amount` (i128: 1..2_000_000)
+  - `duration` (u64: 1..7200)
+  - `is_allowlisted` (bool)
+
+Properties verified:
+1. RecipientNotAllowlisted iff !is_allowlisted
+2. DepositExceedsCap iff deposit_amount > cap
+3. InvalidTimeRange iff start_time >= end_time
+4. DurationTooShort iff duration < min_duration
+5. No valid input is wrongly rejected
+
+### Gap Analysis: Uncovered Public Entry Points
+
+The following public functions in `factory/src/lib.rs` were **not** fuzzed:
+
+#### Admin Setters (Numeric/Address Inputs)
+
+1. **`init`**
+   - Inputs: `max_deposit` (i128), `min_duration` (u64)
+   - Validation: `max_deposit > 0`, `min_duration <= MAX_MIN_DURATION_SECONDS`
+   - Risk: integer overflow/underflow, boundary conditions
+
+2. **`set_cap`**
+   - Input: `max_deposit` (i128)
+   - Validation: `max_deposit > 0`
+   - Risk: negative values, zero, overflow
+
+3. **`set_min_duration`**
+   - Input: `min_duration` (u64)
+   - Validation: `min_duration <= MAX_MIN_DURATION_SECONDS`
+   - Risk: exceeding max constant, boundary at MAX_MIN_DURATION_SECONDS
+
+4. **`set_rate_bounds`**
+   - Inputs: `min_rate` (Option<i128>), `max_rate` (Option<i128>)
+   - Validation: non-negative values, min <= max when both set
+   - Risk: negative rates, inverted bounds, None handling
+
+5. **`set_factory_paused`**
+   - Input: `paused` (bool)
+   - Validation: none (simple toggle)
+   - Risk: low, but state persistence should be verified
+
+#### View Functions (Numeric Inputs)
+
+6. **`get_factory_streams_paginated`**
+   - Inputs: `start_index` (u32), `limit` (u32)
+   - Validation: none (should handle extreme values gracefully)
+   - Risk: out-of-bounds access, integer overflow in pagination logic
+
+### Extended Fuzz Harness (factory_fuzz_extended.rs)
+
+Added 6 new proptest properties covering all gaps:
+
+1. **`prop_init_cap_validation`**
+   - Fuzzes `max_deposit` across full i128 range
+   - Fuzzes `min_duration` beyond MAX_MIN_DURATION_SECONDS
+   - Verifies: InvalidCap iff max_deposit <= 0
+   - Verifies: InvalidMinDuration iff min_duration > MAX_MIN_DURATION_SECONDS
+
+2. **`prop_set_cap_validation`**
+   - Fuzzes `new_cap` across full i128 range
+   - Verifies: InvalidCap iff new_cap <= 0
+
+3. **`prop_set_min_duration_validation`**
+   - Fuzzes `new_min_duration` beyond MAX_MIN_DURATION_SECONDS
+   - Verifies: InvalidMinDuration iff new_min_duration > MAX_MIN_DURATION_SECONDS
+
+4. **`prop_set_rate_bounds_validation`**
+   - Fuzzes `min_rate` and `max_rate` as Option<i128>
+   - Verifies: InvalidRateBounds iff min < 0 OR max < 0 OR (both set and min > max)
+
+5. **`prop_set_factory_paused_toggle`**
+   - Fuzzes `paused` as bool
+   - Verifies: state persistence matches input
+
+6. **`prop_paginated_boundary_conditions`**
+   - Fuzzes `start_index` (0..1000) and `limit` (0..200)
+   - Verifies: no panic on extreme values
+
+### Prioritization Rationale
+
+Prioritized functions with:
+- **Numeric inputs** (i128, u64, u32) — higher risk of overflow/underflow
+- **Validation logic** — complex error paths
+- **Boundary conditions** — edge cases at min/max values
+
+De-prioritized:
+- Address-shaped inputs (already validated by Soroban SDK)
+- State-machine flows (covered by existing unit tests)
+- Allowlist operations (simple boolean logic)
+
+### Execution Plan
+
+1. Run each property test with default proptest config (256 cases per property)
+2. Monitor for panics, assertion failures, or unexpected errors
+3. Report any crashes with minimal reproduction case
+4. Do NOT silently patch — report clearly with stack trace

--- a/contracts/factory/tests/factory_fuzz_extended.rs
+++ b/contracts/factory/tests/factory_fuzz_extended.rs
@@ -1,0 +1,204 @@
+//! Extended fuzz coverage for FluxoraFactory entry points.
+//!
+//! Gap analysis: The original `factory_fuzz.rs` only fuzzes `create_stream`.
+//! This harness adds coverage for admin setter functions that take numeric
+//! and address-shaped inputs:
+//!   - `init` — validates max_deposit (i128), min_duration (u64)
+//!   - `set_cap` — validates max_deposit (i128)
+//!   - `set_min_duration` — validates min_duration (u64)
+//!   - `set_rate_bounds` — validates min_rate/max_rate (Option<i128>)
+//!   - `set_factory_paused` — validates bool
+//!   - `get_factory_streams_paginated` — validates start_index/limit (u32)
+//!
+//! Priority: numeric overflow, underflow, boundary conditions.
+
+use fluxora_factory::{FactoryError, FluxoraFactory, FluxoraFactoryClient, MAX_MIN_DURATION_SECONDS};
+use fluxora_stream::{FluxoraStream, FluxoraStreamClient};
+use proptest::prelude::*;
+use soroban_sdk::{
+    testutils::Address as _,
+    token::{Client as TokenClient, StellarAssetClient},
+    Address, Env,
+};
+
+/// Setup a fresh factory environment for fuzzing.
+fn setup_factory() -> (Env, FluxoraFactoryClient<'static>, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let stream_cid = env.register_contract(None, FluxoraStream);
+    let stream_client = FluxoraStreamClient::new(&env, &stream_cid);
+
+    let factory_cid = env.register_contract(None, FluxoraFactory);
+    let factory = FluxoraFactoryClient::new(&env, &factory_cid);
+
+    let token_admin = Address::generate(&env);
+    let token_id = env
+        .register_stellar_asset_contract_v2(token_admin)
+        .address();
+    let token = TokenClient::new(&env, &token_id);
+    let stellar_asset = StellarAssetClient::new(&env, &token_id);
+
+    let admin = Address::generate(&env);
+    let sender = Address::generate(&env);
+
+    stellar_asset.mint(&sender, &1_000_000_000_i128);
+    stream_client.init(&token_id, &admin);
+    token.approve(&sender, &stream_cid, &i128::MAX, &100_000);
+
+    // Initialize factory with reasonable defaults
+    factory.init(&admin, &stream_cid, &1_000_000_i128, &60_u64);
+
+    (env, factory, admin)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Fuzz target: init validation
+// ─────────────────────────────────────────────────────────────────────────────
+
+proptest! {
+    #[test]
+    fn prop_init_cap_validation(
+        max_deposit in i128::MIN..i128::MAX,
+        min_duration in 0u64..(MAX_MIN_DURATION_SECONDS + 1000),
+    ) {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let stream_cid = env.register_contract(None, FluxoraStream);
+        let stream_client = FluxoraStreamClient::new(&env, &stream_cid);
+
+        let factory_cid = env.register_contract(None, FluxoraFactory);
+        let factory = FluxoraFactoryClient::new(&env, &factory_cid);
+
+        let token_admin = Address::generate(&env);
+        let token_id = env
+            .register_stellar_asset_contract_v2(token_admin)
+            .address();
+
+        let admin = Address::generate(&env);
+        stream_client.init(&token_id, &admin);
+
+        let result = factory.try_init(&admin, &stream_cid, &max_deposit, &min_duration);
+
+        // Property: InvalidCap iff max_deposit <= 0
+        if max_deposit <= 0 {
+            assert_eq!(result, Err(Ok(FactoryError::InvalidCap)));
+        } else if min_duration > MAX_MIN_DURATION_SECONDS {
+            // Property: InvalidMinDuration iff min_duration > MAX_MIN_DURATION_SECONDS
+            assert_eq!(result, Err(Ok(FactoryError::InvalidMinDuration)));
+        } else {
+            // Valid config should succeed
+            assert!(result.is_ok(), "Valid init was rejected: {:?}", result);
+        }
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Fuzz target: set_cap validation
+// ─────────────────────────────────────────────────────────────────────────────
+
+proptest! {
+    #[test]
+    fn prop_set_cap_validation(new_cap in i128::MIN..i128::MAX) {
+        let (_env, factory, _admin) = setup_factory();
+
+        let result = factory.try_set_cap(&new_cap);
+
+        // Property: InvalidCap iff new_cap <= 0
+        if new_cap <= 0 {
+            assert_eq!(result, Err(Ok(FactoryError::InvalidCap)));
+        } else {
+            assert!(result.is_ok(), "Valid cap was rejected: {:?}", result);
+        }
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Fuzz target: set_min_duration validation
+// ─────────────────────────────────────────────────────────────────────────────
+
+proptest! {
+    #[test]
+    fn prop_set_min_duration_validation(new_min_duration in 0u64..(MAX_MIN_DURATION_SECONDS + 10000)) {
+        let (_env, factory, _admin) = setup_factory();
+
+        let result = factory.try_set_min_duration(&new_min_duration);
+
+        // Property: InvalidMinDuration iff new_min_duration > MAX_MIN_DURATION_SECONDS
+        if new_min_duration > MAX_MIN_DURATION_SECONDS {
+            assert_eq!(result, Err(Ok(FactoryError::InvalidMinDuration)));
+        } else {
+            assert!(result.is_ok(), "Valid min_duration was rejected: {:?}", result);
+        }
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Fuzz target: set_rate_bounds validation
+// ─────────────────────────────────────────────────────────────────────────────
+
+proptest! {
+    #[test]
+    fn prop_set_rate_bounds_validation(
+        min_rate_opt in proptest::option::of(i128::MIN..i128::MAX),
+        max_rate_opt in proptest::option::of(i128::MIN..i128::MAX),
+    ) {
+        let (_env, factory, _admin) = setup_factory();
+
+        let result = factory.try_set_rate_bounds(&min_rate_opt, &max_rate_opt);
+
+        // Property: InvalidRateBounds iff:
+        //   - min_rate < 0, OR
+        //   - max_rate < 0, OR
+        //   - both set and min_rate > max_rate
+        let expect_invalid = match (min_rate_opt, max_rate_opt) {
+            (Some(min), _) if min < 0 => true,
+            (_, Some(max)) if max < 0 => true,
+            (Some(min), Some(max)) if min > max => true,
+            _ => false,
+        };
+
+        if expect_invalid {
+            assert_eq!(result, Err(Ok(FactoryError::InvalidRateBounds)));
+        } else {
+            assert!(result.is_ok(), "Valid rate bounds were rejected: {:?}", result);
+        }
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Fuzz target: set_factory_paused (bool toggle)
+// ─────────────────────────────────────────────────────────────────────────────
+
+proptest! {
+    #[test]
+    fn prop_set_factory_paused_toggle(paused in proptest::bool::ANY) {
+        let (_env, factory, _admin) = setup_factory();
+
+        let result = factory.try_set_factory_paused(&paused);
+        assert!(result.is_ok(), "set_factory_paused failed: {:?}", result);
+
+        // Verify state matches
+        let actual_paused = factory.is_factory_paused();
+        assert_eq!(actual_paused, paused, "Pause state mismatch");
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Fuzz target: get_factory_streams_paginated boundary conditions
+// ─────────────────────────────────────────────────────────────────────────────
+
+proptest! {
+    #[test]
+    fn prop_paginated_boundary_conditions(
+        start_index in 0u32..1000u32,
+        limit in 0u32..200u32,
+    ) {
+        let (_env, factory, _admin) = setup_factory();
+
+        // This should never panic, even with extreme values
+        let _result = factory.get_factory_streams_paginated(&start_index, &limit);
+        // No assertion on content — just verify it doesn't panic
+    }
+}


### PR DESCRIPTION
Closes #891

## Summary

Extended fuzz coverage for FluxoraFactory to cover admin setter functions and pagination that were not fuzzed by the original factory_fuzz.rs.

## Gap Analysis

Original factory_fuzz.rs only fuzzes create_stream. Uncovered public entry points:

**Admin Setters (numeric inputs):**
- init — validates max_deposit (i128), min_duration (u64)
- set_cap — validates max_deposit (i128)
- set_min_duration — validates min_duration (u64)
- set_rate_bounds — validates min_rate/max_rate (Option<i128>)
- set_factory_paused — validates bool toggle

**View Functions:**
- get_factory_streams_paginated — validates start_index/limit (u32)

## Changes

6 new proptest properties in factory_fuzz_extended.rs:
1. prop_init_cap_validation — fuzz max_deposit across full i128 range
2. prop_set_cap_validation — fuzz set_cap with full i128 range
3. prop_set_min_duration_validation — fuzz beyond MAX_MIN_DURATION_SECONDS
4. prop_set_rate_bounds_validation — fuzz negative/inverted rate bounds
5. prop_set_factory_paused_toggle — verify state persistence
6. prop_paginated_boundary_conditions — verify no panic on extreme values

Includes FUZZ_GAP_ANALYSIS.md with prioritization rationale.

## Note

Pre-existing compilation errors in upstream stream/src/lib.rs (duplicate MAX_POOL_RECIPIENTS definitions) prevent local fuzz execution. Should be fixed upstream first.

## Acceptance Criteria
- [x] Gap analysis documents previously uncovered entry points
- [x] Harness extended to cover gaps
- [ ] Bounded local fuzz run (blocked by upstream compilation error)