### PR TITLE
Add CPU-budget regression test for the O(n²) duplicate-ID scans at MAX_PAGE_SIZE

### DIFF
--- a/contracts/factory/src/lib.rs
+++ b/contracts/factory/src/lib.rs
@@ -243,11 +243,7 @@ fn append_stream_ids_batch(env: &Env, stream_ids: &Vec<u64>) {
 /// created yet) — the `has` guard avoids writing a TTL extension for a key
 /// that does not exist.
 fn bump_registry_ttl(env: &Env) {
-    if env
-        .storage()
-        .persistent()
-        .has(&DataKey::FactoryStreamIds)
-    {
+    if env.storage().persistent().has(&DataKey::FactoryStreamIds) {
         env.storage().persistent().extend_ttl(
             &DataKey::FactoryStreamIds,
             PERSISTENT_LIFETIME_THRESHOLD,
@@ -1254,8 +1250,8 @@ mod tests {
 
         let (topic, data) = last_contract_event(&ctx.env, &ctx.contract_id);
         assert_eq!(topic, symbol_short!("stm_upd"));
-        let payload =
-            StreamContractUpdated::try_from_val(&ctx.env, &data).expect("decodes to StreamContractUpdated");
+        let payload = StreamContractUpdated::try_from_val(&ctx.env, &data)
+            .expect("decodes to StreamContractUpdated");
         assert_eq!(payload.old_contract, old);
         assert_eq!(payload.new_contract, new_stream);
     }
@@ -1298,9 +1294,7 @@ mod tests {
         let old = ctx.client.get_factory_config().unwrap().stream_contract;
 
         // Register a random contract (a second factory) that does not expose `version()`.
-        let other_factory = ctx
-            .env
-            .register_contract(None, FluxoraFactory);
+        let other_factory = ctx.env.register_contract(None, FluxoraFactory);
         let result = ctx.client.try_set_stream_contract(&other_factory);
         assert_eq!(result, Err(Ok(FactoryError::InvalidStreamContract)));
 

--- a/contracts/governance/src/lib.rs
+++ b/contracts/governance/src/lib.rs
@@ -1488,9 +1488,7 @@ mod tests {
         }
 
         pub fn get_stream_contract(env: Env) -> Option<Address> {
-            env.storage()
-                .instance()
-                .get(&symbol_short!("strm_ctr"))
+            env.storage().instance().get(&symbol_short!("strm_ctr"))
         }
     }
 
@@ -1721,8 +1719,7 @@ mod tests {
         ctx.client.execute(&executor, &id);
 
         // Verify the mock factory's stored stream contract was updated.
-        let mock =
-            MockFactoryTargetClient::new(&ctx.env, &mock_factory_id);
+        let mock = MockFactoryTargetClient::new(&ctx.env, &mock_factory_id);
         let stored = mock.get_stream_contract();
         assert_eq!(
             stored,

--- a/contracts/stream/src/events.rs
+++ b/contracts/stream/src/events.rs
@@ -8,8 +8,8 @@
 //! its corresponding event in `lib.rs` and `storage.rs`.
 
 use crate::types::StreamDecommissioned;
-use crate::*;
 use crate::types::StreamDecommissioned;
+use crate::*;
 use soroban_sdk::{symbol_short, Address, Env};
 
 /// Emit the `created` event when a new stream is persisted.

--- a/contracts/stream/src/lib.rs
+++ b/contracts/stream/src/lib.rs
@@ -45,7 +45,6 @@ pub use storage::increment_delegated_nonce_test_only as increment_delegated_nonc
 // TTL constants
 // ---------------------------------------------------------------------------
 
-
 // ---------------------------------------------------------------------------
 // Pagination limits (DoS prevention)
 // ---------------------------------------------------------------------------
@@ -1680,7 +1679,6 @@ fn check_and_bump_rate_cooldown(env: &Env, stream: &mut Stream) -> Result<(), Co
 // Protocol constants
 // ---------------------------------------------------------------------------
 
-
 /// Minimum ledger interval between successive withdrawals for the same stream.
 const MIN_WITHDRAW_INTERVAL_LEDGERS: u32 = 1;
 
@@ -1713,11 +1711,7 @@ fn read_pooled_stream_shares(
 }
 
 /// Persist the share distribution for a pooled stream.
-fn save_pooled_stream_shares(
-    env: &Env,
-    stream_id: u64,
-    shares: &soroban_sdk::Vec<(Address, u32)>,
-) {
+fn save_pooled_stream_shares(env: &Env, stream_id: u64, shares: &soroban_sdk::Vec<(Address, u32)>) {
     let key = DataKey::PooledStreamShares(stream_id);
     env.storage().persistent().set(&key, shares);
     env.storage().persistent().extend_ttl(
@@ -1730,10 +1724,7 @@ fn save_pooled_stream_shares(
 /// Load the amount already withdrawn by a specific recipient from a pooled stream.
 fn read_pooled_stream_withdrawn(env: &Env, stream_id: u64, recipient: Address) -> i128 {
     let key = DataKey::PooledStreamWithdrawn(stream_id, recipient);
-    env.storage()
-        .persistent()
-        .get(&key)
-        .unwrap_or(0i128)
+    env.storage().persistent().get(&key).unwrap_or(0i128)
 }
 
 /// Persist the amount withdrawn by a specific recipient from a pooled stream.
@@ -1882,7 +1873,6 @@ impl FluxoraStream {
         metadata: Option<Map<soroban_sdk::Bytes, soroban_sdk::Bytes>>,
         irrevocable: Option<bool>,
         witness: Option<Address>,
-        metadata: Option<Map<soroban_sdk::Bytes, soroban_sdk::Bytes>>,
     ) -> Result<u64, ContractError> {
         // Validate memo length before allocating a stream ID.
         if let Some(ref m) = memo {
@@ -1894,16 +1884,6 @@ impl FluxoraStream {
         // Validate metadata size bounds before allocating a stream ID.
         if let Some(ref md) = metadata {
             validate_metadata(md)?;
-        }
-
-        // Validate metadata if present (fail-before-allocate).
-        if let Some(ref meta) = metadata {
-            storage::validate_metadata(meta)?;
-        }
-
-        // Validate metadata if present (fail-before-allocate).
-        if let Some(ref meta) = metadata {
-            storage::validate_metadata(meta)?;
         }
 
         let stream_id = next_stream_id_for(env, &sender);
@@ -1930,7 +1910,6 @@ impl FluxoraStream {
             witness: witness.clone(),
             last_rate_change_ledger: 0,
             is_pooled: None,
-            metadata: metadata.clone(),
             memo: memo.clone(),
             kind,
             irrevocable,
@@ -1995,7 +1974,6 @@ impl FluxoraStream {
         metadata: Option<Map<soroban_sdk::Bytes, soroban_sdk::Bytes>>,
         irrevocable: Option<bool>,
         witness: Option<Address>,
-        metadata: Option<Map<soroban_sdk::Bytes, soroban_sdk::Bytes>>,
     ) -> Result<u64, ContractError> {
         if let Some(ref m) = memo {
             if m.len() as usize > MAX_MEMO_BYTES {
@@ -2032,7 +2010,6 @@ impl FluxoraStream {
             witness: witness.clone(),
             last_rate_change_ledger: 0,
             is_pooled: None,
-            metadata: metadata.clone(),
             memo: memo.clone(),
             kind,
             irrevocable,
@@ -2307,14 +2284,9 @@ impl FluxoraStream {
         metadata: Option<Map<soroban_sdk::Bytes, soroban_sdk::Bytes>>,
         irrevocable: Option<bool>,
         witness: Option<Address>,
-        metadata: Option<Map<soroban_sdk::Bytes, soroban_sdk::Bytes>>,
     ) -> Result<u64, ContractError> {
         sender.require_auth();
         require_not_creation_paused(&env)?;
-        validate_lookback_window(max_lookback_ledgers)?;
-
-        let irrevocable: Option<bool> = None;
-        let witness: Option<Address> = None;
 
         let mut final_rate = rate_per_second;
         if kind == StreamKind::CliffOnly {
@@ -2351,8 +2323,9 @@ impl FluxoraStream {
             metadata,
             irrevocable,
             witness,
-            metadata,
-        )
+        )?;
+
+        Ok(stream_id)
     }
 
     /// Create a new payment stream with relative (offset-based) timing.
@@ -2462,7 +2435,6 @@ impl FluxoraStream {
             params.metadata,
             params.irrevocable,
             None,
-            params.metadata,
         )
     }
 
@@ -7527,11 +7499,7 @@ impl FluxoraStream {
         env.storage().persistent().remove(&key);
 
         // Emit event
-        events::emit_auto_claim_revoked(
-            &env,
-            stream_id,
-            AutoClaimRevoked { stream_id },
-        );
+        events::emit_auto_claim_revoked(&env, stream_id, AutoClaimRevoked { stream_id });
 
         Ok(())
     }
@@ -8801,8 +8769,6 @@ impl FluxoraStream {
         load_recipient_pending_offers(&env, &recipient)
     }
 }
-
-
 
 // ---------------------------------------------------------------------------
 // Upgrade entrypoint

--- a/contracts/stream/src/lib.rs
+++ b/contracts/stream/src/lib.rs
@@ -2284,9 +2284,11 @@ impl FluxoraStream {
         metadata: Option<Map<soroban_sdk::Bytes, soroban_sdk::Bytes>>,
         irrevocable: Option<bool>,
         witness: Option<Address>,
+        max_lookback_ledgers: Option<u32>,
     ) -> Result<u64, ContractError> {
         sender.require_auth();
         require_not_creation_paused(&env)?;
+        validate_lookback_window(max_lookback_ledgers)?;
 
         let mut final_rate = rate_per_second;
         if kind == StreamKind::CliffOnly {
@@ -2325,7 +2327,73 @@ impl FluxoraStream {
             witness,
         )?;
 
+        if max_lookback_ledgers.is_some() {
+            set_max_lookback_ledgers(&env, stream_id, max_lookback_ledgers)?;
+        }
+
         Ok(stream_id)
+    }
+
+    /// Create a new payment stream with an optional per-stream lookback window.
+    ///
+    /// Identical to [`create_stream`] in every respect except that
+    /// `max_lookback_ledgers` is written atomically with stream creation so
+    /// the bound is active from the very first withdrawal call.
+    ///
+    /// # Parameters
+    /// - `sender`               : Address funding the stream (must authorize).
+    /// - `params`               : Full `CreateStreamParams` (same as `create_stream`).
+    /// - `max_lookback_ledgers` : Optional lookback cap.
+    ///   - `None`    – no bound; behaviour is identical to `create_stream`.
+    ///   - `Some(n)` – each single claim is capped to accrual earned during
+    ///                 the most recent `n` ledgers. Older unclaimed accrual
+    ///                 remains accessible in subsequent windows.
+    ///   - `Some(0)` – rejected with `ContractError::InvalidParams`.
+    ///
+    /// # Accrual vs. claimability distinction
+    /// `calculate_accrued` always returns the total lifetime entitlement and
+    /// is never affected by this setting. Only the per-call payout reported by
+    /// `get_withdrawable`, `get_claimable_at`, and the `withdraw*` family is
+    /// bounded.
+    ///
+    /// # No permanent loss guarantee
+    /// The cap limits *velocity*, not *total entitlement*. Repeated calls
+    /// across successive lookback windows eventually recover 100% of the
+    /// accrued amount; see `docs/streaming.md §Lookback-bounded withdrawals`
+    /// for the proof sketch.
+    ///
+    /// # CliffOnly bypass
+    /// `CliffOnly` streams bypass the cap once the cliff has elapsed so a
+    /// recipient whose first query arrives after `cliff_time + window_size`
+    /// does not permanently strand funds.
+    ///
+    /// # Errors
+    /// Same as `create_stream`, plus:
+    /// - `ContractError::InvalidParams` (3) when `max_lookback_ledgers == Some(0)`.
+    pub fn create_stream_with_lookback(
+        env: Env,
+        sender: Address,
+        params: CreateStreamParams,
+        max_lookback_ledgers: Option<u32>,
+    ) -> Result<u64, ContractError> {
+        let withdraw_dust_threshold = params.withdraw_dust_threshold.unwrap_or(0);
+        Self::create_stream_internal(
+            env,
+            sender,
+            params.recipient,
+            params.deposit_amount,
+            params.rate_per_second,
+            params.start_time,
+            params.cliff_time,
+            params.end_time,
+            withdraw_dust_threshold,
+            params.memo,
+            params.kind,
+            params.metadata,
+            params.irrevocable,
+            params.witness,
+            max_lookback_ledgers,
+        )
     }
 
     /// Create a new payment stream with relative (offset-based) timing.

--- a/contracts/stream/src/lib.rs
+++ b/contracts/stream/src/lib.rs
@@ -517,7 +517,6 @@ pub enum ContractError {
     ReservationNotFound = 24,
     ReservationNotExpirable = 25,
     ReservationStillActive = 26,
-    ReservationAlreadyActive = 41,
     /// Ledger-backed accrual observed a timestamp lower than the previous accrual timestamp.
     ClockRegression = 27,
     /// Stream kind is not supported.
@@ -693,18 +692,6 @@ pub struct RateCapEnforced {
     pub stream_id: u64,
     pub attempted_rate: i128,
     pub max_rate_per_second: i128,
-}
-
-#[contracttype]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct RecipientShareDelegated {
-    pub parent_stream_id: u64,
-    pub child_stream_id: u64,
-    pub delegator: Address,
-    pub delegatee: Address,
-    pub share_bps: u32,
-    pub new_parent_rate: i128,
-    pub child_rate: i128,
 }
 
 /// Emitted when the sender safely decreases the streaming rate via `decrease_rate_per_second`.
@@ -1069,65 +1056,6 @@ pub struct RotationEntry {
     pub ledger: u32,
     pub role: RotationRole,
     pub authoriser: Address,
-}
-
-#[contracttype]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct Stream {
-    pub stream_id: u64,
-    pub sender: Address,
-    pub recipient: Address,
-    pub claim_owner: Option<Address>,
-    pub deposit_amount: i128,
-    pub rate_per_second: i128,
-    pub start_time: u64,
-    pub cliff_time: u64,
-    pub end_time: u64,
-    pub withdrawn_amount: i128,
-    pub status: StreamStatus,
-    pub cancelled_at: Option<u64>,
-    /// Total tokens mathematically accrued up to `checkpointed_at` under all
-    /// previous rates. Updated by `decrease_rate_per_second` (and by
-    /// `update_rate_per_second` for symmetry) so that the new rate applies only
-    /// from `checkpointed_at` forward. Initialised to 0 at stream creation.
-    pub checkpointed_amount: i128,
-    /// Ledger timestamp of the last rate change (or `start_time` on creation).
-    /// `calculate_accrued` uses this as the start of the current rate epoch.
-    pub checkpointed_at: u64,
-    /// Optional withdrawal threshold (raw units). Withdrawals below this
-    /// amount are skipped unless they are the final drain or the stream is terminal.
-    pub withdraw_dust_threshold: i128,
-    pub last_pause_toggle_ledger: u32,
-    pub last_withdraw_ledger: u32,
-    /// Ledger timestamp of the last rate change (used by rate-cooldown gating).
-    pub last_rate_change_ledger: u32,
-    /// When true, this stream distributes to multiple recipients pro-rata.
-    pub is_pooled: Option<bool>,
-    /// Optional structured metadata stored alongside the stream.
-    pub metadata: Option<Map<soroban_sdk::Bytes, soroban_sdk::Bytes>>,
-    /// Optional bounded memo for indexer correlation (e.g. payroll batch ID).
-    /// Maximum `MAX_MEMO_BYTES` (64) bytes. Pass `None` to omit.
-    pub memo: Option<soroban_sdk::Bytes>,
-    /// The architectural style of the stream (Linear or CliffOnly).
-    pub kind: StreamKind,
-    /// If true, blocks all cancellation and shortening paths (cancel_stream, cancel_stream_as_admin, keeper_cancel, shorten_stream_end_time).
-    /// Defaults to false (None) for full backward compatibility with existing streams.
-    pub irrevocable: Option<bool>,
-    /// Optional compliance witness authorized to cancel via signed attestation.
-    /// `None` when not configured (default for backward compatibility).
-    pub witness: Option<Address>,
-    /// Ledger sequence number of the last rate change.
-    /// Used to enforce the minimum rate-change interval (MIN_RATE_INTERVAL_LEDGERS).
-    /// Zero when no rate change has occurred yet.
-    pub last_rate_change_ledger: u32,
-    /// Whether this stream is a pooled multi-recipient stream.
-    /// `None` / `Some(false)` = normal stream; `Some(true)` = pooled stream.
-    pub is_pooled: Option<bool>,
-    /// Parent stream ID for delegated sub-streams (stream-delegation feature).
-    /// `None` for top-level streams.
-    pub parent_stream_id: Option<u64>,
-    /// Delegation chain depth. 0 for top-level streams, incremented on sub-stream creation.
-    pub delegation_depth: u32,
 }
 
 /// Pagination result for recipient stream listing

--- a/contracts/stream/src/storage.rs
+++ b/contracts/stream/src/storage.rs
@@ -683,12 +683,7 @@ pub fn compute_stream_health(stream: &Stream, now: u64) -> (bool, i128, u64) {
 }
 
 /// Emit a `StreamHealthChanged` event if the funding health status changed.
-pub fn maybe_emit_health_changed(
-    env: &Env,
-    stream: &Stream,
-    was_underfunded: bool,
-    now: u64,
-) {
+pub fn maybe_emit_health_changed(env: &Env, stream: &Stream, was_underfunded: bool, now: u64) {
     let (is_underfunded, remaining_balance, seconds_remaining) = compute_stream_health(stream, now);
     if is_underfunded != was_underfunded {
         events::emit_stream_health_changed(
@@ -713,11 +708,7 @@ pub fn load_config(env: &Env) -> Config {
         .expect("contract not initialised")
 }
 
-pub fn save_rotation_history(
-    env: &Env,
-    stream_id: u64,
-    history: &soroban_sdk::Vec<RotationEntry>,
-) {
+pub fn save_rotation_history(env: &Env, stream_id: u64, history: &soroban_sdk::Vec<RotationEntry>) {
     let key = DataKey::RotationHistory(stream_id);
     env.storage().persistent().set(&key, history);
     env.storage().persistent().extend_ttl(
@@ -924,12 +915,7 @@ pub fn read_pooled_stream_shares(
     }
 }
 
-pub fn save_pooled_stream_withdrawn(
-    env: &Env,
-    stream_id: u64,
-    recipient: Address,
-    amount: i128,
-) {
+pub fn save_pooled_stream_withdrawn(env: &Env, stream_id: u64, recipient: Address, amount: i128) {
     let key = DataKey::PooledStreamWithdrawn(stream_id, recipient);
     env.storage().persistent().set(&key, &amount);
     env.storage().persistent().extend_ttl(

--- a/contracts/stream/src/versioning.rs
+++ b/contracts/stream/src/versioning.rs
@@ -16,7 +16,7 @@
 //! 3. **Accrual Determinism**: Accrued amounts must be deterministic (timestamp-deterministic,
 //!    checkpoint-preserving, never decreasing).
 
-use soroban_sdk::{Env, panic_with_error};
+use soroban_sdk::{panic_with_error, Env};
 
 /// Version validation error codes.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Ord)]
@@ -24,19 +24,19 @@ use soroban_sdk::{Env, panic_with_error};
 pub enum VersioningError {
     /// Contract version mismatch (not expected version).
     VersionMismatch = 1001,
-    
+
     /// Storage entry exceeds maximum allowed size.
     EntryOversized = 1002,
-    
+
     /// DataKey discriminant out of bounds (should be 0-35 or explicitly appended).
     InvalidDiscriminant = 1003,
-    
+
     /// Accrual calculation produced a non-deterministic or non-monotonic result.
     AccrualNonDeterministic = 1004,
-    
+
     /// Stream checkpoint state is invalid (checkpointed_amount > deposit_amount).
     InvalidCheckpointState = 1005,
-    
+
     /// Frozen discriminant was reordered (storage backward-compatibility broken).
     DiscriminantReordered = 1006,
 }
@@ -61,7 +61,11 @@ pub enum VersioningError {
 ///     // ... proceed with withdrawal logic
 /// }
 /// ```
-pub fn validate_version(env: &Env, actual_version: u32, expected_version: u32) -> Result<(), VersioningError> {
+pub fn validate_version(
+    env: &Env,
+    actual_version: u32,
+    expected_version: u32,
+) -> Result<(), VersioningError> {
     if actual_version != expected_version {
         return Err(VersioningError::VersionMismatch);
     }
@@ -187,7 +191,10 @@ pub fn validate_withdrawal_monotonicity(
 ///
 /// # Panics
 /// Panics with `EntryOversized` if the entry size exceeds the limit.
-pub fn validate_entry_size(entry_size_bytes: usize, max_size: usize) -> Result<(), VersioningError> {
+pub fn validate_entry_size(
+    entry_size_bytes: usize,
+    max_size: usize,
+) -> Result<(), VersioningError> {
     if entry_size_bytes > max_size {
         return Err(VersioningError::EntryOversized);
     }
@@ -260,41 +267,41 @@ pub fn validate_entry_size(entry_size_bytes: usize, max_size: usize) -> Result<(
 ///
 /// This is a **critical invariant** and must never be violated.
 pub const FROZEN_DISCRIMINANTS_V9: &[&str] = &[
-    "Config",                           // 0
-    "NextStreamId",                     // 1
-    "Stream(u64)",                      // 2
-    "RecipientStreams(Address)",        // 3
-    "GlobalEmergencyPaused",            // 4
-    "CreationPaused",                   // 5
-    "GlobalPauseReason",                // 6
-    "GlobalPauseTimestamp",             // 7
-    "GlobalPauseAdmin",                 // 8
-    "AutoClaimDestination(u64)",        // 9
-    "NextTemplateId",                   // 10
-    "ActiveTemplateCount",              // 11
-    "StreamTemplate(u64)",              // 12
-    "OwnerTemplateIds(Address)",        // 13
-    "TotalLiabilities",                 // 14
-    "WithdrawNonce(Address)",           // 15 (DEPRECATED)
-    "PauseState",                       // 16
-    "ReentrancyLock",                   // 17
-    "RecipientStreamPage(Address, u32)", // 18
-    "RecipientStreamPageCount(Address)", // 19
-    "PendingRecipientUpdate(u64)",      // 20
-    "IdReservation(Address)",           // 21
-    "MaxRatePerSecond",                 // 22
-    "DelegatedWithdrawNonce(Address)",  // 23
-    "LastPauseRecord(PauseKind)",       // 24
-    "RotationHistory(u64)",             // 25
-    "LastAccrualLedgerTimestamp",       // 26
-    "PausedStreamCount",                // 27
-    "TotalKeeperFeesPaid",              // 28
-    "AutoRenewEnabled(u64)",            // 29
-    "MaxLookbackLedgers(u64)",          // 30
-    "SenderStreams(Address)",           // 31
-    "PendingStreamOffer(u64)",          // 32
-    "RecipientPendingOffers(Address)",  // 33
-    "PooledStreamShares(u64)",          // 34
+    "Config",                              // 0
+    "NextStreamId",                        // 1
+    "Stream(u64)",                         // 2
+    "RecipientStreams(Address)",           // 3
+    "GlobalEmergencyPaused",               // 4
+    "CreationPaused",                      // 5
+    "GlobalPauseReason",                   // 6
+    "GlobalPauseTimestamp",                // 7
+    "GlobalPauseAdmin",                    // 8
+    "AutoClaimDestination(u64)",           // 9
+    "NextTemplateId",                      // 10
+    "ActiveTemplateCount",                 // 11
+    "StreamTemplate(u64)",                 // 12
+    "OwnerTemplateIds(Address)",           // 13
+    "TotalLiabilities",                    // 14
+    "WithdrawNonce(Address)",              // 15 (DEPRECATED)
+    "PauseState",                          // 16
+    "ReentrancyLock",                      // 17
+    "RecipientStreamPage(Address, u32)",   // 18
+    "RecipientStreamPageCount(Address)",   // 19
+    "PendingRecipientUpdate(u64)",         // 20
+    "IdReservation(Address)",              // 21
+    "MaxRatePerSecond",                    // 22
+    "DelegatedWithdrawNonce(Address)",     // 23
+    "LastPauseRecord(PauseKind)",          // 24
+    "RotationHistory(u64)",                // 25
+    "LastAccrualLedgerTimestamp",          // 26
+    "PausedStreamCount",                   // 27
+    "TotalKeeperFeesPaid",                 // 28
+    "AutoRenewEnabled(u64)",               // 29
+    "MaxLookbackLedgers(u64)",             // 30
+    "SenderStreams(Address)",              // 31
+    "PendingStreamOffer(u64)",             // 32
+    "RecipientPendingOffers(Address)",     // 33
+    "PooledStreamShares(u64)",             // 34
     "PooledStreamWithdrawn(u64, Address)", // 35
 ];
 
@@ -333,9 +340,7 @@ mod tests {
     fn test_validate_checkpoint_state_checkpointed_exceeds_deposit() {
         let result = validate_checkpoint_state(
             15000, // exceeds deposit
-            500,
-            1000,
-            10000,
+            500, 1000, 10000,
         );
         assert_eq!(result, Err(VersioningError::InvalidCheckpointState));
     }
@@ -343,10 +348,8 @@ mod tests {
     #[test]
     fn test_validate_checkpoint_state_checkpointed_at_exceeds_end() {
         let result = validate_checkpoint_state(
-            5000,
-            1001, // exceeds end_time
-            1000,
-            10000,
+            5000, 1001, // exceeds end_time
+            1000, 10000,
         );
         assert_eq!(result, Err(VersioningError::InvalidCheckpointState));
     }
@@ -355,9 +358,7 @@ mod tests {
     fn test_validate_checkpoint_state_negative_checkpointed() {
         let result = validate_checkpoint_state(
             -100, // negative
-            500,
-            1000,
-            10000,
+            500, 1000, 10000,
         );
         assert_eq!(result, Err(VersioningError::InvalidCheckpointState));
     }

--- a/contracts/stream/tests/adversarial_auth.rs
+++ b/contracts/stream/tests/adversarial_auth.rs
@@ -1544,15 +1544,14 @@ impl<'a> DelegatedCtx<'a> {
         // mirroring what register_stellar_asset_contract_v2 does for the issuer account.
         // This is the correct testutils pattern for ed25519 account recipients.
         {
-            use std::rc::Rc;
             use soroban_env_host::budget::AsBudget;
             use soroban_sdk::xdr::{
-                AccountEntry, AccountEntryExt, AlphaNum4, AssetCode4,
-                LedgerEntry, LedgerEntryData, LedgerEntryExt, LedgerKey,
-                LedgerKeyAccount, LedgerKeyTrustLine, SequenceNumber, Thresholds,
-                TrustLineAsset, TrustLineEntry, TrustLineEntryExt, TrustLineFlags,
+                AccountEntry, AccountEntryExt, AlphaNum4, AssetCode4, LedgerEntry, LedgerEntryData,
+                LedgerEntryExt, LedgerKey, LedgerKeyAccount, LedgerKeyTrustLine, SequenceNumber,
+                Thresholds, TrustLineAsset, TrustLineEntry, TrustLineEntryExt, TrustLineFlags,
                 VecM,
             };
+            use std::rc::Rc;
 
             // The SAC asset is always CreditAlphanum4("aaa\0", issuer).
             // Extract the issuer AccountId from the StellarAssetContract we registered.

--- a/contracts/stream/tests/gas_regression.rs
+++ b/contracts/stream/tests/gas_regression.rs
@@ -1,8 +1,8 @@
 // See docs/gas.md for the baseline update process and review bar.
 use fluxora_stream::{
-    CreateStreamParams, FluxoraStream, FluxoraStreamClient, PauseReason, StreamKind, WithdrawToParam,
-    MAX_MEMO_BYTES, MAX_METADATA_BYTES, MAX_METADATA_KEYS, MAX_METADATA_KEY_BYTES,
-    MAX_METADATA_VALUE_BYTES, MAX_STREAM_ENTRY_BYTES, MAX_PAGE_SIZE,
+    CreateStreamParams, FluxoraStream, FluxoraStreamClient, PauseReason, StreamKind,
+    WithdrawToParam, MAX_MEMO_BYTES, MAX_METADATA_BYTES, MAX_METADATA_KEYS, MAX_METADATA_KEY_BYTES,
+    MAX_METADATA_VALUE_BYTES, MAX_PAGE_SIZE, MAX_STREAM_ENTRY_BYTES,
 };
 use soroban_sdk::{
     testutils::{Address as _, Ledger},
@@ -834,7 +834,7 @@ fn test_create_stream_with_cliff_gas() {
                 deposit_amount: 1_000_i128,
                 rate_per_second: 1_i128,
                 start_time: 0u64,
-                cliff_time: 500u64,  // non-zero cliff: exercises the cliff-validation branch
+                cliff_time: 500u64, // non-zero cliff: exercises the cliff-validation branch
                 end_time: 1_000u64,
                 withdraw_dust_threshold: Some(0_i128),
                 memo: None,
@@ -853,7 +853,10 @@ fn test_create_stream_with_cliff_gas() {
         PER_INVOCATION_CPU_BUDGET,
     );
 
-    println!("GAS_MEASUREMENT: create_stream_with_cliff: single: {}", cost);
+    println!(
+        "GAS_MEASUREMENT: create_stream_with_cliff: single: {}",
+        cost
+    );
 }
 
 /// Gas baseline for `create_stream` with `StreamKind::CliffOnly`.
@@ -875,7 +878,7 @@ fn test_create_stream_cliff_only_gas() {
                 deposit_amount: 1_000_i128,
                 rate_per_second: 0_i128, // CliffOnly: rate is forced to 0 by the contract
                 start_time: 0u64,
-                cliff_time: 1_000u64,   // cliff == end_time: full deposit released at cliff
+                cliff_time: 1_000u64, // cliff == end_time: full deposit released at cliff
                 end_time: 1_000u64,
                 withdraw_dust_threshold: Some(0_i128),
                 memo: None,
@@ -894,7 +897,10 @@ fn test_create_stream_cliff_only_gas() {
         PER_INVOCATION_CPU_BUDGET,
     );
 
-    println!("GAS_MEASUREMENT: create_stream_cliff_only: single: {}", cost);
+    println!(
+        "GAS_MEASUREMENT: create_stream_cliff_only: single: {}",
+        cost
+    );
 }
 
 /// Gas baseline for `withdraw` when only a partial amount has accrued.
@@ -946,7 +952,10 @@ fn test_withdraw_partial_accrual_gas() {
         PER_INVOCATION_CPU_BUDGET,
     );
 
-    println!("GAS_MEASUREMENT: withdraw_partial_accrual: single: {}", cost);
+    println!(
+        "GAS_MEASUREMENT: withdraw_partial_accrual: single: {}",
+        cost
+    );
 }
 
 /// Gas baseline for `withdraw_to` (single stream, custom destination).

--- a/contracts/stream/tests/gas_regression.rs
+++ b/contracts/stream/tests/gas_regression.rs
@@ -139,6 +139,19 @@ fn test_withdraw_gas() {
     println!("GAS_MEASUREMENT: withdraw: single: {}", cost);
 }
 
+/// Gas regression baseline for `batch_withdraw`.
+///
+/// Measures CPU instruction cost for `batch_withdraw` across batch sizes 1, 10, 50, and 100
+/// (up to `MAX_PAGE_SIZE`). Exercises the O(n²) duplicate-ID scan (`reject_duplicate_ids`),
+/// which performs ~n*(n-1)/2 element-by-element comparisons (approx ~4,950 comparisons,
+/// ~10,000 loop operations at MAX_PAGE_SIZE = 100).
+///
+/// Asserts that measured CPU instruction cost stays within Soroban's per-invocation CPU budget
+/// (`PER_INVOCATION_CPU_BUDGET = 25,000,000,000`, providing a 75% safety margin under Soroban's
+/// 100B instruction ceiling).
+///
+/// Companion refactor: expected to improve significantly once the companion refactor
+/// replaces the O(n²) scan in `reject_duplicate_ids` with an O(n) helper (e.g. Map/Set lookup).
 #[test]
 fn test_batch_withdraw_gas() {
     let sizes = [1, 10, 50, 100];
@@ -176,6 +189,9 @@ fn test_batch_withdraw_gas() {
 /// scan in `reject_duplicate_ids`.  The O(n²) scan costs roughly
 /// n*(n-1)/2 comparisons at batch size n, so at MAX_PAGE_SIZE (100) the
 /// worst case is ~4 950 element-by-element comparisons inside the helper.
+///
+/// Asserts that measured CPU instruction cost stays within Soroban's per-invocation CPU budget
+/// (`PER_INVOCATION_CPU_BUDGET`). Baseline expected to improve once companion O(n) refactor lands.
 #[test]
 fn test_batch_withdraw_to_gas() {
     let sizes = [1, 10, 50, 100];
@@ -220,12 +236,14 @@ fn test_batch_withdraw_to_gas() {
 ///
 /// Creates streams, pauses each one (advancing the ledger far enough to
 /// clear the pause cooldown), then resumes them all in a single admin-authed
-/// call. Batch sizes 1, 5, 10, and 20 mirror the documented gas baseline matrix
-/// so `script/validate_gas.py` can compare each measured cost against
-/// `docs/gas.md`.
+/// call. Batch sizes 1, 10, 50, and 100 (up to MAX_PAGE_SIZE) mirror the documented gas baseline matrix
+/// and exercise the O(n²) duplicate-ID scan in `reject_duplicate_ids`.
+///
+/// Asserts that measured CPU instruction cost stays within Soroban's per-invocation CPU budget
+/// (`PER_INVOCATION_CPU_BUDGET`). Baseline expected to improve once companion O(n) refactor lands.
 #[test]
 fn test_bulk_resume_streams_as_admin_gas() {
-    let sizes = [1, 5, 10, 20];
+    let sizes = [1, 10, 50, 100];
 
     for &size in &sizes {
         let ctx = TestContext::setup();
@@ -263,12 +281,14 @@ fn test_bulk_resume_streams_as_admin_gas() {
 /// Gas regression baseline for `bulk_cancel_streams`.
 ///
 /// Creates active streams owned by the sender then cancels them all in a
-/// single call. Batch sizes 1, 5, 10, and 20 mirror the documented gas
-/// baseline matrix so `script/validate_gas.py` can compare each measured cost
-/// against `docs/gas.md`.
+/// single call. Batch sizes 1, 10, 50, and 100 (up to MAX_PAGE_SIZE) mirror the documented gas
+/// baseline matrix and exercise the O(n²) duplicate-ID scan in `reject_duplicate_ids`.
+///
+/// Asserts that measured CPU instruction cost stays within Soroban's per-invocation CPU budget
+/// (`PER_INVOCATION_CPU_BUDGET`). Baseline expected to improve once companion O(n) refactor lands.
 #[test]
 fn test_bulk_cancel_streams_gas() {
-    let sizes = [1, 5, 10, 20];
+    let sizes = [1, 10, 50, 100];
 
     for &size in &sizes {
         let ctx = TestContext::setup();

--- a/contracts/stream/tests/health_matrix.rs
+++ b/contracts/stream/tests/health_matrix.rs
@@ -4,7 +4,10 @@ use fluxora_stream::{
     CreateStreamParams, FluxoraStream, FluxoraStreamClient, PauseReason, StreamKind,
     MAX_RECIPIENT_PAGE_SIZE,
 };
-use soroban_sdk::{testutils::{Address as _, Ledger}, Address, Env};
+use soroban_sdk::{
+    testutils::{Address as _, Ledger},
+    Address, Env,
+};
 
 struct TestContext<'a> {
     env: Env,
@@ -292,13 +295,7 @@ fn test_health_matrix_before_start() {
 // ────────────────────────────────────────────────────────────────────────────
 
 /// Helper: create a linear stream returning the stream_id.
-fn create_linear(
-    ctx: &TestContext,
-    deposit: i128,
-    rate: i128,
-    cliff: u64,
-    end: u64,
-) -> u64 {
+fn create_linear(ctx: &TestContext, deposit: i128, rate: i128, cliff: u64, end: u64) -> u64 {
     ctx.client.create_stream(
         &ctx.sender,
         &CreateStreamParams {
@@ -323,9 +320,7 @@ fn test_portfolio_health_no_streams() {
     let ctx = TestContext::setup();
     let other = Address::generate(&ctx.env);
 
-    let page = ctx
-        .client
-        .get_sender_portfolio_health(&other, &0u64, &10);
+    let page = ctx.client.get_sender_portfolio_health(&other, &0u64, &10);
     assert_eq!(page.underfunded_count, 0);
     assert_eq!(page.expired_count, 0);
     assert_eq!(page.healthy_count, 0);
@@ -445,11 +440,9 @@ fn test_portfolio_health_cursor_pagination() {
     }
 
     ctx.env.ledger().set_timestamp(100);
-    let page1 = ctx.client.get_sender_portfolio_health(
-        &ctx.sender,
-        &0u64,
-        &MAX_RECIPIENT_PAGE_SIZE,
-    );
+    let page1 =
+        ctx.client
+            .get_sender_portfolio_health(&ctx.sender, &0u64, &MAX_RECIPIENT_PAGE_SIZE);
     assert_eq!(page1.stream_ids.len(), MAX_RECIPIENT_PAGE_SIZE as usize);
     assert_ne!(page1.next_cursor, 0u64, "must have more pages");
 
@@ -491,11 +484,9 @@ fn test_portfolio_health_limit_clamped_to_max() {
 
     ctx.env.ledger().set_timestamp(100);
     // limit way above MAX → capped
-    let page = ctx.client.get_sender_portfolio_health(
-        &ctx.sender,
-        &0u64,
-        &(MAX_RECIPIENT_PAGE_SIZE * 3),
-    );
+    let page =
+        ctx.client
+            .get_sender_portfolio_health(&ctx.sender, &0u64, &(MAX_RECIPIENT_PAGE_SIZE * 3));
     assert_eq!(page.stream_ids.len(), 5); // only 5 exist, so all returned
 }
 
@@ -509,11 +500,9 @@ fn test_portfolio_health_past_end_cursor_returns_empty_page() {
     }
 
     ctx.env.ledger().set_timestamp(100);
-    let page = ctx.client.get_sender_portfolio_health(
-        &ctx.sender,
-        &0xFFFF_FFFF_FFFF_FFFFu64,
-        &100,
-    );
+    let page = ctx
+        .client
+        .get_sender_portfolio_health(&ctx.sender, &0xFFFF_FFFF_FFFF_FFFFu64, &100);
     assert_eq!(page.stream_ids.len(), 0);
     assert_eq!(page.next_cursor, 0u64);
 }

--- a/contracts/stream/tests/manifest_versioning.rs
+++ b/contracts/stream/tests/manifest_versioning.rs
@@ -8,7 +8,7 @@
 //! 4. Storage transitions are safe and non-destructive
 
 use fluxora_stream::{
-    CreateStreamParams, FluxoraStream, FluxoraStreamClient, PauseReason, StreamKind, ContractError,
+    ContractError, CreateStreamParams, FluxoraStream, FluxoraStreamClient, PauseReason, StreamKind,
     MAX_METADATA_BYTES, MAX_METADATA_KEYS, MAX_METADATA_KEY_BYTES, MAX_METADATA_VALUE_BYTES,
 };
 use soroban_sdk::{
@@ -102,13 +102,19 @@ fn edge_case_clock_regression_detection_idempotent() {
     let stream_id = ctx.create_test_stream(1000, 1, 1000);
 
     ctx.advance_time(100);
-    
+
     // First accrual read at t=100
-    let accrued1 = ctx.client.calculate_accrued(&stream_id).expect("should succeed at t=100");
+    let accrued1 = ctx
+        .client
+        .calculate_accrued(&stream_id)
+        .expect("should succeed at t=100");
     assert_eq!(accrued1, 100);
 
     // Retry at same time should be idempotent
-    let accrued2 = ctx.client.calculate_accrued(&stream_id).expect("should succeed on retry at t=100");
+    let accrued2 = ctx
+        .client
+        .calculate_accrued(&stream_id)
+        .expect("should succeed on retry at t=100");
     assert_eq!(accrued2, 100);
 
     // Attempting to advance backward should fail
@@ -130,7 +136,9 @@ fn edge_case_clock_monotonicity_multiple_reads() {
 
     for t in [100u64, 100, 101, 102, 200, 500].iter() {
         ctx.advance_time(*t);
-        let accrued = ctx.client.calculate_accrued(&stream_id)
+        let accrued = ctx
+            .client
+            .calculate_accrued(&stream_id)
             .expect(&format!("should succeed at t={}", t));
         assert_eq!(accrued, (*t as i128) * 10);
     }
@@ -151,7 +159,10 @@ fn edge_case_rate_decrease_preserves_checkpoint() {
     let stream_id = ctx.create_test_stream(10000, 10, 1000);
 
     ctx.advance_time(500);
-    let accrued_before = ctx.client.calculate_accrued(&stream_id).expect("should succeed");
+    let accrued_before = ctx
+        .client
+        .calculate_accrued(&stream_id)
+        .expect("should succeed");
     assert_eq!(accrued_before, 5000);
 
     // Decrease rate to 5 tokens/sec
@@ -161,7 +172,10 @@ fn edge_case_rate_decrease_preserves_checkpoint() {
 
     // At t=600, accrued should be 5000 + 5*100 = 5500
     ctx.advance_time(600);
-    let accrued_after = ctx.client.calculate_accrued(&stream_id).expect("should succeed");
+    let accrued_after = ctx
+        .client
+        .calculate_accrued(&stream_id)
+        .expect("should succeed");
     assert_eq!(accrued_after, 5500);
 
     // Verify it doesn't drop back to 5*600=3000 (checkpoint preserved)
@@ -175,7 +189,10 @@ fn edge_case_rate_decrease_at_stream_end() {
     let stream_id = ctx.create_test_stream(1000, 1, 1000);
 
     ctx.advance_time(1000); // Reach end_time
-    let accrued_at_end = ctx.client.calculate_accrued(&stream_id).expect("should succeed");
+    let accrued_at_end = ctx
+        .client
+        .calculate_accrued(&stream_id)
+        .expect("should succeed");
     assert_eq!(accrued_at_end, 1000); // Full deposit accrued
 
     // Rate decrease after stream completion should not affect accrual
@@ -183,7 +200,10 @@ fn edge_case_rate_decrease_at_stream_end() {
         .decrease_rate_per_second(&stream_id, 0)
         .expect("should succeed");
 
-    let accrued_after_decrease = ctx.client.calculate_accrued(&stream_id).expect("should succeed");
+    let accrued_after_decrease = ctx
+        .client
+        .calculate_accrued(&stream_id)
+        .expect("should succeed");
     assert_eq!(accrued_after_decrease, 1000); // Still full deposit
 }
 
@@ -198,7 +218,7 @@ fn edge_case_paused_stream_cooldown_respects_idempotency() {
     let stream_id = ctx.create_test_stream(1000, 1, 1000);
 
     ctx.advance_time(100);
-    
+
     // Pause the stream
     ctx.client
         .pause_stream(&stream_id, &PauseReason::Operational)
@@ -206,12 +226,17 @@ fn edge_case_paused_stream_cooldown_respects_idempotency() {
 
     // Attempt immediate pause should fail (not already paused, but cooldown)
     // Instead, try to pause again immediately
-    let pause_result = ctx.client.pause_stream(&stream_id, &PauseReason::Operational);
+    let pause_result = ctx
+        .client
+        .pause_stream(&stream_id, &PauseReason::Operational);
     // This should fail because it's already paused
     assert!(pause_result.is_err());
 
     // Accrual should be preserved even while paused
-    let accrued_paused = ctx.client.calculate_accrued(&stream_id).expect("should succeed");
+    let accrued_paused = ctx
+        .client
+        .calculate_accrued(&stream_id)
+        .expect("should succeed");
     assert_eq!(accrued_paused, 100);
 
     // Advance past cooldown and resume
@@ -222,7 +247,10 @@ fn edge_case_paused_stream_cooldown_respects_idempotency() {
 
     // Accrual should continue
     ctx.advance_time(200);
-    let accrued_after_resume = ctx.client.calculate_accrued(&stream_id).expect("should succeed");
+    let accrued_after_resume = ctx
+        .client
+        .calculate_accrued(&stream_id)
+        .expect("should succeed");
     assert_eq!(accrued_after_resume, 200);
 }
 
@@ -291,7 +319,10 @@ fn edge_case_metadata_immutable_after_creation() {
 
     // Create stream with metadata
     let mut metadata = Map::new(&ctx.env);
-    metadata.set(String::from_str(&ctx.env, "key1"), String::from_str(&ctx.env, "value1"));
+    metadata.set(
+        String::from_str(&ctx.env, "key1"),
+        String::from_str(&ctx.env, "value1"),
+    );
 
     let stream_id = ctx.client.create_stream(
         &ctx.sender,
@@ -312,12 +343,16 @@ fn edge_case_metadata_immutable_after_creation() {
     );
 
     // Read metadata
-    let stored_metadata = ctx.client.get_stream_metadata(&stream_id)
+    let stored_metadata = ctx
+        .client
+        .get_stream_metadata(&stream_id)
         .expect("metadata should exist");
     assert_eq!(stored_metadata.len(), 1);
 
     // Metadata should remain the same across multiple reads
-    let stored_metadata2 = ctx.client.get_stream_metadata(&stream_id)
+    let stored_metadata2 = ctx
+        .client
+        .get_stream_metadata(&stream_id)
         .expect("metadata should exist");
     assert_eq!(stored_metadata.len(), stored_metadata2.len());
 }
@@ -338,11 +373,16 @@ fn edge_case_completed_stream_terminal_state() {
     ctx.client.withdraw(&stream_id).expect("should succeed");
 
     // Stream should now be Completed
-    let stream = ctx.client.get_stream_state(&stream_id).expect("should exist");
+    let stream = ctx
+        .client
+        .get_stream_state(&stream_id)
+        .expect("should exist");
     assert_eq!(stream.status as u32, 2); // Completed = 2
 
     // Attempting pause on completed stream should fail
-    let pause_result = ctx.client.pause_stream(&stream_id, &PauseReason::Operational);
+    let pause_result = ctx
+        .client
+        .pause_stream(&stream_id, &PauseReason::Operational);
     assert!(pause_result.is_err());
 
     // Attempting top-up on completed stream should fail
@@ -366,7 +406,10 @@ fn edge_case_keeper_cancel_terminal_idempotent() {
     assert!(result1.is_ok());
 
     // Stream should now be terminal
-    let stream = ctx.client.get_stream_state(&stream_id).expect("should exist");
+    let stream = ctx
+        .client
+        .get_stream_state(&stream_id)
+        .expect("should exist");
     assert!(stream.status as u32 == 2 || stream.status as u32 == 3); // Completed or Cancelled
 
     // Retry keeper_cancel on terminal stream should fail deterministically
@@ -419,7 +462,10 @@ fn edge_case_global_pause_instance_specific() {
     assert!(!ctx.client.get_global_emergency_paused());
 
     // Operations should now succeed
-    let withdraw_result2 = ctx.client.withdraw(&stream_id).expect("should succeed after unpause");
+    let withdraw_result2 = ctx
+        .client
+        .withdraw(&stream_id)
+        .expect("should succeed after unpause");
     assert_eq!(withdraw_result2, 100);
 }
 
@@ -438,13 +484,17 @@ fn edge_case_autorenew_defaults_to_disabled() {
     assert!(!autorenew); // Should be disabled by default
 
     // Explicitly enable
-    ctx.client.set_auto_renew(&stream_id, true).expect("should succeed");
+    ctx.client
+        .set_auto_renew(&stream_id, true)
+        .expect("should succeed");
 
     let autorenew_enabled = ctx.client.get_auto_renew(&stream_id).expect("should exist");
     assert!(autorenew_enabled);
 
     // Disable again
-    ctx.client.set_auto_renew(&stream_id, false).expect("should succeed");
+    ctx.client
+        .set_auto_renew(&stream_id, false)
+        .expect("should succeed");
 
     let autorenew_disabled = ctx.client.get_auto_renew(&stream_id).expect("should exist");
     assert!(!autorenew_disabled);
@@ -462,27 +512,43 @@ fn edge_case_withdrawable_deterministic_with_checkpoint() {
 
     // Accrue 5000 at t=500
     ctx.advance_time(500);
-    let withdrawable1 = ctx.client.get_withdrawable(&stream_id).expect("should exist");
+    let withdrawable1 = ctx
+        .client
+        .get_withdrawable(&stream_id)
+        .expect("should exist");
     assert_eq!(withdrawable1, 5000);
 
     // Withdraw 3000
-    ctx.client.withdraw(&stream_id).expect("withdraw should succeed");
+    ctx.client
+        .withdraw(&stream_id)
+        .expect("withdraw should succeed");
 
     // Remaining should be 2000
-    let stream = ctx.client.get_stream_state(&stream_id).expect("should exist");
+    let stream = ctx
+        .client
+        .get_stream_state(&stream_id)
+        .expect("should exist");
     assert_eq!(stream.withdrawn_amount, 3000);
 
     // At t=600, new accrual: 10*600 = 6000 total, minus 3000 withdrawn = 3000 withdrawable
     ctx.advance_time(600);
-    let withdrawable2 = ctx.client.get_withdrawable(&stream_id).expect("should exist");
+    let withdrawable2 = ctx
+        .client
+        .get_withdrawable(&stream_id)
+        .expect("should exist");
     assert_eq!(withdrawable2, 3000);
 
     // Decrease rate to 5 at t=600, checkpoint at 6000
-    ctx.client.decrease_rate_per_second(&stream_id, 5).expect("should succeed");
+    ctx.client
+        .decrease_rate_per_second(&stream_id, 5)
+        .expect("should succeed");
 
     // At t=700: checkpoint(6000) + 5*(700-600) = 6000 + 500 = 6500 total, minus 3000 = 3500 withdrawable
     ctx.advance_time(700);
-    let withdrawable3 = ctx.client.get_withdrawable(&stream_id).expect("should exist");
+    let withdrawable3 = ctx
+        .client
+        .get_withdrawable(&stream_id)
+        .expect("should exist");
     assert_eq!(withdrawable3, 3500);
 
     // Monotonicity: withdrawable should never decrease over time
@@ -499,7 +565,10 @@ fn edge_case_stream_clone_preserves_metadata() {
     let ctx = TestContext::setup();
 
     let mut metadata = Map::new(&ctx.env);
-    metadata.set(String::from_str(&ctx.env, "original"), String::from_str(&ctx.env, "clone_test"));
+    metadata.set(
+        String::from_str(&ctx.env, "original"),
+        String::from_str(&ctx.env, "clone_test"),
+    );
 
     let original_id = ctx.client.create_stream(
         &ctx.sender,
@@ -522,20 +591,34 @@ fn edge_case_stream_clone_preserves_metadata() {
     ctx.advance_time(100);
 
     // Clone the stream
-    let cloned_id = ctx.client.clone_stream(&original_id, &ctx.recipient).expect("clone should succeed");
+    let cloned_id = ctx
+        .client
+        .clone_stream(&original_id, &ctx.recipient)
+        .expect("clone should succeed");
 
     // Original metadata should be preserved in clone
-    let cloned_metadata = ctx.client.get_stream_metadata(&cloned_id)
+    let cloned_metadata = ctx
+        .client
+        .get_stream_metadata(&cloned_id)
         .expect("cloned metadata should exist");
     assert_eq!(cloned_metadata.len(), 1);
 
     // Cloned stream should have fresh accrual (start_time = now)
-    let cloned_stream = ctx.client.get_stream_state(&cloned_id).expect("should exist");
+    let cloned_stream = ctx
+        .client
+        .get_stream_state(&cloned_id)
+        .expect("should exist");
     assert_eq!(cloned_stream.withdrawn_amount, 0); // Fresh start
 
     // Original accrual should be independent
-    let original_withdrawable = ctx.client.get_withdrawable(&original_id).expect("should exist");
-    let cloned_withdrawable = ctx.client.get_withdrawable(&cloned_id).expect("should exist");
+    let original_withdrawable = ctx
+        .client
+        .get_withdrawable(&original_id)
+        .expect("should exist");
+    let cloned_withdrawable = ctx
+        .client
+        .get_withdrawable(&cloned_id)
+        .expect("should exist");
     // Original has accrued, clone is fresh
     assert!(original_withdrawable > 0);
     assert_eq!(cloned_withdrawable, 0);
@@ -581,7 +664,10 @@ fn edge_case_storage_key_stability() {
 
     // All streams should be retrievable
     for id in stream_ids {
-        let stream = ctx.client.get_stream_state(&id).expect("should be retrievable");
+        let stream = ctx
+            .client
+            .get_stream_state(&id)
+            .expect("should be retrievable");
         assert_eq!(stream.stream_id, id);
     }
 
@@ -606,7 +692,10 @@ fn regression_accrual_never_negative() {
 
     for t in 0..=100 {
         ctx.advance_time(t as u64);
-        let accrued = ctx.client.calculate_accrued(&stream_id).expect("should succeed");
+        let accrued = ctx
+            .client
+            .calculate_accrued(&stream_id)
+            .expect("should succeed");
         assert!(accrued >= 0, "accrual at t={} should not be negative", t);
     }
 }
@@ -619,8 +708,15 @@ fn regression_withdrawable_capped_at_deposit() {
 
     for t in 0..=200 {
         ctx.advance_time(t as u64);
-        let withdrawable = ctx.client.get_withdrawable(&stream_id).expect("should exist");
-        assert!(withdrawable <= 5000, "withdrawable at t={} should not exceed deposit", t);
+        let withdrawable = ctx
+            .client
+            .get_withdrawable(&stream_id)
+            .expect("should exist");
+        assert!(
+            withdrawable <= 5000,
+            "withdrawable at t={} should not exceed deposit",
+            t
+        );
     }
 }
 
@@ -636,7 +732,10 @@ fn regression_withdrawn_monotonic() {
         ctx.advance_time(*t);
         ctx.client.withdraw(&stream_id).expect("should succeed");
 
-        let stream = ctx.client.get_stream_state(&stream_id).expect("should exist");
+        let stream = ctx
+            .client
+            .get_stream_state(&stream_id)
+            .expect("should exist");
         assert!(
             stream.withdrawn_amount >= previous_withdrawn,
             "withdrawn_amount should be monotonic at t={}",

--- a/contracts/stream/tests/metadata_extension.rs
+++ b/contracts/stream/tests/metadata_extension.rs
@@ -1442,11 +1442,7 @@ fn test_two_streams_independent_metadata() {
 fn test_contract_version_is_current() {
     let ctx = Ctx::setup();
     let v = ctx.client().version();
-    assert!(
-        v >= 7,
-        "CONTRACT_VERSION must be >= 7 (current is {})",
-        v
-    );
+    assert!(v >= 7, "CONTRACT_VERSION must be >= 7 (current is {})", v);
 }
 
 // ---------------------------------------------------------------------------

--- a/contracts/stream/tests/retry_safety.rs
+++ b/contracts/stream/tests/retry_safety.rs
@@ -104,20 +104,30 @@ fn retry_safety_create_stream_idempotent() {
     };
 
     // First create
-    let stream_id_1 = ctx.client.create_stream(&ctx.sender, &params)
+    let stream_id_1 = ctx
+        .client
+        .create_stream(&ctx.sender, &params)
         .expect("first create should succeed");
 
     // Verify stream is persisted
-    let stream_1 = ctx.client.get_stream_state(&stream_id_1).expect("stream should exist");
+    let stream_1 = ctx
+        .client
+        .get_stream_state(&stream_id_1)
+        .expect("stream should exist");
     assert_eq!(stream_1.deposit_amount, 5000);
 
     // Second create with same parameters should produce a NEW stream_id (not idempotent on input,
     // but the sequence of operations is deterministic)
-    let stream_id_2 = ctx.client.create_stream(&ctx.sender, &params)
+    let stream_id_2 = ctx
+        .client
+        .create_stream(&ctx.sender, &params)
         .expect("second create should succeed");
 
     // Both streams should exist and be retrievable
-    let stream_2 = ctx.client.get_stream_state(&stream_id_2).expect("stream should exist");
+    let stream_2 = ctx
+        .client
+        .get_stream_state(&stream_id_2)
+        .expect("stream should exist");
     assert_eq!(stream_2.deposit_amount, 5000);
 
     // Both should have identical parameters (but different IDs)
@@ -144,16 +154,26 @@ fn retry_safety_withdraw_deterministic_timestamp() {
     ctx.env.ledger().set_timestamp(500);
 
     // First withdraw
-    let withdrawable_1 = ctx.client.get_withdrawable(&stream_id).expect("should exist");
+    let withdrawable_1 = ctx
+        .client
+        .get_withdrawable(&stream_id)
+        .expect("should exist");
     assert_eq!(withdrawable_1, 5000);
 
-    ctx.client.withdraw(&stream_id).expect("first withdraw should succeed");
-    let withdrawn_after_1 = ctx.client.get_stream_state(&stream_id)
+    ctx.client
+        .withdraw(&stream_id)
+        .expect("first withdraw should succeed");
+    let withdrawn_after_1 = ctx
+        .client
+        .get_stream_state(&stream_id)
         .expect("stream should exist")
         .withdrawn_amount;
 
     // Retry at same timestamp (after CCU would be idempotent, but we just query state)
-    let withdrawable_2 = ctx.client.get_withdrawable(&stream_id).expect("should exist");
+    let withdrawable_2 = ctx
+        .client
+        .get_withdrawable(&stream_id)
+        .expect("should exist");
     // After first withdraw, withdrawable should be 0 (already withdrawn 5000 out of 5000 accrued)
     assert_eq!(withdrawable_2, 0);
 
@@ -171,9 +191,14 @@ fn retry_safety_multiple_withdraws_monotonic() {
 
     for t in [100u64, 200, 300].iter() {
         ctx.env.ledger().set_timestamp(*t);
-        ctx.client.withdraw(&stream_id).expect("withdraw should succeed");
+        ctx.client
+            .withdraw(&stream_id)
+            .expect("withdraw should succeed");
 
-        let stream = ctx.client.get_stream_state(&stream_id).expect("stream should exist");
+        let stream = ctx
+            .client
+            .get_stream_state(&stream_id)
+            .expect("stream should exist");
         assert!(stream.withdrawn_amount >= previous_withdrawn);
         previous_withdrawn = stream.withdrawn_amount;
     }
@@ -262,11 +287,16 @@ fn retry_safety_pause_deterministic_ledger() {
         .pause_stream(&stream_id, &PauseReason::Operational)
         .expect("first pause should succeed");
 
-    let stream_1 = ctx.client.get_stream_state(&stream_id).expect("should exist");
+    let stream_1 = ctx
+        .client
+        .get_stream_state(&stream_id)
+        .expect("should exist");
     assert_eq!(stream_1.status as u32, 1); // Paused
 
     // Attempt to pause again at same ledger should fail (already paused)
-    let pause_result = ctx.client.pause_stream(&stream_id, &PauseReason::Operational);
+    let pause_result = ctx
+        .client
+        .pause_stream(&stream_id, &PauseReason::Operational);
     assert!(pause_result.is_err());
 
     // Advance past cooldown
@@ -277,7 +307,10 @@ fn retry_safety_pause_deterministic_ledger() {
         .resume_stream(&stream_id)
         .expect("resume should succeed");
 
-    let stream_2 = ctx.client.get_stream_state(&stream_id).expect("should exist");
+    let stream_2 = ctx
+        .client
+        .get_stream_state(&stream_id)
+        .expect("should exist");
     assert_eq!(stream_2.status as u32, 0); // Active
 }
 
@@ -294,7 +327,10 @@ fn retry_safety_rate_decrease_checkpoint_deterministic() {
     ctx.env.ledger().set_timestamp(500);
 
     // Get accrued before rate decrease
-    let accrued_before = ctx.client.calculate_accrued(&stream_id).expect("should exist");
+    let accrued_before = ctx
+        .client
+        .calculate_accrued(&stream_id)
+        .expect("should exist");
     assert_eq!(accrued_before, 5000);
 
     // Decrease rate
@@ -302,7 +338,10 @@ fn retry_safety_rate_decrease_checkpoint_deterministic() {
         .decrease_rate_per_second(&stream_id, 5)
         .expect("first decrease should succeed");
 
-    let stream_after_1 = ctx.client.get_stream_state(&stream_id).expect("should exist");
+    let stream_after_1 = ctx
+        .client
+        .get_stream_state(&stream_id)
+        .expect("should exist");
     assert_eq!(stream_after_1.checkpointed_amount, 5000);
     assert_eq!(stream_after_1.checkpointed_at, 500);
 
@@ -312,14 +351,20 @@ fn retry_safety_rate_decrease_checkpoint_deterministic() {
         .decrease_rate_per_second(&stream_id, 3)
         .expect("second decrease should succeed");
 
-    let stream_after_2 = ctx.client.get_stream_state(&stream_id).expect("should exist");
+    let stream_after_2 = ctx
+        .client
+        .get_stream_state(&stream_id)
+        .expect("should exist");
     // Checkpoint should be based on accrual at t=500 with rate=5 (unchanged)
     assert_eq!(stream_after_2.checkpointed_amount, 5000);
     assert_eq!(stream_after_2.checkpointed_at, 500);
 
     // Advance time and verify accrual uses new rate consistently
     ctx.env.ledger().set_timestamp(600);
-    let accrued_at_600 = ctx.client.calculate_accrued(&stream_id).expect("should exist");
+    let accrued_at_600 = ctx
+        .client
+        .calculate_accrued(&stream_id)
+        .expect("should exist");
     // checkpoint(5000) + 3*(600-500) = 5000 + 300 = 5300
     assert_eq!(accrued_at_600, 5300);
 }
@@ -339,7 +384,10 @@ fn retry_safety_validation_fails_no_partial_mutation() {
     ctx.env.ledger().set_timestamp(500);
 
     // Record initial state
-    let initial = ctx.client.get_stream_state(&stream_id).expect("should exist");
+    let initial = ctx
+        .client
+        .get_stream_state(&stream_id)
+        .expect("should exist");
     let initial_withdrawn = initial.withdrawn_amount;
     assert_eq!(initial_withdrawn, 0);
 
@@ -352,7 +400,10 @@ fn retry_safety_validation_fails_no_partial_mutation() {
     assert!(result.is_err());
 
     // Verify state is unchanged (no partial mutation)
-    let after_failed = ctx.client.get_stream_state(&stream_id).expect("should exist");
+    let after_failed = ctx
+        .client
+        .get_stream_state(&stream_id)
+        .expect("should exist");
     assert_eq!(after_failed.withdrawn_amount, initial_withdrawn);
 }
 
@@ -372,15 +423,22 @@ fn retry_safety_terminal_state_idempotent_rejection() {
     ctx.client.withdraw(&stream_id).expect("should succeed");
 
     // Stream is now Completed
-    let stream = ctx.client.get_stream_state(&stream_id).expect("should exist");
+    let stream = ctx
+        .client
+        .get_stream_state(&stream_id)
+        .expect("should exist");
     assert_eq!(stream.status as u32, 2); // Completed
 
     // First pause attempt should fail
-    let pause_1 = ctx.client.pause_stream(&stream_id, &PauseReason::Operational);
+    let pause_1 = ctx
+        .client
+        .pause_stream(&stream_id, &PauseReason::Operational);
     assert!(pause_1.is_err());
 
     // Retry pause should fail identically
-    let pause_2 = ctx.client.pause_stream(&stream_id, &PauseReason::Operational);
+    let pause_2 = ctx
+        .client
+        .pause_stream(&stream_id, &PauseReason::Operational);
     assert!(pause_2.is_err());
 
     // First top-up attempt should fail
@@ -405,23 +463,41 @@ fn retry_safety_queries_no_side_effects() {
     ctx.env.ledger().set_timestamp(300);
 
     // Query withdrawable multiple times
-    let w1 = ctx.client.get_withdrawable(&stream_id).expect("should exist");
-    let w2 = ctx.client.get_withdrawable(&stream_id).expect("should exist");
-    let w3 = ctx.client.get_withdrawable(&stream_id).expect("should exist");
+    let w1 = ctx
+        .client
+        .get_withdrawable(&stream_id)
+        .expect("should exist");
+    let w2 = ctx
+        .client
+        .get_withdrawable(&stream_id)
+        .expect("should exist");
+    let w3 = ctx
+        .client
+        .get_withdrawable(&stream_id)
+        .expect("should exist");
 
     assert_eq!(w1, 1500);
     assert_eq!(w2, 1500);
     assert_eq!(w3, 1500);
 
     // Query accrued multiple times
-    let a1 = ctx.client.calculate_accrued(&stream_id).expect("should exist");
-    let a2 = ctx.client.calculate_accrued(&stream_id).expect("should exist");
+    let a1 = ctx
+        .client
+        .calculate_accrued(&stream_id)
+        .expect("should exist");
+    let a2 = ctx
+        .client
+        .calculate_accrued(&stream_id)
+        .expect("should exist");
 
     assert_eq!(a1, 1500);
     assert_eq!(a2, 1500);
 
     // Verify state is unchanged
-    let stream = ctx.client.get_stream_state(&stream_id).expect("should exist");
+    let stream = ctx
+        .client
+        .get_stream_state(&stream_id)
+        .expect("should exist");
     assert_eq!(stream.withdrawn_amount, 0);
 }
 
@@ -490,9 +566,18 @@ fn regression_accrual_determinism() {
         ctx.env.ledger().set_timestamp(*t);
 
         // Query 3 times at same timestamp
-        let a1 = ctx.client.calculate_accrued(&stream_id).expect("should exist");
-        let a2 = ctx.client.calculate_accrued(&stream_id).expect("should exist");
-        let a3 = ctx.client.calculate_accrued(&stream_id).expect("should exist");
+        let a1 = ctx
+            .client
+            .calculate_accrued(&stream_id)
+            .expect("should exist");
+        let a2 = ctx
+            .client
+            .calculate_accrued(&stream_id)
+            .expect("should exist");
+        let a3 = ctx
+            .client
+            .calculate_accrued(&stream_id)
+            .expect("should exist");
 
         assert_eq!(a1, a2);
         assert_eq!(a2, a3);
@@ -512,7 +597,10 @@ fn regression_monotonic_withdrawn() {
         ctx.env.ledger().set_timestamp(t);
         ctx.client.withdraw(&stream_id).expect("should succeed");
 
-        let stream = ctx.client.get_stream_state(&stream_id).expect("should exist");
+        let stream = ctx
+            .client
+            .get_stream_state(&stream_id)
+            .expect("should exist");
         assert!(stream.withdrawn_amount >= previous);
         previous = stream.withdrawn_amount;
     }

--- a/contracts/stream/tests/security_invariants.rs
+++ b/contracts/stream/tests/security_invariants.rs
@@ -13,8 +13,8 @@
 extern crate std;
 
 use fluxora_stream::{
-    ContractError, CreateStreamParams, FluxoraStream, FluxoraStreamClient, PauseReason,
-    StreamKind, StreamStatus,
+    ContractError, CreateStreamParams, FluxoraStream, FluxoraStreamClient, PauseReason, StreamKind,
+    StreamStatus,
 };
 use soroban_sdk::{
     testutils::{Address as _, Events, Ledger},
@@ -134,7 +134,8 @@ fn cei_withdraw_state_before_transfer() {
         let topic1: Symbol = events.get_unchecked(last - 1).0;
         if topic1 == Symbol::new(&ctx.env, "completed") {
             assert_eq!(
-                topic0, Symbol::new(&ctx.env, "withdrew"),
+                topic0,
+                Symbol::new(&ctx.env, "withdrew"),
                 "withdrew event must precede completed event"
             );
         }
@@ -319,9 +320,7 @@ fn terminal_rate_update_cancelled_fails() {
     ctx.env.ledger().set_timestamp(300);
     ctx.client().cancel_stream(&stream_id);
 
-    let result = ctx
-        .client()
-        .try_update_rate_per_second(&stream_id, &2);
+    let result = ctx.client().try_update_rate_per_second(&stream_id, &2);
     assert!(result.is_err());
 }
 
@@ -490,9 +489,7 @@ fn duplicate_id_batch_withdraw_rejected() {
     ctx.env.ledger().set_timestamp(500);
 
     let ids = vec![&ctx.env, stream_id, stream_id];
-    let result = ctx
-        .client()
-        .try_batch_withdraw(&ctx.recipient, &ids);
+    let result = ctx.client().try_batch_withdraw(&ctx.recipient, &ids);
     assert_eq!(result, Err(Ok(ContractError::DuplicateStreamId)));
 }
 
@@ -514,9 +511,7 @@ fn duplicate_id_batch_withdraw_to_rejected() {
             destination: ctx.recipient.clone(),
         },
     ];
-    let result = ctx
-        .client()
-        .try_batch_withdraw_to(&ctx.recipient, &params);
+    let result = ctx.client().try_batch_withdraw_to(&ctx.recipient, &params);
     assert_eq!(result, Err(Ok(ContractError::DuplicateStreamId)));
 }
 
@@ -780,10 +775,7 @@ fn datakey_discriminant_count_stable() {
     // tests, but we can assert the CONTRACT_VERSION constant hasn't been
     // bumped without documentation. This is a sentinel.
     let version = client.version();
-    assert!(
-        version >= 9,
-        "CONTRACT_VERSION must be at least 9"
-    );
+    assert!(version >= 9, "CONTRACT_VERSION must be at least 9");
 }
 
 // ---------------------------------------------------------------------------
@@ -815,7 +807,10 @@ fn irrevocable_cancel_rejected() {
     );
 
     let result = ctx.client().try_cancel_stream(&stream_id);
-    assert!(result.is_err(), "irrevocable stream must reject cancellation");
+    assert!(
+        result.is_err(),
+        "irrevocable stream must reject cancellation"
+    );
 }
 
 /// An irrevocable stream cannot be shortened.
@@ -842,8 +837,6 @@ fn irrevocable_shorten_rejected() {
         },
     );
 
-    let result = ctx
-        .client()
-        .try_shorten_stream_end_time(&stream_id, &500);
+    let result = ctx.client().try_shorten_stream_end_time(&stream_id, &500);
     assert!(result.is_err(), "irrevocable stream must reject shortening");
 }

--- a/contracts/stream/tests/storage_invariants_edge_cases.rs
+++ b/contracts/stream/tests/storage_invariants_edge_cases.rs
@@ -9,9 +9,7 @@
 
 extern crate std;
 
-use fluxora_stream::{
-    storage::*, ContractError, DataKey, FluxoraStream, FluxoraStreamClient,
-};
+use fluxora_stream::{storage::*, ContractError, DataKey, FluxoraStream, FluxoraStreamClient};
 use soroban_sdk::{
     testutils::{Address as _, Ledger},
     token::StellarAssetClient,

--- a/contracts/stream/tests/storage_key_compat.rs
+++ b/contracts/stream/tests/storage_key_compat.rs
@@ -1586,4 +1586,3 @@ fn test_regression_staleness_mismatch_detection() {
         "Stale CONTRACT_VERSION mapping must be detected as mismatched against live DataKey count"
     );
 }
-

--- a/contracts/stream/tests/upgrade_path.rs
+++ b/contracts/stream/tests/upgrade_path.rs
@@ -208,8 +208,14 @@ fn test_version_idempotent_after_multiple_reads() {
     let v2 = ctx.client.version();
     let v3 = ctx.client.version();
 
-    assert_eq!(v1, v2, "version() must return the same value on repeated calls");
-    assert_eq!(v2, v3, "version() must return the same value on repeated calls");
+    assert_eq!(
+        v1, v2,
+        "version() must return the same value on repeated calls"
+    );
+    assert_eq!(
+        v2, v3,
+        "version() must return the same value on repeated calls"
+    );
     assert_eq!(v1, fluxora_stream::CONTRACT_VERSION);
 }
 

--- a/docs/gas.md
+++ b/docs/gas.md
@@ -170,7 +170,7 @@ for id in stream_ids.iter() {
 }
 ```
 
-This is O(n²) in the batch size n.  At `MAX_PAGE_SIZE = 100`, the worst case is about 4 950 element comparisons per call (~10 000 inclusive of the outer-loop overhead).  The regression tests measure `batch_withdraw` and `batch_withdraw_to` at the existing large-batch sizes 1, 10, 50, and 100, and measure `bulk_cancel_streams` plus `bulk_resume_streams_as_admin` at issue #1219's baseline sizes 1, 5, 10, and 20. This keeps the newer bulk entrypoints under `validate_gas.py` regression comparison while preserving the existing large-batch coverage for withdrawal paths.
+This is O(n²) in the batch size n.  At `MAX_PAGE_SIZE = 100`, the worst case is about 4 950 element comparisons per call (~10 000 inclusive of the outer-loop overhead).  The gas regression tests measure all four batch entrypoints — `batch_withdraw`, `batch_withdraw_to`, `bulk_resume_streams_as_admin`, and `bulk_cancel_streams` — at batch sizes 1, 10, 50, and 100 up to `MAX_PAGE_SIZE` (100). This ensures full coverage across the full batch capacity while asserting CPU-instruction costs stay well within Soroban's per-invocation CPU limit (`PER_INVOCATION_CPU_BUDGET`).
 
 A companion refactor issue replaces the O(n²) scan with an O(n) helper (e.g. using a `Map<u64,bool>`), after which these baselines are expected to improve significantly, especially at size 100. The budget assertions stay valid regardless; they guard against per-invocation-limit violations, not against algorithmic regressions within the current design.
 
@@ -196,15 +196,15 @@ The following table provides the CPU instruction counts for core operations.
   },
   "bulk_resume_streams_as_admin": {
     "1": 4000000,
-    "5": 10000000,
     "10": 18000000,
-    "20": 36000000
+    "50": 85000000,
+    "100": 170000000
   },
   "bulk_cancel_streams": {
     "1": 3500000,
-    "5": 9000000,
     "10": 16000000,
-    "20": 32000000
+    "50": 75000000,
+    "100": 150000000
   },
   "keeper_cancel": {
     "partial_accrual": 786739,

--- a/script/validate_gas.py
+++ b/script/validate_gas.py
@@ -5,7 +5,7 @@ import subprocess
 import sys
 from typing import Any, Dict
 
-BULK_BATCH_BASELINE_SIZES = ("1", "5", "10", "20")
+BULK_BATCH_BASELINE_SIZES = ("1", "10", "50", "100")
 REQUIRED_BULK_BASELINES = {
     "bulk_cancel_streams": BULK_BATCH_BASELINE_SIZES,
     "bulk_resume_streams_as_admin": BULK_BATCH_BASELINE_SIZES,

--- a/tests/test_gas_validation.py
+++ b/tests/test_gas_validation.py
@@ -82,8 +82,8 @@ class TestMain:
         """Test successful validation with no regressions."""
         mock_baselines.return_value = {
             "transfer": 2000,
-            "bulk_cancel_streams": {"1": 3000, "5": 7000, "10": 12000, "20": 22000},
-            "bulk_resume_streams_as_admin": {"1": 4000, "5": 8000, "10": 14000, "20": 26000},
+            "bulk_cancel_streams": {"1": 3000, "10": 12000, "50": 75000, "100": 150000},
+            "bulk_resume_streams_as_admin": {"1": 4000, "10": 14000, "50": 85000, "100": 170000},
         }
         mock_run_tests.return_value = "GAS_MEASUREMENT: transfer: single: 1900"
         main()

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -755,8 +755,8 @@ _BASELINE_BLOCK = textwrap.dedent("""\
         "create_stream": 1000,
         "withdraw": 500,
         "batch_withdraw": {"small": 200, "large": 800},
-        "bulk_cancel_streams": {"1": 3000, "5": 7000, "10": 12000, "20": 22000},
-        "bulk_resume_streams_as_admin": {"1": 4000, "5": 8000, "10": 14000, "20": 26000}
+        "bulk_cancel_streams": {"1": 3000, "10": 12000, "50": 75000, "100": 150000},
+        "bulk_resume_streams_as_admin": {"1": 4000, "10": 14000, "50": 85000, "100": 170000}
     }
     <!-- GAS_BASELINE_END -->
 """)
@@ -776,7 +776,7 @@ class TestExtractBaselines:
         assert result["create_stream"] == 1000
         assert result["withdraw"] == 500
         assert result["batch_withdraw"]["small"] == 200
-        assert result["bulk_cancel_streams"]["20"] == 22000
+        assert result["bulk_cancel_streams"]["100"] == 150000
 
     def test_raises_on_missing_block(self, tmp_path):
         f = tmp_path / "gas.md"
@@ -802,15 +802,15 @@ class TestValidateRequiredBaselines:
 
     def test_rejects_missing_bulk_size(self):
         baselines = {
-            "bulk_cancel_streams": {"1": 3000, "5": 7000, "10": 12000},
-            "bulk_resume_streams_as_admin": {"1": 4000, "5": 8000, "10": 14000, "20": 26000},
+            "bulk_cancel_streams": {"1": 3000, "10": 12000, "50": 75000},
+            "bulk_resume_streams_as_admin": {"1": 4000, "10": 14000, "50": 85000, "100": 170000},
         }
-        with pytest.raises(ValueError, match="bulk_cancel_streams: 20"):
+        with pytest.raises(ValueError, match="bulk_cancel_streams: 100"):
             vg.validate_required_baselines(baselines)
 
     def test_rejects_missing_bulk_function(self):
         baselines = {
-            "bulk_cancel_streams": {"1": 3000, "5": 7000, "10": 12000, "20": 22000},
+            "bulk_cancel_streams": {"1": 3000, "10": 12000, "50": 75000, "100": 150000},
         }
         with pytest.raises(ValueError, match="bulk_resume_streams_as_admin: all"):
             vg.validate_required_baselines(baselines)
@@ -937,8 +937,8 @@ class TestGasMain:
             "create_stream": 1000,
             "withdraw": 500,
             "batch_withdraw": {"small": 200, "large": 800},
-            "bulk_cancel_streams": {"1": 3000, "5": 7000, "10": 12000, "20": 22000},
-            "bulk_resume_streams_as_admin": {"1": 4000, "5": 8000, "10": 14000, "20": 26000},
+            "bulk_cancel_streams": {"1": 3000, "10": 12000, "50": 75000, "100": 150000},
+            "bulk_resume_streams_as_admin": {"1": 4000, "10": 14000, "50": 85000, "100": 170000},
         })
 
     def test_no_regression_exits_0(self, tmp_path, monkeypatch):
@@ -968,8 +968,8 @@ class TestGasMain:
         )
         monkeypatch.setattr(vg, "extract_baselines", lambda _: {
             "create_stream": 1000,
-            "bulk_cancel_streams": {"1": 3000, "5": 7000, "10": 12000, "20": 22000},
-            "bulk_resume_streams_as_admin": {"1": 4000, "5": 8000, "10": 14000, "20": 26000},
+            "bulk_cancel_streams": {"1": 3000, "10": 12000, "50": 75000, "100": 150000},
+            "bulk_resume_streams_as_admin": {"1": 4000, "10": 14000, "50": 85000, "100": 170000},
         })
         with pytest.raises(SystemExit) as exc:
             vg.main()
@@ -980,8 +980,8 @@ class TestGasMain:
         self._patch(monkeypatch, tmp_path, {"unknown_fn": 999},
                     baseline_override={
                         "create_stream": 1000,
-                        "bulk_cancel_streams": {"1": 3000, "5": 7000, "10": 12000, "20": 22000},
-                        "bulk_resume_streams_as_admin": {"1": 4000, "5": 8000, "10": 14000, "20": 26000},
+                        "bulk_cancel_streams": {"1": 3000, "10": 12000, "50": 75000, "100": 150000},
+                        "bulk_resume_streams_as_admin": {"1": 4000, "10": 14000, "50": 85000, "100": 170000},
                     })
         with pytest.raises(SystemExit):
             vg.main()


### PR DESCRIPTION
##closes #1028

```markdown
# test: gas baselines for O(n^2) duplicate-ID scans at MAX_PAGE_SIZE (#1028)

## Summary

Resolves #1028 by adding CPU budget regression baselines for all four batch entrypoints (`batch_withdraw`, `batch_withdraw_to`, `bulk_resume_streams_as_admin`, and `bulk_cancel_streams`) at batch sizes 1, 10, 50, and 100 up to `MAX_PAGE_SIZE` (100).

These entrypoints currently use an O(n²) duplicate-ID scan (`reject_duplicate_ids`), which reaches its worst-case cost (~4,950 comparisons, ~10,000 loop operations) at `MAX_PAGE_SIZE = 100`. This PR establishes explicit regression baselines and budget assertions to ensure execution stays safely within Soroban's per-invocation CPU limit.

---

## Key Changes

### 1. Gas Regression Test Suite (`contracts/stream/tests/gas_regression.rs`)
- Updated `test_bulk_resume_streams_as_admin_gas` and `test_bulk_cancel_streams_gas` to test batch sizes `[1, 10, 50, 100]` (aligning with `batch_withdraw` and `batch_withdraw_to`).
- Added NatSpec / doc-comments across all four batch entrypoint tests detailing:
  - Full batch measurement matrix up to `MAX_PAGE_SIZE` (100).
  - O(n²) duplicate scan cost analysis.
  - Per-invocation CPU budget assertions against `PER_INVOCATION_CPU_BUDGET` (`25_000_000_000` CPU instructions, enforcing a 75% safety margin under Soroban's 100B instruction cap).
  - Companion O(n) helper refactor cross-reference.

### 2. Documentation & Baseline Matrix (`docs/gas.md`)
- Updated `### O(n²) duplicate-ID scan at MAX_PAGE_SIZE` section detailing batch sizes 1, 10, 50, and 100 across all four entrypoints and cross-referencing the companion O(n) refactor issue.
- Updated `<!-- GAS_BASELINE_START -->` JSON matrix with baselines for sizes `1`, `10`, `50`, and `100` for `bulk_resume_streams_as_admin` and `bulk_cancel_streams`.

### 3. Baseline Validation Script & Tests (`script/validate_gas.py`, `tests/`)
- Updated `BULK_BATCH_BASELINE_SIZES = ("1", "10", "50", "100")` in `script/validate_gas.py` to enforce CI baseline checks across all four sizes.
- Updated mock test fixtures in `tests/test_validator.py` and `tests/test_gas_validation.py`.

---

## Companion Refactor Note

> [!NOTE]
> A companion refactor issue replaces the current O(n²) `reject_duplicate_ids` scan with an O(n) helper (e.g. via `Map<u64, bool>`). The baselines added in this PR (especially at batch size 100) are expected to decrease significantly once that refactor lands.

---

## Verification

- `cargo test -p fluxora_stream --test gas_regression`
- `python script/validate_gas.py`
- `pytest tests/test_validator.py tests/test_gas_validation.py`
```