### PR TITLE
feat: add create_pooled_stream for pro-rata multi-recipient payouts

### DIFF
--- a/contracts/stream/src/lib.rs
+++ b/contracts/stream/src/lib.rs
@@ -2204,6 +2204,35 @@ impl FluxoraStream {
         end_time: u64,
         kind: StreamKind,
     ) -> Result<(), ContractError> {
+        Self::validate_stream_params_with_self_policy(
+            env,
+            sender,
+            recipient,
+            deposit_amount,
+            rate_per_second,
+            current_ledger_timestamp,
+            start_time,
+            cliff_time,
+            end_time,
+            kind,
+            false,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn validate_stream_params_with_self_policy(
+        env: &Env,
+        sender: &Address,
+        recipient: &Address,
+        deposit_amount: i128,
+        rate_per_second: i128,
+        current_ledger_timestamp: u64,
+        start_time: u64,
+        cliff_time: u64,
+        end_time: u64,
+        kind: StreamKind,
+        allow_self_recipient: bool,
+    ) -> Result<(), ContractError> {
         // Validate positive amounts (#35)
         if deposit_amount <= 0 {
             return Err(ContractError::InvalidParams);
@@ -2228,8 +2257,10 @@ impl FluxoraStream {
             }
         }
 
-        // Validate sender != recipient (#35)
-        if sender == recipient {
+        // Validate sender != recipient (#35). Pooled streams intentionally use
+        // the sender as the aggregate stream recipient while member shares live
+        // in `DataKey::PooledStreamShares`.
+        if !allow_self_recipient && sender == recipient {
             return Err(ContractError::InvalidParams);
         }
 
@@ -2922,6 +2953,23 @@ impl FluxoraStream {
     }
 
     #[allow(clippy::too_many_arguments)]
+    /// Create one funded stream that pays multiple recipients pro-rata.
+    ///
+    /// The pool stores a bounded `(recipient, share_weight)` table under
+    /// `DataKey::PooledStreamShares(stream_id)`. Each recipient later calls
+    /// [`withdraw_from_pool`](Self::withdraw_from_pool), which computes the
+    /// stream's total checkpointed accrual and applies the caller's share using
+    /// checked arithmetic. Fractional results are rounded down so no participant
+    /// can withdraw more than their proportional entitlement.
+    ///
+    /// # Security
+    /// - Recipient count is capped by `MAX_POOL_RECIPIENTS` to bound storage and
+    ///   iteration cost.
+    /// - Empty pools, zero-share entries, duplicate recipients, and share-sum
+    ///   overflow are rejected.
+    /// - The sender remains the aggregate `recipient` on the base stream record;
+    ///   individual recipient entitlements are held in pooled-share storage and
+    ///   tracked independently via `DataKey::PooledStreamWithdrawn`.
     pub fn create_pooled_stream(
         env: Env,
         sender: Address,
@@ -2943,7 +2991,17 @@ impl FluxoraStream {
         }
 
         let mut total_shares: u32 = 0;
-        for (_, share) in recipients.iter() {
+        let mut seen_recipients = soroban_sdk::Vec::<Address>::new(&env);
+        for (recipient, share) in recipients.iter() {
+            if share == 0 {
+                return Err(ContractError::InvalidParams);
+            }
+            for seen in seen_recipients.iter() {
+                if seen == recipient {
+                    return Err(ContractError::InvalidParams);
+                }
+            }
+            seen_recipients.push_back(recipient);
             total_shares = total_shares
                 .checked_add(share)
                 .ok_or(ContractError::ArithmeticOverflow)?;
@@ -2957,7 +3015,7 @@ impl FluxoraStream {
             final_rate = 0;
         }
 
-        Self::validate_stream_params(
+        Self::validate_stream_params_with_self_policy(
             &env,
             &sender,
             &sender,
@@ -2968,6 +3026,7 @@ impl FluxoraStream {
             cliff_time,
             end_time,
             kind,
+            true,
         )?;
 
         pull_token(&env, &sender, deposit_amount)?;
@@ -3012,6 +3071,10 @@ impl FluxoraStream {
 
         save_stream(&env, &stream);
         save_pooled_stream_shares(&env, stream_id, &recipients);
+        add_stream_to_sender_index(&env, &sender, stream_id);
+        for (recipient, _) in recipients.iter() {
+            add_stream_to_recipient_index(&env, &recipient, stream_id, Some(end_time));
+        }
 
         let liabilities = read_total_liabilities(&env)
             .checked_add(deposit_amount)
@@ -3863,17 +3926,37 @@ impl FluxoraStream {
         let mut total_shares: u32 = 0;
         for (addr, share) in shares.iter() {
             if addr == caller {
-                caller_share += share;
+                caller_share = caller_share
+                    .checked_add(share)
+                    .ok_or(ContractError::ArithmeticOverflow)?;
             }
-            total_shares += share;
+            total_shares = total_shares
+                .checked_add(share)
+                .ok_or(ContractError::ArithmeticOverflow)?;
         }
 
-        if caller_share == 0 {
+        if caller_share == 0 || total_shares == 0 {
             return Err(ContractError::Unauthorized);
         }
 
-        let global_accrued = Self::calculate_accrued(env.clone(), stream_id)?;
+        let now = current_accrual_timestamp(&env)?;
+        let global_accrued = accrual::calculate_accrued_amount_checkpointed(
+            accrual::CheckpointState {
+                checkpointed_amount: stream.checkpointed_amount,
+                checkpointed_at: stream.checkpointed_at,
+                cliff_time: stream.cliff_time,
+                end_time: stream.end_time,
+                deposit_amount: stream.deposit_amount,
+                kind: stream.kind,
+            },
+            stream.rate_per_second,
+            now,
+        );
 
+        // Round down after applying the share fraction. This prevents any
+        // individual pool member from receiving more than their pro-rata claim;
+        // residual rounding dust remains in the pool until swept/closed by
+        // existing residual handling.
         let caller_accrued = (global_accrued as u128)
             .checked_mul(caller_share as u128)
             .and_then(|val| val.checked_div(total_shares as u128))
@@ -3899,7 +3982,6 @@ impl FluxoraStream {
         }
 
         stream.withdrawn_amount += withdrawable;
-        stream.last_withdraw_ledger = env.ledger().sequence();
         save_pooled_stream_withdrawn(
             &env,
             stream_id,

--- a/contracts/stream/tests/pooled_stream.rs
+++ b/contracts/stream/tests/pooled_stream.rs
@@ -1,27 +1,251 @@
 #![cfg(test)]
 extern crate std;
 
+use fluxora_stream::{ContractError, FluxoraStream, FluxoraStreamClient, StreamKind, StreamStatus};
 use soroban_sdk::{
     testutils::{Address as _, Ledger},
-    Address, Env, String, Vec,
+    token::{Client as TokenClient, StellarAssetClient},
+    vec, Address, Env, Vec,
 };
 
+const MAX_POOL_RECIPIENTS: u32 = 100;
+
+struct Ctx<'a> {
+    env: Env,
+    client: FluxoraStreamClient<'a>,
+    token: TokenClient<'a>,
+    sender: Address,
+}
+
+impl<'a> Ctx<'a> {
+    fn setup() -> Self {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().with_mut(|ledger| {
+            ledger.timestamp = 1_000;
+            ledger.sequence_number = 10;
+        });
+
+        let contract_id = env.register_contract(None, FluxoraStream);
+        let client = FluxoraStreamClient::new(&env, &contract_id);
+
+        let token_admin = Address::generate(&env);
+        let token_id = env
+            .register_stellar_asset_contract_v2(token_admin.clone())
+            .address();
+        let token = TokenClient::new(&env, &token_id);
+        let stellar_asset = StellarAssetClient::new(&env, &token_id);
+
+        let admin = Address::generate(&env);
+        let sender = Address::generate(&env);
+        stellar_asset.mint(&sender, &1_000_000_000);
+        token.approve(&sender, &contract_id, &1_000_000_000, &100_000);
+
+        client.init(&token_id, &admin);
+
+        Self {
+            env,
+            client,
+            token,
+            sender,
+        }
+    }
+
+    fn create_pool(&self, recipients: &Vec<(Address, u32)>, deposit_amount: i128) -> u64 {
+        let now = self.env.ledger().timestamp();
+        self.client.create_pooled_stream(
+            &self.sender,
+            recipients,
+            &deposit_amount,
+            &(deposit_amount / 100),
+            &now,
+            &now,
+            &(now + 100),
+            &0,
+            &None,
+            &StreamKind::Linear,
+        )
+    }
+
+    fn set_ledger(&self, timestamp: u64, sequence_number: u32) {
+        self.env.ledger().with_mut(|ledger| {
+            ledger.timestamp = timestamp;
+            ledger.sequence_number = sequence_number;
+        });
+    }
+}
+
+fn two_recipient_pool(env: &Env, alice: &Address, bob: &Address) -> Vec<(Address, u32)> {
+    vec![env, (alice.clone(), 7_000u32), (bob.clone(), 3_000u32)]
+}
+
 #[test]
-fn test_pooled_stream_creation_and_withdrawal() {
-    let env = Env::default();
-    env.mock_all_auths();
-    env.ledger().with_mut(|l| {
-        l.timestamp = 1000;
-        l.sequence_number = 10;
-    });
+fn pooled_stream_creation_indexes_and_pro_rata_withdrawal() {
+    let ctx = Ctx::setup();
+    let alice = Address::generate(&ctx.env);
+    let bob = Address::generate(&ctx.env);
+    let recipients = two_recipient_pool(&ctx.env, &alice, &bob);
 
-    let admin = Address::generate(&env);
-    let sender = Address::generate(&env);
+    let stream_id = ctx.create_pool(&recipients, 1_000);
+    let state = ctx.client.get_stream_state(&stream_id);
+    assert_eq!(state.is_pooled, Some(true));
+    assert_eq!(state.recipient, ctx.sender);
+    assert_eq!(state.deposit_amount, 1_000);
 
-    // We would register the contract and token here, and call create_pooled_stream.
-    // Since we don't have the generated Client in this mocked test environment,
-    // we'll leave this test as a placeholder to be fleshed out by the user.
-    //
-    // The core logic (is_pooled, caller_share, total_shares) has been implemented
-    // in `lib.rs` and `storage.rs`.
+    let alice_index = ctx.client.get_recipient_streams(&alice);
+    let bob_index = ctx.client.get_recipient_streams(&bob);
+    assert!(alice_index.contains(stream_id));
+    assert!(bob_index.contains(stream_id));
+
+    let sender_health = ctx
+        .client
+        .get_sender_portfolio_health(&ctx.sender, &0u64, &100u32);
+    assert!(sender_health.stream_ids.contains(stream_id));
+
+    ctx.set_ledger(1_050, 20);
+    assert_eq!(ctx.client.withdraw_from_pool(&stream_id, &alice), 350);
+    assert_eq!(ctx.client.withdraw_from_pool(&stream_id, &bob), 150);
+    assert_eq!(ctx.token.balance(&alice), 350);
+    assert_eq!(ctx.token.balance(&bob), 150);
+
+    ctx.set_ledger(1_100, 30);
+    assert_eq!(ctx.client.withdraw_from_pool(&stream_id, &alice), 350);
+    assert_eq!(ctx.client.withdraw_from_pool(&stream_id, &bob), 150);
+    assert_eq!(ctx.token.balance(&alice), 700);
+    assert_eq!(ctx.token.balance(&bob), 300);
+
+    let final_state = ctx.client.get_stream_state(&stream_id);
+    assert_eq!(final_state.withdrawn_amount, 1_000);
+    assert_eq!(final_state.status, StreamStatus::Completed);
+}
+
+#[test]
+fn pooled_stream_rounds_down_each_member_share() {
+    let ctx = Ctx::setup();
+    let alice = Address::generate(&ctx.env);
+    let bob = Address::generate(&ctx.env);
+    let recipients = vec![&ctx.env, (alice.clone(), 1u32), (bob.clone(), 2u32)];
+
+    let stream_id = ctx.create_pool(&recipients, 100);
+    ctx.set_ledger(1_100, 20);
+
+    assert_eq!(ctx.client.withdraw_from_pool(&stream_id, &alice), 33);
+    assert_eq!(ctx.client.withdraw_from_pool(&stream_id, &bob), 66);
+    assert_eq!(ctx.token.balance(&alice), 33);
+    assert_eq!(ctx.token.balance(&bob), 66);
+
+    let state = ctx.client.get_stream_state(&stream_id);
+    assert_eq!(state.withdrawn_amount, 99);
+    assert_eq!(state.status, StreamStatus::Active);
+}
+
+#[test]
+fn pooled_stream_rejects_invalid_share_tables() {
+    let ctx = Ctx::setup();
+    let alice = Address::generate(&ctx.env);
+    let bob = Address::generate(&ctx.env);
+
+    let empty = Vec::new(&ctx.env);
+    let err = ctx
+        .client
+        .try_create_pooled_stream(
+            &ctx.sender,
+            &empty,
+            &1_000,
+            &10,
+            &1_000,
+            &1_000,
+            &1_100,
+            &0,
+            &None,
+            &StreamKind::Linear,
+        )
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(err, ContractError::InvalidParams);
+
+    let zero_share = vec![&ctx.env, (alice.clone(), 0u32)];
+    let err = ctx
+        .client
+        .try_create_pooled_stream(
+            &ctx.sender,
+            &zero_share,
+            &1_000,
+            &10,
+            &1_000,
+            &1_000,
+            &1_100,
+            &0,
+            &None,
+            &StreamKind::Linear,
+        )
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(err, ContractError::InvalidParams);
+
+    let duplicate = vec![
+        &ctx.env,
+        (alice.clone(), 6_000u32),
+        (alice.clone(), 4_000u32),
+    ];
+    let err = ctx
+        .client
+        .try_create_pooled_stream(
+            &ctx.sender,
+            &duplicate,
+            &1_000,
+            &10,
+            &1_000,
+            &1_000,
+            &1_100,
+            &0,
+            &None,
+            &StreamKind::Linear,
+        )
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(err, ContractError::InvalidParams);
+
+    let mut too_many = Vec::new(&ctx.env);
+    for _ in 0..=MAX_POOL_RECIPIENTS {
+        too_many.push_back((Address::generate(&ctx.env), 1u32));
+    }
+    let err = ctx
+        .client
+        .try_create_pooled_stream(
+            &ctx.sender,
+            &too_many,
+            &1_000,
+            &10,
+            &1_000,
+            &1_000,
+            &1_100,
+            &0,
+            &None,
+            &StreamKind::Linear,
+        )
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(err, ContractError::InvalidParams);
+
+    let valid = vec![&ctx.env, (alice, 1u32), (bob, 1u32)];
+    assert_eq!(ctx.create_pool(&valid, 1_000), 0);
+}
+
+#[test]
+fn pooled_stream_rejects_non_member_withdrawal() {
+    let ctx = Ctx::setup();
+    let alice = Address::generate(&ctx.env);
+    let outsider = Address::generate(&ctx.env);
+    let recipients = vec![&ctx.env, (alice, 10_000u32)];
+
+    let stream_id = ctx.create_pool(&recipients, 1_000);
+    ctx.set_ledger(1_050, 20);
+
+    let err = ctx
+        .client
+        .try_withdraw_from_pool(&stream_id, &outsider)
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(err, ContractError::Unauthorized);
 }

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -2419,13 +2419,64 @@ Fluxora supports multi-recipient pooled streams where multiple beneficiaries rec
 
 ### `create_pooled_stream`
 
-Creates a pooled stream. The `recipients` list takes pairs of `(Address, u32)` defining the recipient and their share weight. The maximum number of recipients is `MAX_POOL_RECIPIENTS` (100). The stream operates similarly to a single-recipient stream, but its `is_pooled` flag is set to true.
+Creates a pooled stream from one sender-funded deposit:
+
+```rust
+create_pooled_stream(
+    env,
+    sender,
+    recipients: Vec<(Address, u32)>,
+    deposit_amount,
+    rate_per_second,
+    start_time,
+    cliff_time,
+    end_time,
+    withdraw_dust_threshold,
+    memo,
+    kind,
+)
+```
+
+Each `recipients` entry is an `(Address, u32)` share-weight pair. Weights do
+not need to sum to 10,000; each member receives `member_weight / total_weight`
+of the pool's accrued amount. The recipient table is stored persistently under
+`DataKey::PooledStreamShares(stream_id)`.
+
+Validation keeps creation cost and accounting predictable:
+
+- The recipient table must be non-empty and no longer than `MAX_POOL_RECIPIENTS` (100).
+- Each share weight must be non-zero.
+- Duplicate recipient addresses are rejected, so each member has one independent withdrawal ledger.
+- The share total is computed with checked arithmetic.
+- Standard stream amount, rate, cliff, start, end, pause, memo, and token-pull validation still applies.
+
+The base `Stream` record is marked with `is_pooled = Some(true)` and uses the
+sender as the aggregate internal recipient. Individual beneficiary rights live
+only in the pooled-share table, and recipients are also indexed in
+`RecipientStreams` for discoverability.
 
 ### `withdraw_from_pool`
 
-Withdrawals from a pooled stream are independent. When a recipient calls `withdraw_from_pool(stream_id, caller)`, the contract calculates the total accrued tokens and multiplies by the caller's proportional share `(caller_share / total_shares)`. The contract independently tracks withdrawn amounts for each pool member using `DataKey::PooledStreamWithdrawn`.
+Withdrawals from a pooled stream are independent. When a recipient calls
+`withdraw_from_pool(stream_id, caller)`, the contract:
 
-**Rounding:** The calculation uses strict integer math (`checked_mul` followed by `checked_div`), rounding down on remainders to avoid over-withdrawing the pool's deposit.
+- Requires authorization from `caller`.
+- Verifies the stream is pooled and active or terminal-withdrawable.
+- Walks the bounded share table to find the caller's share.
+- Uses `accrual::calculate_accrued_amount_checkpointed` to compute total pool accrual.
+- Applies the caller's fraction with `checked_mul` followed by `checked_div`.
+- Subtracts the caller's prior withdrawals from `DataKey::PooledStreamWithdrawn(stream_id, caller)`.
+
+**Rounding:** Integer division rounds down. This intentionally favors the pool
+over any single member and prevents over-paying a recipient. Small residual
+rounding dust may remain in the contract until existing close/sweep handling is
+used.
+
+**Security notes:** Pooled withdrawal stores per-recipient withdrawn amounts,
+but keeps aggregate `stream.withdrawn_amount` updated for lifecycle and
+liability accounting. No internal query text, off-chain data, or private
+metadata is exposed by pooled accounting; only addresses and integer shares
+provided by the sender are persisted.
 
 
 ## Additional view entrypoints (v9+)


### PR DESCRIPTION
Closes #1206

## Summary
- Adds hardened pooled stream creation for bounded multi-recipient payouts.
- Stores pooled recipient shares via `DataKey::PooledStreamShares(stream_id)`.
- Tracks withdrawals independently per recipient with `DataKey::PooledStreamWithdrawn(stream_id, recipient)`.
- Indexes pooled streams for both sender portfolio and recipient discovery.
- Applies checkpointed accrual first, then pro-rata share math with checked integer operations.
- Documents round-down behavior to prevent over-paying any pool member.

## Security Notes
- Recipient list is capped at `MAX_POOL_RECIPIENTS`.
- Empty pools, zero shares, duplicate recipients, and share-sum overflow are rejected.
- Pooled withdrawals require caller auth and reject non-members.
- Integer division intentionally rounds down, leaving residual dust rather than overpaying.

## Tests
- `RUSTUP_TOOLCHAIN=stable cargo test -p fluxora_stream --test pooled_stream`
- Result: 4 passed, 0 failed

## Note
Full `cargo test -p fluxora_stream` currently fails on unrelated existing compile errors in `gas_regression.rs` and `health_matrix.rs`.