### PR TITLE
test(gas): add edge-case gas regression tests and docs (#1286)

### DIFF
--- a/contracts/stream/tests/gas_regression.rs
+++ b/contracts/stream/tests/gas_regression.rs
@@ -1133,3 +1133,419 @@ fn test_batch_withdraw_max_page_size_gas() {
         page, cost
     );
 }
+
+// ---------------------------------------------------------------------------
+// Additional edge-case gas measurements (issue #1286)
+//
+// These tests fill the remaining coverage gaps identified in the issue review:
+//
+//   cancel_stream_single         — single `cancel_stream` by the sender on a
+//                                  partially-accrued active stream.  The bulk
+//                                  variant (`bulk_cancel_streams`) is already
+//                                  measured but does not expose the per-stream
+//                                  cost in isolation.
+//
+//   zero_accrual_withdraw        — `withdraw` when the cliff has not yet been
+//                                  reached.  No token transfer is issued; the
+//                                  accrual short-circuit path is exercised and
+//                                  its cost documented.
+//
+//   update_rate_per_second       — `update_rate_per_second` (rate increase) on
+//                                  an active stream.  Checkpoints the accrual,
+//                                  validates the new rate against the max-rate
+//                                  cap, then saves the updated stream.
+//
+//   decrease_rate_per_second     — `decrease_rate_per_second` on an active
+//                                  stream.  Checkpoints accrual, computes a
+//                                  partial refund, persists state, and issues
+//                                  a token transfer back to the sender.
+//
+//   top_up_stream                — `top_up_stream` adds deposit to an active
+//                                  stream.  Pulls tokens from the funder and
+//                                  increases the global liabilities counter.
+//
+//   shorten_stream_end_time      — `shorten_stream_end_time` truncates an active
+//                                  stream's schedule, computes a sender refund,
+//                                  and issues the refund token transfer.
+//
+//   extend_stream_end_time       — `extend_stream_end_time` pushes an active
+//                                  stream's end time further into the future when
+//                                  the existing deposit is sufficient to cover the
+//                                  extended schedule at the current rate.
+//
+//   emergency_pause_create       — `create_stream` attempted while the contract
+//                                  is under emergency pause.  The call should
+//                                  revert with `GloballyPaused` after a minimal
+//                                  storage read; this test documents the cost of
+//                                  the early-exit guard.
+// ---------------------------------------------------------------------------
+
+/// Gas baseline for `cancel_stream` (single stream, partial accrual).
+///
+/// Measures the cost of a sender-initiated cancellation at mid-stream (t=500
+/// on a 0→1 000 schedule).  The contract executes:
+///   1. Load stream.
+///   2. Calculate accrued-to-date.
+///   3. Transfer accrued portion to recipient.
+///   4. Transfer unstreamed refund to sender.
+///   5. Persist `Cancelled` state with `cancelled_at`.
+///
+/// Two token transfers occur (recipient + sender), so this is more expensive
+/// than a plain `withdraw` (one transfer) and cheaper than `keeper_cancel`
+/// (three transfers plus fee arithmetic).
+///
+/// Setup: 1 000-token linear stream, t=500 → 500 tokens accrued, 500 refunded.
+#[test]
+fn test_cancel_stream_single_gas() {
+    let ctx = TestContext::setup();
+
+    let stream_id = ctx.create_default_stream();
+
+    // Advance to half-way so there is meaningful accrual AND a meaningful refund.
+    ctx.env.ledger().set_timestamp(500);
+
+    let cost = measure_gas(&ctx, |ctx| {
+        ctx.client.cancel_stream(&stream_id);
+    });
+
+    assert!(
+        cost <= PER_INVOCATION_CPU_BUDGET,
+        "cancel_stream (single) exceeded per-invocation CPU budget: {} > {}",
+        cost,
+        PER_INVOCATION_CPU_BUDGET,
+    );
+
+    println!("GAS_MEASUREMENT: cancel_stream: single: {}", cost);
+}
+
+/// Gas baseline for `withdraw` when the stream's cliff has not yet been reached.
+///
+/// Before `cliff_time`, `calculate_accrued_amount` returns 0.  The `withdraw`
+/// implementation detects a zero withdrawable balance, skips all token-transfer
+/// and state-mutation work, and returns 0 immediately.  This test documents
+/// the cost of that short-circuit path.
+///
+/// The test is labelled `zero_accrual` (not `before_cliff`) because the same
+/// zero-withdrawable path is also hit when the stream is already fully drained
+/// and the caller invokes `withdraw` again — cliff semantics are just the most
+/// natural way to set up the pre-condition in isolation.
+///
+/// Setup: 1 000-token stream with cliff at t=500; ledger is at t=100
+///        → 0 tokens accrued, no transfer issued.
+#[test]
+fn test_withdraw_zero_accrual_gas() {
+    let ctx = TestContext::setup();
+
+    // Create a stream where the cliff is far in the future relative to the
+    // test's ledger timestamp (t=0 initially).
+    let stream_id = ctx.client.create_stream(
+        &ctx.sender,
+        &CreateStreamParams {
+            recipient: ctx.recipient.clone(),
+            deposit_amount: 1_000_i128,
+            rate_per_second: 1_i128,
+            start_time: 0u64,
+            cliff_time: 500u64, // cliff well in the future
+            end_time: 1_000u64,
+            withdraw_dust_threshold: Some(0_i128),
+            memo: None,
+            metadata: None,
+            kind: StreamKind::Linear,
+            irrevocable: None,
+            witness: None,
+        },
+    );
+
+    // Advance to before the cliff — accrual is 0.
+    ctx.env.ledger().set_timestamp(100);
+
+    let cost = measure_gas(&ctx, |ctx| {
+        ctx.client.withdraw(&stream_id);
+    });
+
+    assert!(
+        cost <= PER_INVOCATION_CPU_BUDGET,
+        "withdraw (zero_accrual / pre-cliff) exceeded per-invocation CPU budget: {} > {}",
+        cost,
+        PER_INVOCATION_CPU_BUDGET,
+    );
+
+    println!("GAS_MEASUREMENT: withdraw_zero_accrual: single: {}", cost);
+}
+
+/// Gas baseline for `update_rate_per_second` (rate increase, active stream).
+///
+/// `update_rate_per_second` checkpoints the current accrual, validates the
+/// new rate against the governance-controlled cap and deposit ceiling, and
+/// saves the updated stream.  No token transfer occurs (deposit already locked).
+///
+/// Setup:
+///   deposit = 2 000, rate = 1/s, start = 0, end = 1 000.
+///   At t=300 we increase the rate to 2/s.
+///   new_total_streamable = 2 × 1 000 = 2 000 ≤ deposit, so the update is valid.
+#[test]
+fn test_update_rate_per_second_gas() {
+    let ctx = TestContext::setup();
+
+    // Deposit must cover the higher rate for the full duration:
+    //   rate=2, duration=1000 → total_streamable=2000 ≤ deposit=2000 ✓
+    let stream_id = ctx.client.create_stream(
+        &ctx.sender,
+        &CreateStreamParams {
+            recipient: ctx.recipient.clone(),
+            deposit_amount: 2_000_i128,
+            rate_per_second: 1_i128,  // start at rate=1
+            start_time: 0u64,
+            cliff_time: 0u64,
+            end_time: 1_000u64,
+            withdraw_dust_threshold: Some(0_i128),
+            memo: None,
+            metadata: None,
+            kind: StreamKind::Linear,
+            irrevocable: None,
+            witness: None,
+        },
+    );
+
+    // Advance ledger sequence past the rate-change cooldown before the call.
+    ctx.env.ledger().with_mut(|l| {
+        l.timestamp = 300;
+        l.sequence_number += 32; // clear rate-change cooldown
+    });
+
+    let cost = measure_gas(&ctx, |ctx| {
+        ctx.client.update_rate_per_second(&stream_id, &2_i128);
+    });
+
+    assert!(
+        cost <= PER_INVOCATION_CPU_BUDGET,
+        "update_rate_per_second exceeded per-invocation CPU budget: {} > {}",
+        cost,
+        PER_INVOCATION_CPU_BUDGET,
+    );
+
+    println!("GAS_MEASUREMENT: update_rate_per_second: single: {}", cost);
+}
+
+/// Gas baseline for `decrease_rate_per_second` (rate decrease + refund).
+///
+/// `decrease_rate_per_second` checkpoints the current accrual, recomputes the
+/// new deposit ceiling under the lower rate, computes the sender refund, persists
+/// the updated state (CEI order), and issues one token transfer back to the sender.
+///
+/// Setup:
+///   deposit = 2 000, rate = 2/s, start = 0, end = 1 000.
+///   At t=300 we decrease rate to 1/s.
+///   Accrued-to-date = 300 × 2 = 600.  Remaining seconds = 700.
+///   Future accrual at new rate = 1 × 700 = 700.  New deposit = 600 + 700 = 1 300.
+///   Refund = 2 000 − 1 300 = 700 tokens transferred back to sender.
+#[test]
+fn test_decrease_rate_per_second_gas() {
+    let ctx = TestContext::setup();
+
+    // Create a stream where deposit covers rate=2 for the full duration so the
+    // decrease to rate=1 produces a meaningful refund.
+    let stream_id = ctx.client.create_stream(
+        &ctx.sender,
+        &CreateStreamParams {
+            recipient: ctx.recipient.clone(),
+            deposit_amount: 2_000_i128,  // covers rate=2 × duration=1000
+            rate_per_second: 2_i128,
+            start_time: 0u64,
+            cliff_time: 0u64,
+            end_time: 1_000u64,
+            withdraw_dust_threshold: Some(0_i128),
+            memo: None,
+            metadata: None,
+            kind: StreamKind::Linear,
+            irrevocable: None,
+            witness: None,
+        },
+    );
+
+    ctx.env.ledger().with_mut(|l| {
+        l.timestamp = 300;
+        l.sequence_number += 32; // clear rate-change cooldown
+    });
+
+    let cost = measure_gas(&ctx, |ctx| {
+        ctx.client.decrease_rate_per_second(&stream_id, &1_i128);
+    });
+
+    assert!(
+        cost <= PER_INVOCATION_CPU_BUDGET,
+        "decrease_rate_per_second exceeded per-invocation CPU budget: {} > {}",
+        cost,
+        PER_INVOCATION_CPU_BUDGET,
+    );
+
+    println!("GAS_MEASUREMENT: decrease_rate_per_second: single: {}", cost);
+}
+
+/// Gas baseline for `top_up_stream` (add deposit to an active stream).
+///
+/// `top_up_stream` pulls tokens from the funder, increases the stream's
+/// deposit_amount, and updates the global TotalLiabilities counter.  No
+/// schedule change occurs.
+///
+/// Setup: 1 000-token stream active at t=300; top-up amount = 500 tokens.
+#[test]
+fn test_top_up_stream_gas() {
+    let ctx = TestContext::setup();
+
+    let stream_id = ctx.create_default_stream();
+
+    // Advance the ledger so the stream is live (past start) but not yet expired.
+    ctx.env.ledger().set_timestamp(300);
+
+    // The top-up funder can be the sender (the default sender already has
+    // a large allowance set up by TestContext::setup).
+    let cost = measure_gas(&ctx, |ctx| {
+        ctx.client.top_up_stream(&stream_id, &ctx.sender, &500_i128);
+    });
+
+    assert!(
+        cost <= PER_INVOCATION_CPU_BUDGET,
+        "top_up_stream exceeded per-invocation CPU budget: {} > {}",
+        cost,
+        PER_INVOCATION_CPU_BUDGET,
+    );
+
+    println!("GAS_MEASUREMENT: top_up_stream: single: {}", cost);
+}
+
+/// Gas baseline for `shorten_stream_end_time` (schedule truncation + refund).
+///
+/// `shorten_stream_end_time` checkpoints accrual, computes a sender refund for
+/// the truncated portion, persists the updated schedule (CEI), and issues one
+/// token transfer back to the sender.
+///
+/// Setup: 1 000-token stream (rate=1/s, 0→1 000); at t=300 we shorten to t=600.
+///   Remaining seconds at t=600 = 600 − 0 = 600.  New max streamable = 600.
+///   Accrued-to-date = 300 ≤ 600, so new_deposit = 600.
+///   Refund = 1 000 − 600 = 400 tokens transferred to sender.
+#[test]
+fn test_shorten_stream_end_time_gas() {
+    let ctx = TestContext::setup();
+
+    let stream_id = ctx.create_default_stream();
+
+    // Advance to t=300 so accrual is meaningful and refund is non-zero.
+    ctx.env.ledger().set_timestamp(300);
+
+    let cost = measure_gas(&ctx, |ctx| {
+        ctx.client.shorten_stream_end_time(&stream_id, &600u64);
+    });
+
+    assert!(
+        cost <= PER_INVOCATION_CPU_BUDGET,
+        "shorten_stream_end_time exceeded per-invocation CPU budget: {} > {}",
+        cost,
+        PER_INVOCATION_CPU_BUDGET,
+    );
+
+    println!("GAS_MEASUREMENT: shorten_stream_end_time: single: {}", cost);
+}
+
+/// Gas baseline for `extend_stream_end_time` (schedule extension, no token transfer).
+///
+/// `extend_stream_end_time` moves the stream's end time forward without changing
+/// the rate or deposit.  The existing deposit must be sufficient to cover the
+/// extended schedule at the current rate.  No token transfer occurs.
+///
+/// Setup: 2 000-token stream (rate=1/s, 0→1 000).  At t=300 we extend to t=1 500.
+///   new_total_streamable = 1 × 1 500 = 1 500 ≤ deposit=2 000 ✓ (no extra transfer).
+#[test]
+fn test_extend_stream_end_time_gas() {
+    let ctx = TestContext::setup();
+
+    // Use a stream with extra deposit so the extended schedule still fits.
+    let stream_id = ctx.client.create_stream(
+        &ctx.sender,
+        &CreateStreamParams {
+            recipient: ctx.recipient.clone(),
+            deposit_amount: 2_000_i128,  // covers rate=1 × end=1500
+            rate_per_second: 1_i128,
+            start_time: 0u64,
+            cliff_time: 0u64,
+            end_time: 1_000u64,
+            withdraw_dust_threshold: Some(0_i128),
+            memo: None,
+            metadata: None,
+            kind: StreamKind::Linear,
+            irrevocable: None,
+            witness: None,
+        },
+    );
+
+    // Advance to mid-stream.
+    ctx.env.ledger().set_timestamp(300);
+
+    let cost = measure_gas(&ctx, |ctx| {
+        ctx.client.extend_stream_end_time(&stream_id, &1_500u64);
+    });
+
+    assert!(
+        cost <= PER_INVOCATION_CPU_BUDGET,
+        "extend_stream_end_time exceeded per-invocation CPU budget: {} > {}",
+        cost,
+        PER_INVOCATION_CPU_BUDGET,
+    );
+
+    println!("GAS_MEASUREMENT: extend_stream_end_time: single: {}", cost);
+}
+
+/// Gas baseline for the emergency-pause guard on `create_stream`.
+///
+/// When `set_global_emergency_paused(true)` is active, every state-mutating
+/// entry point (including `create_stream`) calls `require_not_globally_paused`
+/// early in its execution.  That function reads one instance-storage key
+/// (`GlobalEmergencyPaused`) and returns `GloballyPaused` before any stream
+/// validation, deposit transfer, or storage write occurs.
+///
+/// This test captures the cost of that early-exit guard so that any future
+/// change to the pause-check overhead (e.g. additional flag reads) is detected.
+/// The test calls `try_create_stream` (the fallible variant) so the panic from
+/// the expected error does not abort the test process.
+///
+/// Setup: emergency pause activated; `create_stream` called with a valid payload
+///        → call reverts at `require_not_globally_paused`.
+#[test]
+fn test_create_stream_under_emergency_pause_gas() {
+    let ctx = TestContext::setup();
+
+    // Activate the global emergency pause.
+    ctx.client.set_global_emergency_paused(&true);
+
+    let params = CreateStreamParams {
+        recipient: ctx.recipient.clone(),
+        deposit_amount: 1_000_i128,
+        rate_per_second: 1_i128,
+        start_time: 0u64,
+        cliff_time: 0u64,
+        end_time: 1_000u64,
+        withdraw_dust_threshold: Some(0_i128),
+        memo: None,
+        metadata: None,
+        kind: StreamKind::Linear,
+        irrevocable: None,
+        witness: None,
+    };
+
+    // Reset budget and call the fallible variant so we capture cost even on revert.
+    ctx.env.budget().reset_unlimited();
+    let _result = ctx.client.try_create_stream(&ctx.sender, &params);
+    let cost = ctx.env.budget().cpu_instruction_cost();
+
+    assert!(
+        cost <= PER_INVOCATION_CPU_BUDGET,
+        "create_stream (emergency_pause guard) exceeded per-invocation CPU budget: {} > {}",
+        cost,
+        PER_INVOCATION_CPU_BUDGET,
+    );
+
+    println!(
+        "GAS_MEASUREMENT: create_stream_emergency_pause: single: {}",
+        cost
+    );
+}

--- a/docs/gas.md
+++ b/docs/gas.md
@@ -306,6 +306,147 @@ cargo test -p fluxora_stream gas_regression -- --nocapture 2>&1 | grep GAS_MEASU
 
 ---
 
+## Edge-Case Gas Coverage
+
+The following tests in `contracts/stream/tests/gas_regression.rs` explicitly document gas costs
+for paths that are implicit in the baseline tests above. Each test prints a `GAS_MEASUREMENT`
+line and asserts the measured cost stays within `PER_INVOCATION_CPU_BUDGET` (25 billion
+CPU instructions — 25 % of the Soroban per-invocation ceiling).
+
+### cancel_stream (single)
+
+`cancel_stream` by the stream sender on a partially-accrued active stream.  Issues two
+token transfers (accrued portion → recipient; unstreamed refund → sender) and freezes
+the stream state at `Cancelled` with a `cancelled_at` timestamp.
+
+| Aspect | Detail |
+|---|---|
+| Token transfers | 2 (recipient + sender refund) |
+| Cost relative to peers | More than `withdraw` (1 transfer); less than `keeper_cancel` (3 transfers + fee arithmetic) |
+| Test name | `test_cancel_stream_single_gas` |
+| Setup | 1 000-token linear stream; t=500 → 500 accrued, 500 refunded |
+
+### withdraw (zero accrual / pre-cliff)
+
+`withdraw` called before `cliff_time` is reached.  `calculate_accrued_amount` returns 0
+immediately; the contract skips all token-transfer and storage-mutation work and returns 0.
+Captures the cost of the short-circuit path.
+
+| Aspect | Detail |
+|---|---|
+| Token transfers | 0 (short-circuit return) |
+| Cost relative to peers | Lower than a normal `withdraw` (no transfer, no state write) |
+| Test name | `test_withdraw_zero_accrual_gas` |
+| Setup | 1 000-token stream with cliff at t=500; ledger at t=100 → 0 accrued |
+
+### update_rate_per_second
+
+`update_rate_per_second` (rate increase) on an active stream.  Checkpoints accrual under
+the old rate, validates the new rate against the governance cap and deposit ceiling, and
+saves the updated stream.  No token transfer occurs.
+
+| Aspect | Detail |
+|---|---|
+| Token transfers | 0 (deposit already locked) |
+| Additional work | Accrual checkpoint write + rate-cooldown ledger bump |
+| Test name | `test_update_rate_per_second_gas` |
+| Setup | 2 000-token stream (rate=1/s, 0→1 000); increase to rate=2 at t=300 |
+
+### decrease_rate_per_second
+
+`decrease_rate_per_second` on an active stream.  Checkpoints accrual under the old rate,
+computes the sender refund from the reduced deposit ceiling, persists updated state (CEI
+ordering), and issues one token transfer back to the sender.
+
+| Aspect | Detail |
+|---|---|
+| Token transfers | 1 (sender refund) |
+| Additional work | Accrual checkpoint write + refund calculation + rate-cooldown bump |
+| Test name | `test_decrease_rate_per_second_gas` |
+| Setup | 2 000-token stream (rate=2/s, 0→1 000); decrease to rate=1 at t=300 → 700-token refund |
+
+### top_up_stream
+
+`top_up_stream` adds deposit to an active stream.  Pulls tokens from the funder, increases
+`deposit_amount`, and increments the global `TotalLiabilities` counter.  No schedule
+change occurs.
+
+| Aspect | Detail |
+|---|---|
+| Token transfers | 1 (pull from funder) |
+| Additional work | `TotalLiabilities` read + write |
+| Test name | `test_top_up_stream_gas` |
+| Setup | Default 1 000-token stream at t=300; top-up of 500 tokens |
+
+### shorten_stream_end_time
+
+`shorten_stream_end_time` truncates an active stream's schedule, checkpoints accrual,
+computes a sender refund for the unstreamed portion, persists the new schedule (CEI), and
+issues one token transfer back to the sender.
+
+| Aspect | Detail |
+|---|---|
+| Token transfers | 1 (sender refund for truncated portion) |
+| Additional work | Accrual checkpoint + `TotalLiabilities` decrement |
+| Test name | `test_shorten_stream_end_time_gas` |
+| Setup | 1 000-token stream (rate=1/s, 0→1 000); shorten to end=600 at t=300 → 400-token refund |
+
+### extend_stream_end_time
+
+`extend_stream_end_time` moves the stream's end time forward.  Validates that the existing
+deposit covers the extended schedule at the current rate.  No token transfer occurs.
+
+| Aspect | Detail |
+|---|---|
+| Token transfers | 0 (deposit already sufficient) |
+| Additional work | Single `save_stream` write after parameter validation |
+| Test name | `test_extend_stream_end_time_gas` |
+| Setup | 2 000-token stream (rate=1/s, 0→1 000); extend to end=1 500 at t=300 |
+
+### create_stream (emergency pause guard)
+
+`create_stream` attempted while `set_global_emergency_paused(true)` is active.  The call
+reads `GlobalEmergencyPaused` from instance storage and returns `GloballyPaused` before
+any stream validation, token transfer, or storage write occurs.  Captures the cost of the
+early-exit guard path.
+
+| Aspect | Detail |
+|---|---|
+| Token transfers | 0 (reverts before any transfer) |
+| Cost relative to peers | Much lower than a successful `create_stream` — only 1 instance-storage read |
+| Test name | `test_create_stream_under_emergency_pause_gas` |
+| Setup | Emergency pause activated; valid `create_stream` params submitted |
+
+### Summary: all edge-case tests
+
+| Test name | Entry point | Token transfers | Key coverage point |
+|---|---|---|---|
+| `test_cancel_stream_single_gas` | `cancel_stream` | 2 | Single-stream cancel cost isolated from bulk variant |
+| `test_withdraw_zero_accrual_gas` | `withdraw` | 0 | Pre-cliff / zero-withdrawable short-circuit path |
+| `test_update_rate_per_second_gas` | `update_rate_per_second` | 0 | Accrual checkpoint + rate increase |
+| `test_decrease_rate_per_second_gas` | `decrease_rate_per_second` | 1 | Checkpoint + refund calculation + rate decrease |
+| `test_top_up_stream_gas` | `top_up_stream` | 1 | Token pull + liabilities increment |
+| `test_shorten_stream_end_time_gas` | `shorten_stream_end_time` | 1 | Truncated schedule + sender refund |
+| `test_extend_stream_end_time_gas` | `extend_stream_end_time` | 0 | Extended schedule, no extra deposit |
+| `test_create_stream_under_emergency_pause_gas` | `create_stream` | 0 | Emergency-pause early-exit guard cost |
+| `test_create_stream_with_cliff_gas` | `create_stream` | 1 | Cliff-validation branch overhead |
+| `test_create_stream_cliff_only_gas` | `create_stream` | 1 | `CliffOnly` kind branch vs `Linear` |
+| `test_withdraw_partial_accrual_gas` | `withdraw` | 1 | Mid-stream accrual formula path |
+| `test_withdraw_to_single_gas` | `withdraw_to` | 1 | Custom destination routing branch |
+| `test_pause_then_resume_single_gas` | `pause_stream` / `resume_stream` | 0 | Pause/resume state-machine cost (both legs) |
+| `test_create_streams_partial_gas` | `create_streams_partial` | varies | Per-entry isolation overhead on mixed batches |
+| `test_batch_withdraw_max_page_size_gas` | `batch_withdraw` | varies | O(n²) scan at `MAX_PAGE_SIZE` boundary |
+
+These edge-case tests complement the baseline tests in the JSON block above.  They are
+intentionally **not** included in the JSON baseline comparison (validate_gas.py only
+compares measurements that have a corresponding baseline entry) — their purpose is to
+document the current cost and fail via `assert!` if any measurement exceeds
+`PER_INVOCATION_CPU_BUDGET`.  To promote any of these measurements to a tracked baseline,
+add the corresponding key/value pair to the JSON block and follow the
+[baseline update process](#baseline-update-process).
+
+---
+
 ## Release Hardening
 
 ### Gas Baseline Determinism Contract


### PR DESCRIPTION
## Summary

Fixes #1286

Audited the existing gas regression test surface and found 8 cost paths left implicit. This PR adds explicit tests and documentation for each.

## New tests added to `contracts/stream/tests/gas_regression.rs`

| Test | Entry point | Transfers | Coverage point |
|---|---|---|---|
| `test_cancel_stream_single_gas` | `cancel_stream` | 2 | Single-stream cancel cost, isolated from bulk variant |
| `test_withdraw_zero_accrual_gas` | `withdraw` | 0 | Pre-cliff short-circuit path (0 transfers, no state write) |
| `test_update_rate_per_second_gas` | `update_rate_per_second` | 0 | Accrual checkpoint + rate increase |
| `test_decrease_rate_per_second_gas` | `decrease_rate_per_second` | 1 | Checkpoint + refund calculation + rate decrease |
| `test_top_up_stream_gas` | `top_up_stream` | 1 | Token pull + `TotalLiabilities` increment |
| `test_shorten_stream_end_time_gas` | `shorten_stream_end_time` | 1 | Truncated schedule + sender refund |
| `test_extend_stream_end_time_gas` | `extend_stream_end_time` | 0 | Extended schedule, deposit sufficient, no token transfer |
| `test_create_stream_under_emergency_pause_gas` | `create_stream` | 0 | Emergency-pause early-exit guard cost before any transfer |

Each test:
- Uses the existing `TestContext` harness (no new infrastructure)
- Asserts `cost <= PER_INVOCATION_CPU_BUDGET` (25 billion CPU instructions)
- Prints a `GAS_MEASUREMENT` line for future baseline promotion

## Documentation update to `docs/gas.md`

New **Edge-Case Gas Coverage** section added with:
- Per-test tables: token transfer count, key coverage point, setup, test name
- Summary table of all 15 edge-case tests (new + previously existing)
- Note explaining these tests guard against budget violations without being in the JSON baseline

## Testing

- Python test suite: 361 passed, 5 failed — same 5 pre-existing failures, no new regressions
- Rust tests will run in CI (Rust toolchain not available in this environment)
- No contract logic changed; purely additive (tests + docs)

## Acceptance criteria (issue #1286)

- [x] Current contract behavior still works as it does today (no logic changes)
- [x] Edge-case behavior is documented and covered by tests
- [x] Change stays backward compatible with the current release