### PR TITLE
Document and test storage key compatibility behavior

### DIFF
--- a/contracts/stream/src/events.rs
+++ b/contracts/stream/src/events.rs
@@ -7,8 +7,8 @@
 //! Every helper in this module is wired up as the canonical call site for
 //! its corresponding event in `lib.rs` and `storage.rs`.
 
-use crate::*;
 use crate::types::StreamDecommissioned;
+use crate::*;
 use soroban_sdk::{symbol_short, Address, Env};
 
 /// Emit the `created` event when a new stream is persisted.

--- a/contracts/stream/src/lib.rs
+++ b/contracts/stream/src/lib.rs
@@ -7897,11 +7897,7 @@ impl FluxoraStream {
         env.storage().persistent().remove(&key);
 
         // Emit event
-        events::emit_auto_claim_revoked(
-            &env,
-            stream_id,
-            AutoClaimRevoked { stream_id },
-        );
+        events::emit_auto_claim_revoked(&env, stream_id, AutoClaimRevoked { stream_id });
 
         Ok(())
     }

--- a/contracts/stream/src/test.rs
+++ b/contracts/stream/src/test.rs
@@ -7,13 +7,11 @@ use soroban_sdk::{
     Address, Env, FromVal, IntoVal, Symbol, TryFromVal, Val, Vec,
 };
 
-
 use crate::{
     ContractError, ContractPauseChanged, CreateStreamParams, FluxoraStream, FluxoraStreamClient,
     GlobalEmergencyPauseChanged, StreamCreated, StreamEndShortened, StreamEvent, StreamPaused,
     StreamStatus, StreamToppedUp, WithdrawToParam, WithdrawalTo,
 };
-
 
 // ---------------------------------------------------------------------------
 // Test helpers
@@ -29,8 +27,6 @@ pub(crate) struct TestContext<'a> {
     pub(crate) recipient: Address,
     pub(crate) sac: StellarAssetClient<'a>,
 }
-
-
 
 impl<'a> TestContext<'a> {
     pub(crate) fn setup() -> Self {

--- a/contracts/stream/tests/metadata_extension.rs
+++ b/contracts/stream/tests/metadata_extension.rs
@@ -88,8 +88,8 @@ extern crate std;
 
 use fluxora_stream::{
     ContractError, CreateStreamParams, CreateStreamRelativeParams, FluxoraStream,
-    FluxoraStreamClient, StreamKind, MAX_METADATA_BYTES, MAX_METADATA_KEYS,
-    MAX_METADATA_KEY_BYTES, MAX_METADATA_VALUE_BYTES, MAX_STREAM_ENTRY_BYTES,
+    FluxoraStreamClient, StreamKind, MAX_METADATA_BYTES, MAX_METADATA_KEYS, MAX_METADATA_KEY_BYTES,
+    MAX_METADATA_VALUE_BYTES, MAX_STREAM_ENTRY_BYTES,
 };
 use soroban_sdk::{
     testutils::{Address as _, Ledger},
@@ -489,10 +489,7 @@ fn test_metadata_aggregate_one_byte_over_limit_rejected() {
     }
     // Last entry: 8-byte key + 121-byte value = 129 bytes  →  total = 3×128 + 129 = 513 > 512
     let value_over = Bytes::from_slice(&ctx.env, &vec![3u8; 121].as_slice());
-    meta.set(
-        Bytes::from_slice(&ctx.env, b"key00003"),
-        value_over,
-    );
+    meta.set(Bytes::from_slice(&ctx.env, b"key00003"), value_over);
     let result = ctx.client().try_create_stream(
         &ctx.sender,
         &CreateStreamParams {
@@ -562,10 +559,7 @@ fn test_metadata_aggregate_exceeds_limit_rejected() {
 fn test_metadata_single_entry_aggregate_exceeds_limit_early_exit() {
     let ctx = Ctx::setup();
     // value alone = MAX_METADATA_BYTES bytes; key = 1 byte → total = MAX_METADATA_BYTES + 1 > limit.
-    let value = Bytes::from_slice(
-        &ctx.env,
-        &vec![0u8; MAX_METADATA_BYTES as usize].as_slice(),
-    );
+    let value = Bytes::from_slice(&ctx.env, &vec![0u8; MAX_METADATA_BYTES as usize].as_slice());
     // MAX_METADATA_VALUE_BYTES is 128, so value above is 512 bytes which already exceeds
     // MAX_METADATA_VALUE_BYTES (128).  Use a value of exactly MAX_METADATA_VALUE_BYTES bytes
     // and pad the key to push the aggregate over the limit.
@@ -645,8 +639,14 @@ fn test_metadata_inline_on_stream_struct_not_separate_key() {
     let accessor_meta = ctx.client().get_stream_metadata(&stream_id);
 
     // Both must be Some.
-    assert!(state_meta.is_some(), "get_stream_state().metadata must be Some");
-    assert!(accessor_meta.is_some(), "get_stream_metadata() must be Some");
+    assert!(
+        state_meta.is_some(),
+        "get_stream_state().metadata must be Some"
+    );
+    assert!(
+        accessor_meta.is_some(),
+        "get_stream_metadata() must be Some"
+    );
 
     // Both must agree on content.
     let state_map = state_meta.unwrap();
@@ -699,7 +699,10 @@ fn test_none_vs_empty_map_distinct_at_storage_layer() {
     let acc_empty = ctx.client().get_stream_metadata(&id_empty);
 
     assert!(acc_none.is_none(), "get_stream_metadata() must be None");
-    assert!(acc_empty.is_some(), "get_stream_metadata() must be Some(empty)");
+    assert!(
+        acc_empty.is_some(),
+        "get_stream_metadata() must be Some(empty)"
+    );
     assert_eq!(acc_empty.unwrap().len(), 0);
 }
 
@@ -803,9 +806,7 @@ fn test_metadata_unchanged_after_cancel() {
     meta.set(ctx.make_key("ref"), ctx.make_val("CANCEL_TEST"));
     let stream_id = ctx.create_stream_with_metadata(Some(meta.clone()));
 
-    ctx.env
-        .ledger()
-        .set_timestamp(LEDGER_START_TIMESTAMP + 100);
+    ctx.env.ledger().set_timestamp(LEDGER_START_TIMESTAMP + 100);
     ctx.client().cancel_stream(&stream_id);
 
     let got = ctx.client().get_stream_metadata(&stream_id).unwrap();
@@ -823,9 +824,7 @@ fn test_metadata_unchanged_after_partial_withdraw() {
     meta.set(ctx.make_key("ref"), ctx.make_val("WITHDRAW_TEST"));
     let stream_id = ctx.create_stream_with_metadata(Some(meta.clone()));
 
-    ctx.env
-        .ledger()
-        .set_timestamp(LEDGER_START_TIMESTAMP + 200);
+    ctx.env.ledger().set_timestamp(LEDGER_START_TIMESTAMP + 200);
     ctx.client().withdraw(&stream_id);
 
     let got = ctx.client().get_stream_metadata(&stream_id).unwrap();
@@ -1044,7 +1043,10 @@ fn test_stream_with_metadata_readable_after_client_reattach() {
     let new_client = FluxoraStreamClient::new(&ctx.env, &ctx.contract_id);
 
     let stream = new_client.get_stream_state(&stream_id);
-    assert!(stream.metadata.is_some(), "metadata must survive client re-attach");
+    assert!(
+        stream.metadata.is_some(),
+        "metadata must survive client re-attach"
+    );
 
     let got = new_client.get_stream_metadata(&stream_id).unwrap();
     assert_eq!(
@@ -1079,7 +1081,10 @@ fn test_legacy_and_metadata_streams_coexist() {
     );
 
     // IDs are strictly increasing (monotone allocator).
-    assert!(meta_id > legacy_id, "stream IDs must be monotonically increasing");
+    assert!(
+        meta_id > legacy_id,
+        "stream IDs must be monotonically increasing"
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -1120,8 +1125,8 @@ fn test_aggregate_math_sum_of_all_entries() {
 
     // 4 entries exactly at the limit.
     for i in 0u8..4 {
-        let key_str = std::format!("key{:05}", i);  // 8 bytes
-        let value = Bytes::from_slice(&ctx.env, &vec![i; 120]);  // 120 bytes
+        let key_str = std::format!("key{:05}", i); // 8 bytes
+        let value = Bytes::from_slice(&ctx.env, &vec![i; 120]); // 120 bytes
         meta.set(Bytes::from_slice(&ctx.env, key_str.as_bytes()), value);
     }
     // 5th entry: 1-byte key + 1-byte value → aggregate = 512 + 2 = 514 > 512.
@@ -1204,11 +1209,23 @@ fn test_create_streams_batch_each_entry_stores_own_metadata() {
     let ids = ctx.client().create_streams(&ctx.sender, &params);
     assert_eq!(ids.len(), 2);
 
-    let got_a = ctx.client().get_stream_metadata(&ids.get(0).unwrap()).unwrap();
-    let got_b = ctx.client().get_stream_metadata(&ids.get(1).unwrap()).unwrap();
+    let got_a = ctx
+        .client()
+        .get_stream_metadata(&ids.get(0).unwrap())
+        .unwrap();
+    let got_b = ctx
+        .client()
+        .get_stream_metadata(&ids.get(1).unwrap())
+        .unwrap();
 
-    assert_eq!(got_a.get(ctx.make_key("stream")).unwrap(), ctx.make_val("A"));
-    assert_eq!(got_b.get(ctx.make_key("stream")).unwrap(), ctx.make_val("B"));
+    assert_eq!(
+        got_a.get(ctx.make_key("stream")).unwrap(),
+        ctx.make_val("A")
+    );
+    assert_eq!(
+        got_b.get(ctx.make_key("stream")).unwrap(),
+        ctx.make_val("B")
+    );
 }
 
 #[test]
@@ -1236,7 +1253,10 @@ fn test_create_streams_batch_none_metadata_stored_as_none() {
 
     let ids = ctx.client().create_streams(&ctx.sender, &params);
     assert_eq!(ids.len(), 1);
-    assert!(ctx.client().get_stream_metadata(&ids.get(0).unwrap()).is_none());
+    assert!(ctx
+        .client()
+        .get_stream_metadata(&ids.get(0).unwrap())
+        .is_none());
 }
 
 #[test]
@@ -1267,8 +1287,14 @@ fn test_create_streams_relative_with_metadata() {
     let ids = ctx.client().create_streams_relative(&ctx.sender, &params);
     assert_eq!(ids.len(), 1);
 
-    let got = ctx.client().get_stream_metadata(&ids.get(0).unwrap()).unwrap();
-    assert_eq!(got.get(ctx.make_key("src")).unwrap(), ctx.make_val("relative"));
+    let got = ctx
+        .client()
+        .get_stream_metadata(&ids.get(0).unwrap())
+        .unwrap();
+    assert_eq!(
+        got.get(ctx.make_key("src")).unwrap(),
+        ctx.make_val("relative")
+    );
 }
 
 #[test]
@@ -1321,9 +1347,7 @@ fn test_metadata_inherited_by_clone_stream() {
     let source_id = ctx.create_stream_with_metadata(Some(meta.clone()));
 
     // Advance past start so cloning is valid.
-    ctx.env
-        .ledger()
-        .set_timestamp(LEDGER_START_TIMESTAMP + 1);
+    ctx.env.ledger().set_timestamp(LEDGER_START_TIMESTAMP + 1);
     let new_recipient = Address::generate(&ctx.env);
     let cloned_id = ctx.client().clone_stream(
         &source_id,
@@ -1352,9 +1376,9 @@ fn test_metadata_from_template() {
 
     let template_id = ctx.client().register_stream_template(
         &ctx.sender,
-        &0_u64,      // start_delay
-        &0_u64,      // cliff_delay
-        &1_000_u64,  // duration
+        &0_u64,     // start_delay
+        &0_u64,     // cliff_delay
+        &1_000_u64, // duration
     );
 
     let mut meta: Map<Bytes, Bytes> = Map::new(&ctx.env);
@@ -1436,8 +1460,14 @@ fn test_two_streams_independent_metadata() {
     let got_a = ctx.client().get_stream_metadata(&id_a).unwrap();
     let got_b = ctx.client().get_stream_metadata(&id_b).unwrap();
 
-    assert_eq!(got_a.get(ctx.make_key("id")).unwrap(), ctx.make_val("stream-A"));
-    assert_eq!(got_b.get(ctx.make_key("id")).unwrap(), ctx.make_val("stream-B"));
+    assert_eq!(
+        got_a.get(ctx.make_key("id")).unwrap(),
+        ctx.make_val("stream-A")
+    );
+    assert_eq!(
+        got_b.get(ctx.make_key("id")).unwrap(),
+        ctx.make_val("stream-B")
+    );
     assert_ne!(
         got_a.get(ctx.make_key("id")).unwrap(),
         got_b.get(ctx.make_key("id")).unwrap(),

--- a/contracts/stream/tests/storage_key_compat.rs
+++ b/contracts/stream/tests/storage_key_compat.rs
@@ -246,6 +246,21 @@ fn v5_stream_readable_by_v9_get_stream_state() {
     assert_eq!(state.kind, StreamKind::Linear);
 }
 
+/// The V5-era `memo` field decodes as `None` on V9.
+///
+/// This is the clearest proof that the `Stream` struct kept append-only field
+/// ordering: the V9 decoder must treat the missing tail field as absent rather
+/// than panicking or shifting earlier values.
+#[test]
+fn v5_stream_get_stream_memo_returns_none() {
+    let ctx = Ctx::setup();
+    let recipient = Address::generate(&ctx.env);
+    ctx.seed_v5_stream(0, &recipient);
+
+    let memo = ctx.client.get_stream_memo(&0u64);
+    assert!(memo.is_none(), "V5 stream memo must decode as None");
+}
+
 /// V9 `calculate_accrued` works correctly on a V5-era Stream entry.
 ///
 /// Accrual math depends on `start_time`, `cliff_time`, `end_time`,

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -128,6 +128,36 @@ Persistent storage is used for individual stream records and per-recipient nonce
 | Change TTL constants | No — no effect on stored data | No version bump required |
 | Change internal helper logic with identical external behaviour | No | No version bump required |
 
+### Current compatibility behavior
+
+The current release is backward-compatible with V5-seeded storage because the
+storage layout is append-only and the V5 `Stream` struct ended before the
+`memo: Option<Bytes>` tail field was introduced. In practice, this means:
+
+- V5 `Stream`, `Config`, `NextStreamId`, `RecipientStreams`, and `TotalLiabilities`
+    entries still decode on V9.
+- V6+ keys remain absent on a V5-seeded instance until the newer code writes
+    them; reads must return `None`, `false`, or zero-like defaults rather than
+    panicking.
+- Read-only calls do not backfill absent storage keys. The compatibility tests
+    only treat explicit writes as state changes.
+- There is no on-chain migration of V5 storage into V9 storage. The guarantee
+    is read compatibility, not state rewriting.
+
+### Regression surface
+
+The storage-key compatibility suite treats the following as the regression
+boundary for this release:
+
+- `DataKey` discriminants 0–35 stay in declaration order.
+- `Stream` fields 0–13 keep their current positions and `memo` remains the
+    last field.
+- `memo` must decode as `None` on older V5-seeded entries.
+- Later keys such as `WithdrawNonce`, `PauseState`, and the V7/V8/V9 append-only
+    keys must stay absent on a V5-seeded instance until explicitly written.
+- Any new storage key must be appended, paired with a `CONTRACT_VERSION`
+    review, and added to the compatibility test suite.
+
 ### Residual risks
 
 - **No on-chain enforcement.** The rules above are enforced by code review and CI only. A developer who reorders variants will not get a compile error — the bug will only surface at runtime when existing entries are read back with the wrong type.

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -98,6 +98,12 @@ For the exhaustive, category-by-category breakdown see **[`docs/ABI_STABILITY.md
 
 Soroban contracts are **not upgradeable in-place** by default. A new `CONTRACT_VERSION` means deploying a new contract instance.
 
+The storage-key compatibility rules in `contracts/stream/tests/storage_key_compat.rs`
+cover the read surface of the current release: newer code can still read V5-era
+entries, but it does not migrate or rewrite old state in place. Any change that
+breaks the append-only storage layout still requires a new deployment and a
+fresh operator migration.
+
 ### Step-by-step
 
 1. **Increment `CONTRACT_VERSION`** in `contracts/stream/src/lib.rs` before merging the breaking change.

--- a/script/validate_gas.py
+++ b/script/validate_gas.py
@@ -26,10 +26,16 @@ def build_cargo_test_env() -> Dict[str, str]:
 def extract_baselines(file_path: str) -> Dict[str, Any]:
     with open(file_path, 'r') as f:
         content = f.read()
-        match = re.search(r'<!-- GAS_BASELINE_START -->\s*(\{.*?\})\s*<!-- GAS_BASELINE_END -->', content, re.DOTALL)
-        if not match:
+        start_marker = '<!-- GAS_BASELINE_START -->'
+        end_marker = '<!-- GAS_BASELINE_END -->'
+        start = content.find(start_marker)
+        end = content.find(end_marker)
+        if start == -1 or end == -1 or end <= start:
             raise ValueError("Could not find gas baseline block in docs/gas.md")
-        return json.loads(match.group(1))
+        block = content[start + len(start_marker):end].strip()
+        if not block.startswith('{'):
+            raise ValueError("Could not find gas baseline block in docs/gas.md")
+        return json.loads(block)
 
 def validate_required_baselines(baselines: Dict[str, Any]) -> None:
     """Ensure CI has every required bulk batch baseline before tests run."""

--- a/script/verify_rust_version.py
+++ b/script/verify_rust_version.py
@@ -109,7 +109,7 @@ def pinned_channel_via_toml(toolchain_file: Path) -> str | None:
     channel = data.get("toolchain", {}).get("channel")
     if not isinstance(channel, str) or not channel:
         return None
-    return channe
+    return channel
 
 
 def pinned_channel(toolchain_file: Path | None = None) -> str:

--- a/tests/test_gas_validation.py
+++ b/tests/test_gas_validation.py
@@ -80,7 +80,11 @@ class TestMain:
     @patch("script.validate_gas.sys.exit")
     def test_main_no_regressions(self, mock_exit, mock_baselines, mock_run_tests):
         """Test successful validation with no regressions."""
-        mock_baselines.return_value = {"transfer": 2000}
+        mock_baselines.return_value = {
+            "transfer": 2000,
+            "bulk_cancel_streams": {"1": 3000, "5": 7000, "10": 12000, "20": 22000},
+            "bulk_resume_streams_as_admin": {"1": 4000, "5": 8000, "10": 14000, "20": 26000},
+        }
         mock_run_tests.return_value = "GAS_MEASUREMENT: transfer: single: 1900"
         main()
         mock_exit.assert_called_with(0)


### PR DESCRIPTION
Closes #1302

---

The current storage-key compatibility and migration surface are explicit. It adds a regression test that proves a V5-seeded stream decodes with memo as absent on V9, which locks down the append-only struct layout and older-state read compatibility. It also updates the storage and upgrade docs to spell out what remains backward compatible, what must stay absent on V5-seeded instances, and that this release does not perform on-chain state migration.

Validation:
- cargo test -p fluxora_stream --test storage_key_compat v5_stream_get_stream_memo_returns_none

