### PR TITLE
docs(stream): document metadata extension behavior (Closes #1294)

### DIFF
--- a/contracts/stream/src/storage.rs
+++ b/contracts/stream/src/storage.rs
@@ -710,19 +710,25 @@ pub(crate) fn push_token(env: &Env, to: &Address, amount: i128) -> Result<(), Co
 // Metadata validation (issue #580)
 // ---------------------------------------------------------------------------
 
-/// Validate an optional per-stream metadata map against all size bounds.
+/// Validate a per-stream metadata map against all size bounds.
 ///
-/// Called from `persist_new_stream` / `persist_new_stream_skip_index` before any
-/// state is written, so a violation never allocates a stream ID.
+/// Called from stream creation paths (`persist_new_stream`, offer creation, etc.)
+/// **before** any stream ID is allocated or tokens are transferred. A violation
+/// therefore never leaves partial state.
 ///
-/// # Invariants checked
-/// - `metadata.len() <= MAX_METADATA_KEYS`
-/// - each key length <= `MAX_METADATA_KEY_BYTES`
-/// - each value length <= `MAX_METADATA_VALUE_BYTES`
-/// - aggregate (sum of all key lengths + all value lengths) <= `MAX_METADATA_BYTES`
+/// # Validation order
+/// 1. Key count `<= MAX_METADATA_KEYS` (8)
+/// 2. Per entry: key length `<= MAX_METADATA_KEY_BYTES` (32)
+/// 3. Per entry: value length `<= MAX_METADATA_VALUE_BYTES` (128)
+/// 4. Running sum of all key + value bytes `<= MAX_METADATA_BYTES` (512)
+///
+/// # Immutability
+/// Metadata validated here is stored on the `Stream` struct and is never modified
+/// by subsequent operations. See [`docs/metadata-extension.md`](../../../docs/metadata-extension.md)
+/// for the full operation compatibility matrix.
 ///
 /// # Errors
-/// Returns `ContractError::MetadataTooLarge` on any bound violation.
+/// Returns [`ContractError::MetadataTooLarge`] on any bound violation.
 pub(crate) fn validate_metadata(
     metadata: &Map<soroban_sdk::Bytes, soroban_sdk::Bytes>,
 ) -> Result<(), ContractError> {

--- a/contracts/stream/tests/metadata_extension.rs
+++ b/contracts/stream/tests/metadata_extension.rs
@@ -1,5 +1,4 @@
 extern crate std;
-extern crate std;
 
 // Comprehensive tests for per-stream metadata TLV extension (issue #580).
 //
@@ -88,7 +87,7 @@ extern crate std;
 
 use fluxora_stream::{
     ContractError, CreateStreamParams, CreateStreamRelativeParams, FluxoraStream,
-    FluxoraStreamClient, StreamKind, MAX_METADATA_BYTES, MAX_METADATA_KEYS,
+    FluxoraStreamClient, StreamKind, StreamStatus, MAX_METADATA_BYTES, MAX_METADATA_KEYS,
     MAX_METADATA_KEY_BYTES, MAX_METADATA_VALUE_BYTES, MAX_STREAM_ENTRY_BYTES,
 };
 use soroban_sdk::{
@@ -785,8 +784,11 @@ fn test_metadata_unchanged_after_pause_resume() {
     meta.set(ctx.make_key("ref"), ctx.make_val("PAUSE_TEST"));
     let stream_id = ctx.create_stream_with_metadata(Some(meta.clone()));
 
+    // First pause requires ledger sequence >= MIN_PAUSE_INTERVAL when counter is 0.
+    ctx.env.ledger().with_mut(|l| l.sequence_number += 17);
     ctx.client()
         .pause_stream(&stream_id, &fluxora_stream::PauseReason::Operational);
+    ctx.env.ledger().with_mut(|l| l.sequence_number += 17);
     ctx.client().resume_stream(&stream_id);
 
     let got = ctx.client().get_stream_metadata(&stream_id).unwrap();
@@ -1543,5 +1545,96 @@ fn test_double_init_does_not_corrupt_stream_count() {
     assert_eq!(
         count_before, count_after,
         "stream count must be unchanged after a failed double-init"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Stream offer: metadata round-trip via accept
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_metadata_round_trips_via_stream_offer_accept() {
+    let ctx = Ctx::setup();
+    let now = ctx.env.ledger().timestamp();
+
+    let mut meta: Map<Bytes, Bytes> = Map::new(&ctx.env);
+    meta.set(ctx.make_key("offer_ref"), ctx.make_val("OFFER-42"));
+
+    let offer_id = ctx.client().create_stream_offer(
+        &ctx.sender,
+        &CreateStreamParams {
+            recipient: ctx.recipient.clone(),
+            deposit_amount: 1000_i128,
+            rate_per_second: 1_i128,
+            start_time: now + 10,
+            cliff_time: now + 10,
+            end_time: now + 1010,
+            withdraw_dust_threshold: Some(0_i128),
+            memo: None,
+            metadata: Some(meta.clone()),
+            kind: StreamKind::Linear,
+            irrevocable: None,
+            witness: None,
+        },
+        &None,
+    );
+
+    ctx.env.ledger().set_timestamp(now + 5);
+    let stream_id = ctx.client().accept_stream_offer(&ctx.recipient, &offer_id);
+    let got = ctx.client().get_stream_metadata(&stream_id).unwrap();
+    assert_eq!(
+        got.get(ctx.make_key("offer_ref")).unwrap(),
+        ctx.make_val("OFFER-42"),
+        "metadata must copy from offer to stream on accept"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Cancelled stream: metadata still readable via get_stream_metadata
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_get_stream_metadata_readable_on_cancelled_stream() {
+    let ctx = Ctx::setup();
+    let mut meta: Map<Bytes, Bytes> = Map::new(&ctx.env);
+    meta.set(ctx.make_key("status"), ctx.make_val("pre-cancel"));
+    let stream_id = ctx.create_stream_with_metadata(Some(meta));
+
+    ctx.env.ledger().set_timestamp(100);
+    ctx.client().cancel_stream(&stream_id);
+
+    let state = ctx.client().get_stream_state(&stream_id);
+    assert_eq!(state.status, StreamStatus::Cancelled);
+
+    let got = ctx.client().get_stream_metadata(&stream_id).unwrap();
+    assert_eq!(
+        got.get(ctx.make_key("status")).unwrap(),
+        ctx.make_val("pre-cancel"),
+        "get_stream_metadata must work on cancelled streams"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// shorten_stream_end_time: metadata unchanged
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_metadata_unchanged_after_shorten_stream_end_time() {
+    let ctx = Ctx::setup();
+    let mut meta: Map<Bytes, Bytes> = Map::new(&ctx.env);
+    meta.set(ctx.make_key("ref"), ctx.make_val("SHORTEN_TEST"));
+    let stream_id = ctx.create_stream_with_metadata(Some(meta));
+
+    ctx.env
+        .ledger()
+        .set_timestamp(LEDGER_START_TIMESTAMP + 200);
+    ctx.client()
+        .shorten_stream_end_time(&stream_id, &(LEDGER_START_TIMESTAMP + 500));
+
+    let got = ctx.client().get_stream_metadata(&stream_id).unwrap();
+    assert_eq!(
+        got.get(ctx.make_key("ref")).unwrap(),
+        ctx.make_val("SHORTEN_TEST"),
+        "metadata must survive shorten_stream_end_time"
     );
 }

--- a/docs/metadata-extension.md
+++ b/docs/metadata-extension.md
@@ -1,0 +1,106 @@
+# Per-Stream Metadata Extension
+
+Standalone reference for the optional bounded key-value `metadata` map attached to
+streams at creation time (issue #580, `CONTRACT_VERSION` 4+).
+
+**Implementation:** `validate_metadata` in `contracts/stream/src/storage.rs`; creation
+paths in `contracts/stream/src/lib.rs`.
+
+**Related:** [streaming.md § Per-stream metadata](./streaming.md#per-stream-metadata-tlv-extension-contract_version-4)
+
+---
+
+## Overview
+
+Each stream may store `metadata: Option<Map<Bytes, Bytes>>` — a Soroban map of
+opaque byte keys and values for integrator correlation (invoice IDs, project codes,
+external URIs). Metadata is validated once at creation, persisted on the `Stream`
+struct, emitted in `StreamCreated`, and exposed read-only via `get_stream_metadata`.
+
+Metadata is **immutable** after the stream is created. No entry-point mutates or
+clears the map.
+
+---
+
+## Bounds
+
+| Bound | Constant | Value | Error on violation |
+|-------|----------|-------|-------------------|
+| Maximum key-value pairs | `MAX_METADATA_KEYS` | 8 | `MetadataTooLarge` |
+| Maximum aggregate bytes (all keys + values) | `MAX_METADATA_BYTES` | 512 | `MetadataTooLarge` |
+| Maximum single key length | `MAX_METADATA_KEY_BYTES` | 32 | `MetadataTooLarge` |
+| Maximum single value length | `MAX_METADATA_VALUE_BYTES` | 128 | `MetadataTooLarge` |
+
+Empty keys and empty values are allowed. `Some(empty map)` is valid.
+
+---
+
+## Validation order
+
+`validate_metadata` runs **before** stream ID allocation and token transfer:
+
+1. Reject if `metadata.len() > MAX_METADATA_KEYS`
+2. For each `(key, value)` pair (iteration order):
+   - Reject if `key.len() > MAX_METADATA_KEY_BYTES`
+   - Reject if `value.len() > MAX_METADATA_VALUE_BYTES`
+   - Accumulate `key.len() + value.len()` into running total (saturating add)
+   - Reject if running total `> MAX_METADATA_BYTES`
+
+On failure: `ContractError::MetadataTooLarge`; no stream ID consumed; no tokens moved.
+
+Creation paths that call validation: `create_stream`, `create_streams`,
+`create_streams_relative`, `create_streams_partial`, `create_stream_from_template`,
+`create_stream_offer`.
+
+---
+
+## Compatibility matrix
+
+Metadata is written at creation and **never mutated**. Operations either ignore
+metadata or copy it to a new stream.
+
+| Operation | Metadata behavior |
+|-----------|-------------------|
+| `create_stream` / `create_streams` / relative / partial | **Set** — validated and stored |
+| `create_stream_from_template` | **Set** — caller-supplied map validated |
+| `create_stream_offer` | **Set on offer** — stored on `StreamOffer`; copied on accept |
+| `accept_stream_offer` | **Copied** — offer metadata becomes stream metadata |
+| `reject_stream_offer` / `cancel_stream_offer` | Unaffected — offer removed; no stream yet |
+| `get_stream_metadata` | **Read** — permissionless; works on active, paused, cancelled streams |
+| `pause_stream` / `resume_stream` | Unchanged |
+| `cancel_stream` / `keeper_cancel` / `witnessed_cancel_stream` | Unchanged — still readable |
+| `withdraw` / `withdraw_to` / `batch_withdraw` / `batch_withdraw_to` | Unchanged |
+| `delegated_withdraw` | Unchanged |
+| `top_up_stream` | Unchanged |
+| `update_rate_per_second` / `decrease_rate_per_second` | Unchanged |
+| `extend_stream_end_time` / `shorten_stream_end_time` | Unchanged |
+| `transfer_sender` / recipient rotation | Unchanged |
+| `set_auto_renew` / `get_auto_renew` | Unchanged — auto-renew flag only |
+| `clone_stream` | **Inherited** — clone receives `source.metadata.clone()` |
+| `close_completed_stream` / `close_cancelled_stream` | Entry removed — metadata no longer queryable |
+
+---
+
+## Upgrade path (V5 → current)
+
+V5 `Stream` entries had no `metadata` field. Soroban XDR decoding is forward-compatible:
+V5-encoded streams decode with `metadata == None`. No migration is required.
+
+---
+
+## Regression surface
+
+Executable coverage lives in `contracts/stream/tests/metadata_extension.rs`:
+
+- Bounds validation (keys, values, aggregate)
+- Immutability across pause/resume/cancel/withdraw/top-up
+- Batch and template creation paths
+- Offer accept round-trip
+- Post-`shorten_stream_end_time` readability
+- `get_stream_metadata` on cancelled streams
+
+Run:
+
+```bash
+cargo test -p fluxora_stream --test metadata_extension --features testutils
+```

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -32,6 +32,9 @@ No hidden rules or implementation details are required to understand protocol be
 
 ### Per-stream metadata (TLV extension, CONTRACT_VERSION 4)
 
+> **Full reference:** [metadata-extension.md](./metadata-extension.md) — bounds table,
+> validation order, compatibility matrix, upgrade notes, and regression commands.
+
 From **CONTRACT_VERSION 4**, every stream may carry an optional bounded key-value map
 (`metadata: Option<Map<Bytes, Bytes>>`) for rich integration data such as invoice IDs,
 project codes, and external reference URIs.
@@ -77,6 +80,11 @@ and which are unaffected (metadata is not read or written):
 | `top_up_stream` | Unchanged — only `deposit_amount` is modified. |
 | `update_rate_per_second` / `decrease_rate_per_second` | Unchanged — rate fields are modified; metadata is untouched. |
 | `extend_stream_end_time` | Unchanged — `end_time` and `deposit_amount` are modified. |
+| `shorten_stream_end_time` | Unchanged — schedule fields modified; metadata untouched. |
+| `create_stream_offer` | **Set on offer** — validated and stored on pending offer. |
+| `accept_stream_offer` | **Copied** — offer metadata becomes stream metadata. |
+| `reject_stream_offer` / `cancel_stream_offer` | Unaffected — no stream created. |
+| `set_auto_renew` / `get_auto_renew` | Unchanged — auto-renew flag only. |
 | `transfer_sender` | Unchanged — only the `sender` field is rotated. |
 | `update_recipient` | Unchanged — only the `recipient` field is rotated. |
 | `delegate_recipient_share` | Unchanged — delegation splits the rate, not metadata. |


### PR DESCRIPTION
## Description

Documents per-stream metadata extension behavior (issue #1294): standalone reference, streaming.md compatibility table extensions, expanded `validate_metadata` rustdoc, and net-new integration tests. Rebased onto latest `upstream/main` after #1375/#1376 merges — no regressions to dust-threshold docs or hardened #1373 test coverage.

## Type of Change

- [x] Documentation update
- [x] Test coverage improvement

## Related Issues

Closes #1294

## Changes Made

- **[ADD]** `docs/metadata-extension.md` — bounds, validation order, compatibility matrix, upgrade notes
- **[MODIFY]** `docs/streaming.md` — link to standalone doc; extend compatibility table (offer/accept, shorten, auto-renew)
- **[MODIFY]** `contracts/stream/src/storage.rs` — expand `validate_metadata` rustdoc
- **[MODIFY]** `contracts/stream/tests/metadata_extension.rs` — offer accept round-trip; cancelled stream read; shorten end time immutability; pause cooldown ledger advance

## Snapshot Test Changes

### Did this PR modify snapshot test files?

- [x] No - no snapshot changes

## Testing

### Test Coverage

- [x] All tests pass locally: `cargo test -p fluxora_stream --test metadata_extension --features testutils`
- [x] New tests added for new functionality
- [ ] Existing tests updated for changed functionality
- [ ] Test coverage remains above 95%

### Manual Testing

- [x] Tested edge cases (offer accept metadata copy, cancelled stream read, shorten immutability)

## Documentation

- [x] Code comments added/updated
- [x] Documentation updated (if behavior changed)

## Security Considerations

- [x] No new security concerns introduced

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes

## Verification Results

```
cargo test -p fluxora_stream --test metadata_extension --features testutils
✅ 47 passed; 0 failed
```

| Acceptance Criteria | Status |
| --- | --- |
| The current contract behavior still works as it does today | ✅ |
| The edge-case behavior is documented and covered by tests | ✅ |
| The change stays backward compatible with the current release | ✅ |