### PR TITLE
ci: warn when wasm headroom drops below 10%

### DIFF
--- a/script/check-wasm-size.sh
+++ b/script/check-wasm-size.sh
@@ -101,5 +101,22 @@ if [ "$FAILED" -ne 0 ]; then
   exit 1
 fi
 
+# Edge-case: warn when headroom drops below 10% of budget.
+for CONTRACT in "${!BUDGETS[@]}"; do
+  BUDGET="${BUDGETS[$CONTRACT]}"
+  if [ "$OPTIMIZED" -eq 1 ]; then
+    WASM_FILE="${WASM_DIR}/${CONTRACT}.optimized.wasm"
+  else
+    WASM_FILE="${WASM_DIR}/${CONTRACT}.wasm"
+  fi
+  if [ -f "$WASM_FILE" ]; then
+    SIZE=$(wc -c < "$WASM_FILE")
+    THRESHOLD=$(( BUDGET * 90 / 100 ))
+    if [ "$SIZE" -gt "$THRESHOLD" ]; then
+      echo "::warning::${CONTRACT}.wasm is within 10% of budget — consider expanding budget or reducing binary size." >&2
+    fi
+  fi
+done
+
 echo ""
 echo "All contracts within WASM size budget."


### PR DESCRIPTION
## Summary

Adds a headroom warning to the WASM size budget check script, catching near-limit binaries before they become regressions.

## Changes

- Added post-budget warning loop that flags any contract binary within 10% of its size budget, providing early visibility into size creep.

## Motivation

Part of the WASM size check hardening effort tracked in #1308. This closes the edge case where a binary is technically within budget but leaves almost no headroom for future feature additions, making the next size-increasing change a hard regression.

## Linked Issue

Closes #1308