### PR TITLE
fix: stabilize WASM size budget checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -250,6 +250,81 @@ jobs:
           retention-days: 30
           if-no-files-found: warn
 
+  wasm-size-budget:
+    name: WASM Size Budget
+    runs-on: ubuntu-latest
+    needs: lint
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@1.94.1
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Verify Rust toolchain version
+        run: python3 script/verify_rust_version.py
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-wasm-size-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-wasm-size-
+
+      # docs/gas.md documents the budget check against all three workspace
+      # contracts, so all three must actually be built here (the `build` job
+      # above only produces fluxora_stream, which is what it needs for the
+      # reproducibility/checksum pipeline).
+      - name: Build all contracts (release, wasm32)
+        run: cargo build --release --workspace --target wasm32-unknown-unknown
+
+      - name: Install Stellar CLI (pinned)
+        run: |
+          set -euo pipefail
+          mkdir -p "$HOME/.local/bin"
+          ARCHIVE="stellar-cli-${STELLAR_CLI_VERSION}-x86_64-unknown-linux-gnu.tar.gz"
+          URL="https://github.com/stellar/stellar-cli/releases/download/v${STELLAR_CLI_VERSION}/${ARCHIVE}"
+          curl -sSfL "$URL" -o "$ARCHIVE"
+          tar -xzf "$ARCHIVE"
+          mv stellar "$HOME/.local/bin/stellar"
+          chmod +x "$HOME/.local/bin/stellar"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          stellar --version
+
+      # Best-effort: optimized budgets are informational only (see below),
+      # so a failure here must not fail the job.
+      - name: Optimize WASM (best-effort)
+        continue-on-error: true
+        run: |
+          for c in fluxora_stream fluxora_factory fluxora_governance; do
+            stellar contract optimize --wasm "target/wasm32-unknown-unknown/release/${c}.wasm" || \
+              echo "::warning::stellar contract optimize failed for ${c} — skipping optimized-size check for it."
+          done
+
+      # Hard gate: the raw release artifact is what actually gets uploaded
+      # to the network, so it's what the budget must be enforced against.
+      - name: Check raw WASM size budgets
+        run: bash script/check-wasm-size.sh
+
+      # Informational only: optimized sizes are reported (bloat/shrink
+      # annotations, step summary) but never fail the job — see
+      # docs/gas.md#optimize-step for why the hard gate stays on raw
+      # artifacts (reproducible without depending on the Stellar CLI).
+      - name: Check optimized WASM size budgets (informational)
+        continue-on-error: true
+        run: bash script/check-wasm-size.sh --optimized
+
   test:
     name: Test
     runs-on: ubuntu-latest

--- a/docs/gas.md
+++ b/docs/gas.md
@@ -32,10 +32,28 @@ bash script/check-wasm-size.sh
 bash script/check-wasm-size.sh --optimized
 ```
 
-The `wasm-size-budget` CI job:
+The `wasm-size-budget` CI job (`.github/workflows/ci.yml`):
 1. Builds all three contracts with `cargo build --release --workspace --target wasm32-unknown-unknown`.
 2. Runs `stellar contract optimize` on each artifact (best-effort; failures are non-fatal).
 3. Calls `script/check-wasm-size.sh` — **fails the job** if any artifact exceeds its budget.
+
+### Artifact Integrity
+
+Before an artifact's size is evaluated against its budget, the script checks that it is
+actually a WASM module: it must be at least 8 bytes long and its first 4 bytes must be the
+WASM magic number (`0x00 0x61 0x73 0x6D`). This catches an empty or truncated file left behind
+by an interrupted or failed build — without this check, a 0-byte artifact would be well under
+every budget and silently report "OK" instead of surfacing the real problem (the build didn't
+actually produce a contract). A failure here is reported the same way as an over-budget
+artifact: an `::error::` annotation and a non-zero exit code.
+
+### Determinism
+
+The three contracts are always processed in a fixed order (`fluxora_stream`, `fluxora_factory`,
+`fluxora_governance`) via an ordered list, not a bash associative array. This keeps stdout and
+step-summary row order identical across bash versions, operating systems, and repeated or
+retried runs, and keeps the script compatible with bash 3.2 (macOS's default `/bin/bash`,
+which predates `declare -A`).
 
 ### Updating a Budget
 

--- a/script/check-wasm-size.sh
+++ b/script/check-wasm-size.sh
@@ -28,6 +28,19 @@
 #
 # Update these budgets when a deliberate feature addition is landed; document
 # the change in docs/gas.md and in the PR description.
+#
+# Artifact integrity: every artifact is also checked for the 4-byte WASM
+# magic number (0x00 0x61 0x73 0x6D) and a minimum size before its budget is
+# evaluated. This catches empty, truncated, or otherwise corrupted build
+# outputs (e.g. a build interrupted mid-write) that would otherwise silently
+# "pass" the budget check by virtue of being suspiciously small.
+#
+# Determinism: contract processing order is a fixed list (see CONTRACTS
+# below), not a bash associative-array key iteration, so output order (and
+# therefore step-summary row order) is identical across bash versions,
+# platforms, and repeated/retried runs. This also keeps the script
+# compatible with bash 3.2 (macOS's default `/bin/bash`), which predates
+# `declare -A`.
 
 set -euo pipefail
 
@@ -47,13 +60,25 @@ for arg in "$@"; do
 done
 
 # ---------------------------------------------------------------------------
-# Budget table: contract_name -> max_bytes
+# Budget table: fixed-order contract list + lookup function.
+#
+# Deliberately not a bash associative array (`declare -A`): associative-array
+# key iteration order is an implementation detail of the bash build (and
+# `declare -A` itself requires bash 4+, which macOS's shipped `/bin/bash`
+# does not have). An ordered array plus a `case`-based lookup keeps contract
+# processing order — and therefore all printed/step-summary output — fixed
+# and reproducible everywhere.
 # ---------------------------------------------------------------------------
-declare -A BUDGETS=(
-  [fluxora_stream]=262144       # 256 KiB
-  [fluxora_factory]=131072      # 128 KiB
-  [fluxora_governance]=131072   # 128 KiB
-)
+CONTRACTS=(fluxora_stream fluxora_factory fluxora_governance)
+
+budget_for() {
+  case "$1" in
+    fluxora_stream) echo 262144 ;;      # 256 KiB
+    fluxora_factory) echo 131072 ;;     # 128 KiB
+    fluxora_governance) echo 131072 ;;  # 128 KiB
+    *) echo "" ;;
+  esac
+}
 
 # ---------------------------------------------------------------------------
 # Helper: find the previous release tag (most recent v* tag before HEAD)
@@ -70,37 +95,14 @@ find_previous_release_tag() {
 }
 
 # ---------------------------------------------------------------------------
-# Helper: get WASM file size at a given git ref
-# Returns the size in bytes, or empty string if unavailable.
-# ---------------------------------------------------------------------------
-get_wasm_size_at_ref() {
-  local ref="$1"
-  local contract="$2"
-  local suffix=".wasm"
-
-  if [ "$OPTIMIZED" -eq 1 ]; then
-    suffix=".optimized.wasm"
-  fi
-
-  local path="target/wasm32-unknown-unknown/release/${contract}${suffix}"
-
-  # Try to retrieve the blob size from git history.
-  local size
-  size=$(git -C "$GIT_REPO" cat-file -s "${ref}:${path}" 2>/dev/null) || true
-
-  # If the exact path isn't in the tree, try alternative common locations.
-  if [ -z "$size" ]; then
-    # Some tags may store WASM in a different directory structure.
-    size=$(git -C "$GIT_REPO" ls-tree -r -l "${ref}" 2>/dev/null \
-      | awk -v pat="${contract}${suffix}" '$4 == pat { print $4 }' \
-      | head -n 1) || true
-  fi
-
-  echo "$size"
-}
-
-# ---------------------------------------------------------------------------
-# Helper: get blob size from ls-tree output (fallback when cat-file fails)
+# Helper: get a WASM blob's size at a given git ref from `ls-tree`.
+# Returns the size in bytes, or empty string if the ref/path isn't found.
+#
+# This is the single lookup path for delta reporting (an earlier
+# `get_wasm_size_at_ref` helper that tried `git cat-file -s` first has been
+# removed: it was never called, and its own `ls-tree` fallback compared the
+# blob-size column against the filename pattern instead of the path column,
+# so it could not have worked if it had been wired in).
 # ---------------------------------------------------------------------------
 get_blob_size_from_ls_tree() {
   local ref="$1"
@@ -140,8 +142,8 @@ else
   echo "No previous release tag found — delta reporting disabled."
 fi
 
-for CONTRACT in "${!BUDGETS[@]}"; do
-  BUDGET="${BUDGETS[$CONTRACT]}"
+for CONTRACT in "${CONTRACTS[@]}"; do
+  BUDGET="$(budget_for "$CONTRACT")"
 
   if [ "$OPTIMIZED" -eq 1 ]; then
     WASM_FILE="${WASM_DIR}/${CONTRACT}.optimized.wasm"
@@ -160,6 +162,25 @@ for CONTRACT in "${!BUDGETS[@]}"; do
   fi
 
   SIZE=$(wc -c < "$WASM_FILE")
+
+  # Artifact-integrity check: reject empty/truncated/non-WASM files before
+  # they can be evaluated against the byte budget. Without this, a 0-byte
+  # or partial artifact from an interrupted build would silently "pass"
+  # with maximal headroom instead of failing loudly.
+  if [ "$SIZE" -lt 8 ]; then
+    echo "::error::${WASM_FILE} is only ${SIZE} bytes — too small to be a valid WASM module (empty or truncated build artifact?)." >&2
+    FAILED=1
+    SUMMARY_ROWS+=("| ${CONTRACT} | ${SIZE} bytes | ${BUDGET} | ❌ INVALID (too small) |")
+    continue
+  fi
+  MAGIC=$(od -An -tx1 -N4 "$WASM_FILE" | tr -d ' \n')
+  if [ "$MAGIC" != "0061736d" ]; then
+    echo "::error::${WASM_FILE} does not start with the WASM magic number (expected 0061736d, got ${MAGIC}) — not a valid WASM module." >&2
+    FAILED=1
+    SUMMARY_ROWS+=("| ${CONTRACT} | ${SIZE} bytes | ${BUDGET} | ❌ INVALID (bad magic) |")
+    continue
+  fi
+
   BUDGET_KIB=$(( BUDGET / 1024 ))
   SIZE_KIB=$(awk "BEGIN { printf \"%.1f\", ${SIZE}/1024 }")
 
@@ -253,8 +274,8 @@ if [ "$FAILED" -ne 0 ]; then
 fi
 
 # Edge-case: warn when headroom drops below 10% of budget.
-for CONTRACT in "${!BUDGETS[@]}"; do
-  BUDGET="${BUDGETS[$CONTRACT]}"
+for CONTRACT in "${CONTRACTS[@]}"; do
+  BUDGET="$(budget_for "$CONTRACT")"
   if [ "$OPTIMIZED" -eq 1 ]; then
     WASM_FILE="${WASM_DIR}/${CONTRACT}.optimized.wasm"
   else

--- a/tests/test_gas_validation.py
+++ b/tests/test_gas_validation.py
@@ -244,11 +244,25 @@ SCRIPT = os.path.join(os.path.dirname(__file__), "..", "script", "check-wasm-siz
 WASM_DIR = "target/wasm32-unknown-unknown/release"
 
 
+WASM_MAGIC = b"\x00asm\x01\x00\x00\x00"  # magic number + version, 8 bytes
+
+
 def _make_wasm(directory: str, name: str, size_bytes: int) -> str:
-    """Create a dummy WASM file of exactly size_bytes bytes."""
+    """Create a dummy WASM file of exactly size_bytes bytes.
+
+    Starts with a real WASM magic number + version (8 bytes) and pads with
+    zeros to reach the exact requested size, so files built by this helper
+    pass check-wasm-size.sh's artifact-integrity check the same way a real
+    (if minimal) compiled module would. Total byte count is unaffected,
+    which keeps every budget/headroom/delta assertion in this file exact.
+    """
     path = os.path.join(directory, name)
+    if size_bytes < len(WASM_MAGIC):
+        content = b"\x00" * size_bytes
+    else:
+        content = WASM_MAGIC + b"\x00" * (size_bytes - len(WASM_MAGIC))
     with open(path, "wb") as f:
-        f.write(b"\x00" * size_bytes)
+        f.write(content)
     return path
 
 
@@ -469,6 +483,87 @@ class TestCheckWasmSizeScript:
         assert "fluxora_stream" in result.stderr or "fluxora_stream" in result.stdout
         assert "fluxora_factory" in result.stderr or "fluxora_factory" in result.stdout
         assert "fluxora_governance" in result.stderr or "fluxora_governance" in result.stdout
+
+    def test_zero_byte_artifact_fails(self, tmp_path):
+        """An empty (0-byte) artifact is rejected, not silently treated as
+        'within budget'. A 0-byte file is well under every budget, so
+        without an explicit integrity check it would otherwise pass."""
+        open(os.path.join(str(tmp_path), "fluxora_stream.wasm"), "wb").close()
+        _make_wasm(str(tmp_path), "fluxora_factory.wasm", 1024)
+        _make_wasm(str(tmp_path), "fluxora_governance.wasm", 1024)
+
+        result = self._invoke(str(tmp_path))
+        assert result.returncode == 1
+        assert "too small" in result.stderr or "INVALID" in result.stderr
+
+    def test_truncated_non_wasm_artifact_fails(self, tmp_path):
+        """A file that is comfortably within budget but does not start with
+        the WASM magic number is rejected as a corrupted/non-WASM artifact,
+        e.g. an interrupted build that left a partial or garbage file behind
+        at the expected output path."""
+        path = os.path.join(str(tmp_path), "fluxora_stream.wasm")
+        with open(path, "wb") as f:
+            f.write(b"not a real wasm module, just padding bytes " * 20)
+        _make_wasm(str(tmp_path), "fluxora_factory.wasm", 1024)
+        _make_wasm(str(tmp_path), "fluxora_governance.wasm", 1024)
+
+        result = self._invoke(str(tmp_path))
+        assert result.returncode == 1
+        assert "magic number" in result.stderr or "INVALID" in result.stderr
+
+    def test_unrecognized_wasm_file_is_ignored(self, tmp_path):
+        """A .wasm file present in WASM_DIR that isn't one of the three
+        known contracts is silently ignored — the script only evaluates the
+        fixed budget table, not everything on disk. Locks in this
+        intentional, documented behavior."""
+        for contract, budget in [
+            ("fluxora_stream", 262144),
+            ("fluxora_factory", 131072),
+            ("fluxora_governance", 131072),
+        ]:
+            _make_wasm(str(tmp_path), f"{contract}.wasm", budget - 1)
+        # Deliberately huge and not WASM-shaped; would fail both the budget
+        # and the magic-number check if it were evaluated.
+        with open(os.path.join(str(tmp_path), "some_other_contract.wasm"), "wb") as f:
+            f.write(b"\xff" * 1_000_000)
+
+        result = self._invoke(str(tmp_path))
+        assert result.returncode == 0, result.stderr
+
+    def test_contract_processing_order_is_deterministic(self, tmp_path):
+        """Contract rows appear in the same relative order across repeated
+        invocations. Regression guard for replacing `declare -A` (bash
+        associative array, unordered key iteration) with a fixed-order
+        array + lookup function."""
+        for contract, budget in [
+            ("fluxora_stream", 262144),
+            ("fluxora_factory", 131072),
+            ("fluxora_governance", 131072),
+        ]:
+            _make_wasm(str(tmp_path), f"{contract}.wasm", budget // 2)
+
+        names = ("fluxora_stream", "fluxora_factory", "fluxora_governance")
+        first_order = None
+        for _ in range(5):
+            result = self._invoke(str(tmp_path))
+            assert result.returncode == 0, result.stderr
+            order = tuple(sorted(names, key=lambda n: result.stdout.index(n)))
+            if first_order is None:
+                first_order = order
+            else:
+                assert order == first_order, (
+                    "contract row order changed between runs: "
+                    f"{first_order} vs {order}"
+                )
+
+    def test_script_does_not_use_bash4_associative_arrays(self):
+        """Regression guard: `declare -A` requires bash 4+ (macOS ships
+        bash 3.2 by default) and does not guarantee stable key-iteration
+        order across bash builds/platforms. The script must use an ordered
+        array instead."""
+        with open(SCRIPT) as f:
+            content = f.read()
+        assert "declare -A" not in content
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #1309.

`script/check-wasm-size.sh` already had a fairly thorough test suite (`tests/test_gas_validation.py`), but **it was never actually invoked by CI** — `docs/gas.md` describes a `wasm-size-budget` CI job that does not exist in `.github/workflows/ci.yml`, and the existing `build` job only ever compiles `fluxora_stream` to `wasm32-unknown-unknown`, never `fluxora_factory` or `fluxora_governance`. So the byte-budget gate this repo documents as enforced was, in practice, not running at all.

This PR closes that gap and stabilizes two real edge cases in the script along the way:

- **Wires the check into CI.** Adds a `wasm-size-budget` job (parallel to `build`/`test`, depends on `lint`) that builds all three workspace contracts in release/wasm32 mode, runs a best-effort `stellar contract optimize`, and runs `script/check-wasm-size.sh` as a hard gate against the raw artifacts (optimized-artifact check stays informational only, per the existing documented rationale — the hard gate must stay reproducible without depending on the Stellar CLI).
- **Rejects corrupted/truncated artifacts.** Previously, an empty (0-byte) or partial WASM file — e.g. left behind by an interrupted build — would silently report "OK" with full headroom, since it's trivially under budget. The script now requires a minimum size and a valid WASM magic number (`0x00 0x61 0x73 0x6D`) before evaluating an artifact's budget.
- **Makes contract processing order deterministic.** The budget table was a bash associative array (`declare -A`), whose key-iteration order isn't guaranteed across bash builds/platforms (and which isn't supported at all on bash 3.2, i.e. macOS's default `/bin/bash`). Replaced with a fixed-order array + lookup function, so output/step-summary row order is identical across environments and retries.
- **Removes dead code.** `get_wasm_size_at_ref` was defined but never called; its own fallback path compared the `ls-tree` size column against the filename pattern instead of the path column, so it could not have worked correctly even if it had been wired in. Deleted rather than fixed-and-wired-in, to avoid touching the (already correct, already tested) delta-computation path.

## What didn't change

- Budget values (256 KiB / 128 KiB / 128 KiB) are untouched.
- Delta-reporting logic (`get_blob_size_from_ls_tree`, CI annotations, step summary) is untouched — verified manually against a real git repo with tagged releases (see test plan).
- Exit codes and CLI flags (`--optimized`) are unchanged.

## Test plan

- [x] Added regression tests to `tests/test_gas_validation.py`: zero-byte artifact rejection, non-WASM/bad-magic artifact rejection, unrecognized `.wasm` files in the directory being ignored (documents existing behavior), deterministic contract ordering across repeated runs, and a static guard against reintroducing `declare -A`.
- [x] Updated the shared `_make_wasm` test helper to emit a valid WASM magic header so all pre-existing budget/boundary/delta tests keep passing unchanged under the new integrity check (byte counts are unaffected).
- [x] Manually exercised the modified script directly (happy path, zero-byte artifact, bad-magic artifact, exact-budget boundary, unrecognized extra file, 3x determinism check, and a real tagged-git-repo delta scenario) — all behave as expected.
- [x] Confirmed via `git stash` diff that the full Python test suite has the same 35 pre-existing failures with or without this change (all Windows-sandbox `subprocess`-vs-WSL-`bash` path resolution artifacts and one pre-existing, out-of-scope doc/code drift item unrelated to this script) — this PR introduces no new failures.
- [x] Validated the updated `.github/workflows/ci.yml` parses as well-formed YAML and the new job is correctly wired into the dependency graph.
- [ ] CI on this PR (not runnable locally against the real `ubuntu-latest` bash/toolchain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)