### PR TITLE
test(stream): re-enable and fix sweep_liability.rs excess-sweep suite

### DIFF
--- a/contracts/stream/Cargo.toml
+++ b/contracts/stream/Cargo.toml
@@ -164,7 +164,8 @@ required-features = ["testutils"]
 [[test]]
 name = "sweep_liability"
 path = "tests/sweep_liability.rs"
-test = false
+required-features = ["testutils"]
+test = true
 
 [[test]]
 name = "upgrade_path"

--- a/contracts/stream/tests/sweep_liability.rs
+++ b/contracts/stream/tests/sweep_liability.rs
@@ -2,11 +2,11 @@
 
 extern crate std;
 
-use fluxora_stream::{FluxoraStream, FluxoraStreamClient};
+use fluxora_stream::{CreateStreamParams, FluxoraStream, FluxoraStreamClient};
 use soroban_sdk::{
-    testutils::{Address as _, Ledger},
+    testutils::{Address as _, Ledger, MockAuth, MockAuthInvoke},
     token::{Client as TokenClient, StellarAssetClient},
-    Address, Env,
+    Address, Env, IntoVal,
 };
 
 // Keeper fee basis points (mirrors KEEPER_FEE_BPS).
@@ -122,16 +122,20 @@ fn test_sweep_excess_excludes_liabilities_and_fees() {
     assert_eq!(swept, 0);
     assert_eq!(ctx.token.balance(&ctx.contract_id), deposit_amount);
 
-    // Now, create another stream to cancel via keeper to generate keeper fees
+    // Second stream, created relative to the *current* clock so its start_time is
+    // not in the past. Cancelled mid-way to exercise liability bookkeeping before
+    // the sweep.
+    let start2 = ctx.env.ledger().timestamp();
+    let end2 = start2 + 100;
     let stream2_id = client.create_stream(
         &ctx.sender,
         &CreateStreamParams {
             recipient: ctx.recipient.clone(),
             deposit_amount: 10_000,
             rate_per_second: 100,
-            start_time: start_time,
-            cliff_time: start_time,
-            end_time: (start_time + 100),
+            start_time: start2,
+            cliff_time: start2,
+            end_time: end2,
             withdraw_dust_threshold: None,
             memo: None,
             metadata: None,
@@ -141,34 +145,24 @@ fn test_sweep_excess_excludes_liabilities_and_fees() {
         },
     );
 
-    // Cancel the second stream at 50% completion
-    ctx.env.ledger().set_timestamp(start_time + 50);
-
-    // We cancel the stream as the sender to trigger the fee
+    // Sender-cancels the second stream at 50% completion. This settles the stream
+    // and reduces tracked liabilities; the contract still holds exactly what it owes.
+    ctx.env.ledger().set_timestamp(start2 + 50);
     client.cancel_stream(&stream2_id);
 
-    // A fee of 0.5% (50 BPS) of the unstreamed amount (5,000) = 25 is generated and sent to the protocol/keeper
-    // Actually, sender cancellation doesn't send fee to keeper, it just pays protocol if a protocol fee is set.
-    // Wait, cancel_stream pays to whoever the keeper address is in the config? No, keeper_cancel pays to keeper.
-    // Let's test the true excess now.
-
-    // Cover the case where extra tokens were sent directly to the contract (true excess)
+    // Inject tokens directly into the contract to create a genuine surplus over
+    // liabilities — the only thing a sweep is permitted to remove.
     let true_excess = 5_555;
     StellarAssetClient::new(&ctx.env, &ctx.token_id).mint(&ctx.sender, &true_excess);
     ctx.token
         .transfer(&ctx.sender, &ctx.contract_id, &true_excess);
 
-    // Total balance is now deposit_amount + remaining from stream 2 + true_excess
     let pre_sweep_balance = ctx.token.balance(&ctx.contract_id);
 
-    // Sweep the excess
+    // Sweep must remove exactly the injected surplus and never touch funds still
+    // owed to stream 1's recipient.
     let swept2 = client.sweep_excess(&treasury);
-
-    // The swept amount MUST equal the true excess we just injected
     assert_eq!(swept2, true_excess);
-
-    // After sweep, the contract balance should be exactly equal to the total liabilities
-    // The recipient-owed balance from stream 1 is protected.
     assert_eq!(ctx.token.balance(&treasury), true_excess);
     assert_eq!(
         ctx.token.balance(&ctx.contract_id),
@@ -225,18 +219,22 @@ fn test_keeper_fee_rounding_non_evenly_divisible_excess() {
             "fee + remainder must equal total_excess exactly"
         );
 
-        // Verify runtime contract behavior via keeper_cancel with unstreamed excess deposit
+        // Verify runtime contract behavior via keeper_cancel. The keeper fee is
+        // taken from the *unstreamed* portion of the deposit. Build an overfunded
+        // Linear stream whose 1-second schedule streams exactly 1 stroop, so the
+        // unstreamed gross (deposit - streamable) equals total_excess exactly.
         let start_time = ctx.env.ledger().timestamp();
+        let end_time = start_time + 1;
 
         let stream_id = client.create_stream(
             &ctx.sender,
             &CreateStreamParams {
                 recipient: ctx.recipient.clone(),
-                deposit_amount: total_excess,
-                rate_per_second: 0,
+                deposit_amount: total_excess + 1,
+                rate_per_second: 1,
                 start_time: start_time,
                 cliff_time: start_time,
-                end_time: (start_time + 100),
+                end_time: end_time,
                 withdraw_dust_threshold: None,
                 memo: None,
                 metadata: None,
@@ -246,8 +244,9 @@ fn test_keeper_fee_rounding_non_evenly_divisible_excess() {
             },
         );
 
-        // Advance past keeper grace period
-        ctx.env.ledger().set_timestamp(start_time + 604_800 + 1);
+        // Advance past end_time + the keeper grace period (604_800s) so the stream
+        // becomes keeper-cancellable.
+        ctx.env.ledger().set_timestamp(end_time + 604_800 + 1);
 
         let keeper_before = ctx.token.balance(&ctx.keeper);
         let sender_before = ctx.token.balance(&ctx.sender);
@@ -304,16 +303,19 @@ fn test_smallest_possible_excess_one_stroop() {
         "fee + remainder must equal 1 stroop"
     );
 
+    // Overfunded 1-second Linear stream: streams exactly 1 stroop, leaving exactly
+    // 1 stroop (total_excess) unstreamed as the keeper-fee base.
     let start_time = ctx.env.ledger().timestamp();
+    let end_time = start_time + 1;
     let stream_id = client.create_stream(
         &ctx.sender,
         &CreateStreamParams {
             recipient: ctx.recipient.clone(),
-            deposit_amount: total_excess,
-            rate_per_second: 0,
+            deposit_amount: total_excess + 1,
+            rate_per_second: 1,
             start_time: start_time,
             cliff_time: start_time,
-            end_time: (start_time + 100),
+            end_time: end_time,
             withdraw_dust_threshold: None,
             memo: None,
             metadata: None,
@@ -323,8 +325,8 @@ fn test_smallest_possible_excess_one_stroop() {
         },
     );
 
-    // Advance past grace period
-    ctx.env.ledger().set_timestamp(start_time + 604_800 + 1);
+    // Advance past end_time + the keeper grace period so the stream is cancellable.
+    ctx.env.ledger().set_timestamp(end_time + 604_800 + 1);
 
     let keeper_before = ctx.token.balance(&ctx.keeper);
     let sender_before = ctx.token.balance(&ctx.sender);
@@ -354,4 +356,34 @@ fn test_smallest_possible_excess_one_stroop() {
         total_excess,
         "keeper_paid + sender_refunded must equal 1 stroop exactly"
     );
+}
+
+// ---------------------------------------------------------------------------
+// Acceptance criteria: sweep_excess is an admin-gated fund movement — a
+// non-admin caller must be rejected before any tokens leave the contract.
+// ---------------------------------------------------------------------------
+
+/// Only the admin can sweep excess tokens. `sweep_excess` calls `admin.require_auth()`
+/// before computing or moving any excess, so scoping the mocked auth to a non-admin
+/// address (rather than the admin) makes that authorization check fail.
+#[test]
+#[should_panic]
+fn test_sweep_excess_rejects_non_admin() {
+    let ctx = Ctx::setup();
+    let treasury = Address::generate(&ctx.env);
+    let non_admin = Address::generate(&ctx.env);
+
+    // Replace setup's blanket mock_all_auths with an auth scoped to a non-admin
+    // caller; the admin's require_auth inside sweep_excess is then unauthorized.
+    ctx.env.mock_auths(&[MockAuth {
+        address: &non_admin,
+        invoke: &MockAuthInvoke {
+            contract: &ctx.contract_id,
+            fn_name: "sweep_excess",
+            args: (treasury.clone(),).into_val(&ctx.env),
+            sub_invokes: &[],
+        },
+    }]);
+
+    ctx.client().sweep_excess(&treasury);
 }


### PR DESCRIPTION
Closes #1156

Re-enables `contracts/stream/tests/sweep_liability.rs` (previously `test = false`) and updates it to the current soroban-sdk 21.7.7 API and sweep entrypoint.

## What was broken
- The suite referenced `CreateStreamParams` unqualified without importing it (the primary compile break).
- `create_stream` now rejects `rate_per_second == 0` for Linear streams and past-dated `start_time`s, so the original keeper-fee tests (built on `rate = 0` deposits) and the second stream in the liability test no longer create.

## Changes
- Import `CreateStreamParams`.
- Rebuild the two keeper-fee-rounding cases as overfunded 1-second Linear streams: `deposit = gross + 1`, `rate = 1`, so the schedule streams exactly 1 stroop and the unstreamed gross fed to `keeper_cancel` equals each rounding vector exactly. `accrued` for an overfunded Linear stream is `min(rate * duration, deposit) = streamable`, so the gross is pinned to the intended value rather than depending on `rate = 0` behavior the contract no longer allows.
- Rebuild the liability-exclusion test's second stream against the current ledger clock so its schedule is valid.
- Add `test_sweep_excess_rejects_non_admin` (the acceptance criteria's non-admin-rejection case): scopes `mock_auths` to a non-admin address so the `admin.require_auth()` inside `sweep_excess` fails, asserted via `#[should_panic]` (mirrors `adversarial_auth.rs`).
- Flip `test = false` -> `test = true` and add `required-features = ["testutils"]`, matching the sibling `keeper_cancel` and `liability_invariant` tests.

## Verification
```
cargo test -p fluxora_stream --features testutils --test sweep_liability
```
4 passed; 0 failed:
- `test_sweep_excess_excludes_liabilities_and_fees`
- `test_keeper_fee_rounding_non_evenly_divisible_excess`
- `test_smallest_possible_excess_one_stroop`
- `test_sweep_excess_rejects_non_admin` (should_panic)

Re-validated invariant: `sweep_excess` removes only `balance - TotalLiabilities`, never funds still owed to active streams. The liability test drives two distinct real liability values (100000 before, 105000 after a mid-stream sender-cancel) and pins the swept amount by exact equality at each, plus the zero-excess and non-admin-rejection paths.

## Note on the broader test build
Other pre-existing test binaries in this crate (e.g. `gas_regression`) still fail to compile on `main` (unrelated `WithdrawToParam` / `PauseReason` references, part of the known-broken block the issue references). This PR touches only `sweep_liability.rs` and its `Cargo.toml` stanza; those failures reproduce unchanged with this branch's edits stashed.
