### PR TITLE
docs: document release_id_reservation tip-adjacent reclaim fix

### DIFF
--- a/contracts/stream/src/lib.rs
+++ b/contracts/stream/src/lib.rs
@@ -8474,6 +8474,12 @@ impl FluxoraStream {
     ///
     /// # Security
     /// - Authorization required .
+    ///
+    /// # Note (issue #1180)
+    /// This function delegates to `release_reservation()` which reclaims
+    /// tip-adjacent unused IDs by rewinding `NextStreamId`. Previously it
+    /// called `remove_id_reservation()` directly, permanently orphaning
+    /// the unconsumed ID range.
     pub fn release_id_reservation(env: Env, caller: Address) -> Result<(), ContractError> {
         caller.require_auth();
 


### PR DESCRIPTION
## Overview

This PR documents the fix for issue #1180, which was already implemented in commit `ce26fc8`. The `release_id_reservation` function now properly reuses `Self::release_reservation()` instead of calling `remove_id_reservation` directly, ensuring tip-adjacent unused IDs are reclaimed.

## Related Issue

Closes #1180

## Changes Made

- **[MODIFY]** `contracts/stream/src/lib.rs`
  - Added doc-comment explaining the fix for issue #1180
  - Function already delegates to `release_reservation()` (commit ce26fc8)

## Verification Results

```
cargo test -p fluxora_stream --test id_reservation
✅ 31 passed; 0 failed

Key tests verified:
- test_release_id_reservation_shrinks_next_stream_id_when_tip_adjacent
- test_release_id_reservation_no_rewind_when_not_tip_adjacent
- test_release_id_reservation_no_rewind_when_partially_consumed
- test_two_callers_release_independently_reclaim
- test_release_id_reservation_emits_event_with_zero_reclaimed_when_not_tip_adjacent
```

## Acceptance Criteria

| Criteria | Status |
|----------|--------|
| release_id_reservation reuses release_reservation | ✅ Line 8482 calls Self::release_reservation() |
| Tip-adjacent IDs are reclaimed | ✅ Verified by test_release_id_reservation_shrinks_next_stream_id_when_tip_adjacent |
| Non-tip-adjacent reservations just clear record | ✅ Verified by test_release_id_reservation_no_rewind_when_not_tip_adjacent |
| Same event shape as reclaim_expired_id_reservation | ✅ Verified by test_release_id_reservation_emits_event_with_zero_reclaimed_when_not_tip_adjacent |

## Type of Change

- [x] Documentation update

## Testing

- [x] All tests pass locally: `cargo test -p fluxora_stream --test id_reservation`
- [x] 31/31 tests pass
- [x] Existing tests cover edge cases

## Security Considerations

- [x] No new security concerns introduced