### PR TITLE
fix scripts/ → script/ path references in script/README.md

### DIFF
--- a/fix-script-readme-paths.patch
+++ b/fix-script-readme-paths.patch
@@ -1,0 +1,31 @@
+diff --git a/script/README.md b/script/README.md
+index d4d2944..3aba3e1 100644
+--- a/script/README.md
++++ b/script/README.md
+@@ -30,7 +30,7 @@ Implementation is scaffolded; storage, token transfers, and events are left for
+ fluxora-contracts/
+   Cargo.toml                        # workspace
+   .env.example                      # env var template (copy → .env, never commit)
+-  scripts/
++  script/
+     deploy-testnet.sh               # ← build + deploy + init script (see below)
+   contracts/
+     stream/
+@@ -113,7 +113,7 @@ cp .env.example .env
+ 
+ ```bash
+ source .env
+-bash scripts/deploy-testnet.sh
++bash script/deploy-testnet.sh
+ ```
+ 
+ The script will:
+@@ -136,7 +136,7 @@ The script stores the deployed WASM ID in `.wasm_id` and the contract ID in `.co
+ ### 4. Skip init (if already initialised)
+ 
+ ```bash
+-SKIP_INIT=1 bash scripts/deploy-testnet.sh
++SKIP_INIT=1 bash script/deploy-testnet.sh
+ ```
+ 
+ ### 5. Invoke contract methods after deploy

--- a/script/README.md
+++ b/script/README.md
@@ -30,7 +30,7 @@ Implementation is scaffolded; storage, token transfers, and events are left for 
 fluxora-contracts/
   Cargo.toml                        # workspace
   .env.example                      # env var template (copy → .env, never commit)
-  scripts/
+  script/
     deploy-testnet.sh               # ← build + deploy + init script (see below)
   contracts/
     stream/
@@ -113,7 +113,7 @@ cp .env.example .env
 
 ```bash
 source .env
-bash scripts/deploy-testnet.sh
+bash script/deploy-testnet.sh
 ```
 
 The script will:
@@ -136,7 +136,7 @@ The script stores the deployed WASM ID in `.wasm_id` and the contract ID in `.co
 ### 4. Skip init (if already initialised)
 
 ```bash
-SKIP_INIT=1 bash scripts/deploy-testnet.sh
+SKIP_INIT=1 bash script/deploy-testnet.sh
 ```
 
 ### 5. Invoke contract methods after deploy


### PR DESCRIPTION
Closes #1171
Summary

Corrects three instances in script/README.md where the deployment script's directory was referenced as scripts/ (plural) instead of the actual script/ (singular) directory used everywhere else in this workspace (script/check-wasm-size.sh, script/validate_gas.py, script/check-discriminant-collisions.py, etc.).

Changes

script/README.md
Project structure diagram: scripts/ → script/
"Run the deploy script" invocation: bash scripts/deploy-testnet.sh → bash script/deploy-testnet.sh
"Skip init" invocation: SKIP_INIT=1 bash scripts/deploy-testnet.sh → SKIP_INIT=1 bash script/deploy-testnet.sh

Verification performed

grep -rn "scripts/" --include="*.md" . from repo root — confirmed script/README.md was the only file with plural-path drift; zero hits after this fix.
Manually reviewed docs/DEPLOYMENT.md (9 script references) and docs/mainnet.md (2 references) — both already correctly reference the singular script/ directory, no changes needed.
Manually reviewed .github/workflows/ci.yml — all run: steps already use script/ correctly; no doc-only drift found there.

Related

Companion to the already-open issue covering script/deploy-testnet.sh's own internal usage comments (lines 24 and 28 of that file still say scripts/deploy-testnet.sh). That fix is intentionally out of scope here per this issue's description, but is called out so the two PRs stay consistent regardless of merge order.

Risk

None — documentation-only change, no code or CI behavior affected.