### PR TITLE
feat(backend): wire WebSocketHub and StreamChannel into server lifecycle

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,4 +1,5 @@
 import 'dotenv/config';
+import http from 'http';
 import express from 'express';
 import cors from 'cors';
 import helmet from 'helmet';
@@ -6,6 +7,8 @@ import { AppDataSource } from './config/database';
 import userRoutes from './routes/users.routes';
 import streamRoutes from './routes/streams';
 import logger from './utils/logger';
+import { initStreamRealtime, resetStreamRealtime } from './websockets/runtime';
+import { attachWebSocketHub } from './ws/attach';
 
 const app = express();
 const PORT = process.env.PORT || 3000;
@@ -67,11 +70,29 @@ async function startServer(): Promise<void> {
     await AppDataSource.initialize();
     logger.info('Database connection established');
 
-    // Start server
-    app.listen(PORT, () => {
+    // Shared realtime stack: hub + StreamChannel (used by stream lifecycle routes)
+    const { hub } = initStreamRealtime();
+
+    // Explicit HTTP server so we can attach a WebSocket upgrade handler
+    const server = http.createServer(app);
+    attachWebSocketHub(server, hub);
+
+    server.listen(PORT, () => {
       logger.info(`Server running on port ${PORT}`);
+      logger.info(`WebSocket endpoint available at /ws`);
       logger.info(`Environment: ${process.env.NODE_ENV || 'development'}`);
     });
+
+    const shutdown = (signal: string) => {
+      logger.info(`Received ${signal}, shutting down`);
+      resetStreamRealtime();
+      server.close(() => {
+        process.exit(0);
+      });
+    };
+
+    process.on('SIGTERM', () => shutdown('SIGTERM'));
+    process.on('SIGINT', () => shutdown('SIGINT'));
   } catch (error) {
     logger.error('Failed to start server', { error });
     process.exit(1);

--- a/backend/src/routes/streams.ts
+++ b/backend/src/routes/streams.ts
@@ -28,6 +28,7 @@ import { idempotency } from '../middleware/requestProtection';
 import { sendSuccess, sendError, toDecimalString } from '../utils/response';
 import { ValidationError } from '../utils/errors';
 import logger from '../utils/logger';
+import { getStreamChannel } from '../websockets/runtime';
 
 const router = Router();
 
@@ -234,6 +235,10 @@ async function createStream(
       streamId,
       recipientId: input.recipientId
     });
+
+    // Broadcast StreamCreated to any WebSocket clients subscribed to this stream.
+    // No-ops when realtime is not initialized (e.g. isolated route unit tests).
+    getStreamChannel()?.notifyStreamCreated(streamId, stream);
 
     // 201 Created — the idempotency middleware will cache this response
     sendSuccess(res, { stream }, 201);

--- a/backend/src/websockets/runtime.ts
+++ b/backend/src/websockets/runtime.ts
@@ -1,0 +1,54 @@
+/**
+ * Stream realtime runtime
+ *
+ * Process-wide holders for the shared WebSocketHub and StreamChannel.
+ * Initialized once at server start (see index.ts); route handlers access
+ * the channel via getStreamChannel() so they stay decoupled from construction.
+ *
+ * When not initialized (unit tests of routes without a WS server), getters
+ * return null so callers can no-op safely with optional chaining.
+ */
+
+import { WebSocketHub } from '../ws/hub';
+import { StreamChannel } from './streamChannel';
+
+let hub: WebSocketHub | null = null;
+let channel: StreamChannel | null = null;
+
+/**
+ * Construct (or return) the shared hub + stream channel pair.
+ * Safe to call more than once; subsequent calls reuse the same instances.
+ */
+export function initStreamRealtime(): {
+  hub: WebSocketHub;
+  channel: StreamChannel;
+} {
+  if (!hub) {
+    hub = new WebSocketHub();
+    channel = new StreamChannel(hub);
+  }
+  // channel is always set whenever hub is set
+  return { hub, channel: channel as StreamChannel };
+}
+
+/** Shared StreamChannel, or null if realtime has not been initialized. */
+export function getStreamChannel(): StreamChannel | null {
+  return channel;
+}
+
+/** Shared WebSocketHub, or null if realtime has not been initialized. */
+export function getWebSocketHub(): WebSocketHub | null {
+  return hub;
+}
+
+/**
+ * Tear down the shared runtime (clears hub timers/clients).
+ * Intended for graceful process shutdown and integration-test cleanup.
+ */
+export function resetStreamRealtime(): void {
+  if (hub) {
+    hub.cleanup();
+  }
+  hub = null;
+  channel = null;
+}

--- a/backend/src/ws/attach.ts
+++ b/backend/src/ws/attach.ts
@@ -1,0 +1,36 @@
+/**
+ * Attach a WebSocket server to an HTTP server and route upgrades through
+ * the shared WebSocketHub. Used by the application entrypoint and by
+ * integration tests so production and test wiring cannot drift.
+ */
+
+import http from 'http';
+import WebSocket from 'ws';
+import { WebSocketHub } from './hub';
+
+/** Path clients use to open a real-time connection. */
+export const WEBSOCKET_PATH = '/ws';
+
+/** Max inbound WebSocket frame size (matches hub MAX_PAYLOAD_SIZE). */
+export const WEBSOCKET_MAX_PAYLOAD = 1024 * 16;
+
+/**
+ * Create a `ws.Server` bound to `server` on {@link WEBSOCKET_PATH} and
+ * forward each new connection to `hub.addConnection`.
+ */
+export function attachWebSocketHub(
+  server: http.Server,
+  hub: WebSocketHub
+): WebSocket.Server {
+  const wss = new WebSocket.Server({
+    server,
+    path: WEBSOCKET_PATH,
+    maxPayload: WEBSOCKET_MAX_PAYLOAD
+  });
+
+  wss.on('connection', (socket, request) => {
+    hub.addConnection(socket, request);
+  });
+
+  return wss;
+}

--- a/backend/tests/streams-ws.integration.test.ts
+++ b/backend/tests/streams-ws.integration.test.ts
@@ -1,0 +1,319 @@
+/**
+ * End-to-end: POST /api/v1/streams → WebSocket StreamCreated notification
+ *
+ * Proves that production wiring (http.Server + attachWebSocketHub +
+ * initStreamRealtime + getStreamChannel().notifyStreamCreated) delivers a
+ * `created` update to an authenticated client subscribed to the new stream.
+ *
+ * Stream IDs are generated inside the route via uuid.v4(). Clients must
+ * subscribe before create, so this suite forces the next uuid.v4() return
+ * value to a predetermined ID after the socket is already subscribed.
+ */
+
+import http from 'http';
+import express, { Application } from 'express';
+import request from 'supertest';
+import WebSocket from 'ws';
+import jwt from 'jsonwebtoken';
+
+// ---------------------------------------------------------------------------
+// Controllable uuid mock (hoisted)
+// ---------------------------------------------------------------------------
+
+const uuidState: { next: string | null } = { next: null };
+
+jest.mock('uuid', () => {
+  const actual = jest.requireActual<typeof import('uuid')>('uuid');
+  return {
+    ...actual,
+    v4: () => {
+      if (uuidState.next !== null) {
+        const id = uuidState.next;
+        uuidState.next = null;
+        return id;
+      }
+      return actual.v4();
+    }
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Hermetic mocks for cache + logger (same pattern as streams.test.ts)
+// ---------------------------------------------------------------------------
+
+const cacheStore = new Map<string, unknown>();
+
+jest.mock('../src/utils/cache', () => ({
+  __esModule: true,
+  default: {
+    get: jest.fn(async (key: string) => cacheStore.get(key) ?? null),
+    set: jest.fn(async (key: string, value: unknown) => {
+      cacheStore.set(key, value);
+    }),
+    del: jest.fn(async (key: string) => {
+      cacheStore.delete(key);
+    })
+  }
+}));
+
+jest.mock('../src/utils/logger', () => ({
+  __esModule: true,
+  default: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn()
+  }
+}));
+
+// ---------------------------------------------------------------------------
+// Imports after mocks
+// ---------------------------------------------------------------------------
+
+import streamRouter from '../src/routes/streams';
+import {
+  initStreamRealtime,
+  resetStreamRealtime,
+  getStreamChannel,
+  getWebSocketHub
+} from '../src/websockets/runtime';
+import { attachWebSocketHub, WEBSOCKET_PATH } from '../src/ws/attach';
+
+// ---------------------------------------------------------------------------
+// Constants / helpers
+// ---------------------------------------------------------------------------
+
+const JWT_SECRET = 'streams-ws-integration-secret';
+const PREDETERMINED_STREAM_ID = '123e4567-e89b-12d3-a456-426614174000';
+const SENDER = { id: 'sender-user-1', email: 'sender@test.com', role: 'user' };
+
+const VALID_BODY = {
+  recipientId: '987fcdeb-51a2-43d7-b890-123456789abc',
+  depositAmount: '1000000',
+  ratePerSecond: '100',
+  startTime: 1700000000,
+  endTime: 1700010000
+};
+
+function makeToken(
+  payload: { id: string; email: string; role: string } = SENDER
+): string {
+  return jwt.sign(payload, JWT_SECRET, { expiresIn: '1h' });
+}
+
+function buildApp(): Application {
+  const app = express();
+  app.use(express.json());
+  process.env.JWT_SECRET = JWT_SECRET;
+  process.env.NODE_ENV = 'test';
+  app.use('/api/v1/streams', streamRouter);
+  app.use(
+    (
+      err: Error & { statusCode?: number },
+      _req: express.Request,
+      res: express.Response,
+      _next: express.NextFunction
+    ) => {
+      const status = err.statusCode ?? 500;
+      res.status(status).json({
+        success: false,
+        error: {
+          message: err.message,
+          code: status === 401 ? 'UNAUTHORIZED' : 'INTERNAL_ERROR'
+        }
+      });
+    }
+  );
+  return app;
+}
+
+// ---------------------------------------------------------------------------
+// Suite
+// ---------------------------------------------------------------------------
+
+describe('POST /streams → WebSocket StreamCreated (e2e)', () => {
+  let server: http.Server;
+  let port: number;
+  let baseWsUrl: string;
+
+  beforeAll((done) => {
+    process.env.JWT_SECRET = JWT_SECRET;
+    process.env.NODE_ENV = 'test';
+
+    const app = buildApp();
+    const { hub } = initStreamRealtime();
+
+    // Runtime must expose both instances after init
+    expect(getWebSocketHub()).toBe(hub);
+    expect(getStreamChannel()).not.toBeNull();
+
+    server = http.createServer(app);
+    attachWebSocketHub(server, hub);
+
+    server.listen(0, () => {
+      const address = server.address();
+      if (address && typeof address === 'object') {
+        port = address.port;
+        baseWsUrl = `ws://localhost:${port}${WEBSOCKET_PATH}`;
+        done();
+      } else {
+        done(new Error('Failed to bind ephemeral HTTP server'));
+      }
+    });
+  });
+
+  afterAll((done) => {
+    resetStreamRealtime();
+    expect(getStreamChannel()).toBeNull();
+    expect(getWebSocketHub()).toBeNull();
+    server.close(done);
+  });
+
+  beforeEach(() => {
+    cacheStore.clear();
+    uuidState.next = null;
+    jest.clearAllMocks();
+  });
+
+  it(
+    'delivers a created notification to a client subscribed to the new stream id',
+    async () => {
+      const token = makeToken();
+
+      // Attach the message collector before open to avoid racing the welcome frame.
+      const ws = new WebSocket(
+        `${baseWsUrl}?token=${encodeURIComponent(token)}`
+      );
+      const inbox: Record<string, unknown>[] = [];
+      const waiters: Array<{
+        predicate: (msg: Record<string, unknown>) => boolean;
+        resolve: (msg: Record<string, unknown>) => void;
+      }> = [];
+
+      ws.on('message', (data) => {
+        let msg: Record<string, unknown>;
+        try {
+          msg = JSON.parse(data.toString()) as Record<string, unknown>;
+        } catch {
+          return;
+        }
+        inbox.push(msg);
+        for (let i = waiters.length - 1; i >= 0; i--) {
+          if (waiters[i].predicate(msg)) {
+            const waiter = waiters[i];
+            waiters.splice(i, 1);
+            waiter.resolve(msg);
+          }
+        }
+      });
+
+      const nextMatching = (
+        predicate: (msg: Record<string, unknown>) => boolean,
+        timeoutMs = 5000
+      ): Promise<Record<string, unknown>> => {
+        const existing = inbox.find(predicate);
+        if (existing) return Promise.resolve(existing);
+        return new Promise((resolve, reject) => {
+          const timer = setTimeout(() => {
+            const idx = waiters.findIndex((w) => w.resolve === resolveWrapped);
+            if (idx >= 0) waiters.splice(idx, 1);
+            reject(
+              new Error(
+                `Timed out waiting for matching WS message. Inbox: ${JSON.stringify(inbox)}`
+              )
+            );
+          }, timeoutMs);
+          const resolveWrapped = (msg: Record<string, unknown>) => {
+            clearTimeout(timer);
+            resolve(msg);
+          };
+          waiters.push({ predicate, resolve: resolveWrapped });
+        });
+      };
+
+      await new Promise<void>((resolve, reject) => {
+        ws.once('open', () => resolve());
+        ws.once('error', reject);
+      });
+
+      await nextMatching((msg) => msg.type === 'connected');
+
+      // Subscribe to the predetermined stream id before create
+      ws.send(
+        JSON.stringify({
+          type: 'subscribe',
+          streamId: PREDETERMINED_STREAM_ID
+        })
+      );
+      await nextMatching((msg) => msg.type === 'subscribed');
+
+      // Force the next uuid.v4() (streamId in createStream) to the predetermined id.
+      // Pass X-Correlation-Id so the route does not consume an extra uuid for correlation.
+      uuidState.next = PREDETERMINED_STREAM_ID;
+
+      const createdPromise = nextMatching(
+        (msg) =>
+          msg.type === 'stream_update' &&
+          msg.streamId === PREDETERMINED_STREAM_ID &&
+          (msg.payload as { type?: string } | undefined)?.type === 'created'
+      );
+
+      const res = await request(server)
+        .post('/api/v1/streams')
+        .set('Authorization', `Bearer ${token}`)
+        .set('X-Correlation-Id', 'e2e-correlation-1')
+        .send(VALID_BODY);
+
+      expect(res.status).toBe(201);
+      expect(res.body.success).toBe(true);
+      expect(res.body.data.stream.id).toBe(PREDETERMINED_STREAM_ID);
+
+      const notification = await createdPromise;
+      const payload = notification.payload as {
+        type: string;
+        streamId: string;
+        data: {
+          id: string;
+          senderId: string;
+          recipientId: string;
+          status: string;
+          depositAmount: string;
+        };
+      };
+
+      expect(payload.type).toBe('created');
+      expect(payload.streamId).toBe(PREDETERMINED_STREAM_ID);
+      expect(payload.data.id).toBe(PREDETERMINED_STREAM_ID);
+      expect(payload.data.senderId).toBe(SENDER.id);
+      expect(payload.data.recipientId).toBe(VALID_BODY.recipientId);
+      expect(payload.data.status).toBe('active');
+      expect(payload.data.depositAmount).toBe(VALID_BODY.depositAmount);
+
+      ws.close();
+    },
+    15000
+  );
+
+  it('still returns 201 when no WebSocket clients are subscribed', async () => {
+    const token = makeToken();
+    // Do not force a predetermined id; any uuid is fine when nobody is listening.
+    const res = await request(server)
+      .post('/api/v1/streams')
+      .set('Authorization', `Bearer ${token}`)
+      .set('X-Correlation-Id', 'e2e-correlation-2')
+      .send(VALID_BODY);
+
+    expect(res.status).toBe(201);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.stream.id).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+    );
+  });
+
+  it('reuses the same hub and channel across initStreamRealtime calls', () => {
+    const first = initStreamRealtime();
+    const second = initStreamRealtime();
+    expect(second.hub).toBe(first.hub);
+    expect(second.channel).toBe(first.channel);
+  });
+});


### PR DESCRIPTION
## Description

`WebSocketHub` and `StreamChannel` were fully implemented and covered by isolated unit/integration tests, but the application entrypoint never attached a WebSocket upgrade handler and `createStream` never broadcast lifecycle events. Real clients connecting to the deployed server could not open a WebSocket at all, and successful stream creation produced no real-time notification.

This PR wires the existing realtime stack into the running server and emits a `created` notification after a successful `POST /api/v1/streams`.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Test coverage improvement

## Related Issues

Closes #974

## Changes Made

- **`backend/src/websockets/runtime.ts`** (new): process-wide `initStreamRealtime` / `getStreamChannel` / `getWebSocketHub` / `resetStreamRealtime` so routes can notify without hard DI rewrites. Getters return `null` when uninitialized so isolated route unit tests keep working via optional chaining.
- **`backend/src/ws/attach.ts`** (new): `attachWebSocketHub(server, hub)` binds `ws.Server` on `/ws` with the same `maxPayload` used by existing tests, so production and test wiring cannot drift.
- **`backend/src/index.ts`**: replaces `app.listen` with `http.createServer(app)`, initializes the shared hub/channel, attaches the WebSocket server, and cleans up on `SIGTERM`/`SIGINT`.
- **`backend/src/routes/streams.ts`**: after a successful stream construction, calls `getStreamChannel()?.notifyStreamCreated(streamId, stream)` before returning `201`.
- **`backend/tests/streams-ws.integration.test.ts`** (new): end-to-end proof — authenticated WS client subscribes to a predetermined stream id (via controllable `uuid.v4` mock), `POST /api/v1/streams` creates that stream, client receives `stream_update` with `payload.type === 'created'`. Also covers the no-subscriber happy path and runtime singleton reuse.

## Snapshot Test Changes

### Did this PR modify snapshot test files?

- [ ] Yes - snapshot files were updated (explain below)
- [x] No - no snapshot changes

### If yes, explain why snapshots changed:

N/A — backend TypeScript only; no Soroban snapshot impact.

## Testing

### Test Coverage

- [x] Backend suite passes: `cd backend && npm test` (7 suites, 145 tests)
- [x] TypeScript build passes: `cd backend && npm run build`
- [x] New e2e integration tests added for HTTP create → WS notification
- [x] Existing `ws.test.ts` and `websocket.test.ts` pass unchanged
- [x] Existing `routes/streams.test.ts` pass unchanged (null-safe notify when realtime is not initialized)
- [x] New modules at 100% line coverage: `runtime.ts`, `attach.ts`

### Manual Testing

- [x] Tested locally via integration harness (real `http.Server` + `ws` client)
- [x] Covered edge case: create with zero subscribers still returns 201
- [x] Covered happy path: subscriber receives `created` with matching stream fields

**Edge cases covered:**
- No WebSocket subscribers during create → HTTP 201 still succeeds
- Runtime singleton re-init returns the same hub/channel instances
- Graceful reset clears hub timers/clients for clean process/test shutdown

### How to verify

```bash
cd backend
npm ci
npm test
npm run build
# focused e2e:
npx jest tests/streams-ws.integration.test.ts --runInBand
```

## Notes

- Only `notifyStreamCreated` is wired per the issue requirements. Other `StreamChannel` methods (`updated`, `cancelled`, `withdrawn`, `completed`) remain available for follow-up lifecycle routes.
- WebSocket JWT auth on upgrade and interim per-stream authorization policy are unchanged (already implemented on the hub).
- `src/index.ts` remains excluded from Jest coverage collection (existing package config); wiring is exercised by the shared `attach` + `runtime` modules and the new e2e suite.