### PR TITLE
Fix duplicate ClaimOwnershipTransferred/RecipientShareDelegated defs; harden pause semantics tests

### DIFF
--- a/contracts/stream/docs/pause-semantics.md
+++ b/contracts/stream/docs/pause-semantics.md
@@ -1,6 +1,6 @@
 # Pause Semantics
 
-> **Issue reference:** #1329  
+> **Issue reference:** #1329, #1327  
 > **Contract:** `contracts/stream/src/lib.rs`  
 > **Status:** Normative — describes current deployed behavior.
 
@@ -146,25 +146,47 @@ Atomically resumes a batch of paused streams. Two-phase: **validate all first, t
 
 ### What the global pause blocks
 
-All calls that invoke `require_not_globally_paused` fail with `ContractError::ContractPaused`:
+All calls that invoke `require_not_globally_paused` (directly, or transitively via
+`require_not_creation_paused` / `batch_withdraw` → `batch_withdraw_to`) fail with
+`ContractError::ContractPaused`:
 
-- `create_stream`, `create_streams`, `create_streams_partial`
-- `withdraw`, `withdraw_to`, `batch_withdraw`, `withdraw_from_pool`
-- `cancel_stream`
-- `update_rate_per_second`, `decrease_rate_per_second`
+- `create_stream`, `create_streams`, `create_streams_partial`, `clone_stream`
+- `withdraw`, `withdraw_to`, `batch_withdraw`, `batch_withdraw_to`, `withdraw_from_pool`, `delegated_withdraw`
+- `cancel_stream`, `witnessed_cancel_stream`, `bulk_cancel_streams`
+- `update_rate_per_second`, `decrease_rate_per_second`, `delegate_recipient_share`
 - `shorten_stream_end_time`, `extend_stream_end_time`
 - `top_up_stream`
-- `set_admin`, `transfer_claim_ownership`
-- `accept_recipient_update`, `cancel_recipient_update`
-- `accept_stream_offer`, `reject_stream_offer`
+- `transfer_claim_ownership`
+- `update_recipient`, `accept_recipient_update`, `cancel_recipient_update`
+- `accept_stream_offer`
+- `set_lookback_window`, `set_stream_decommissioned`, `set_auto_renew`, `renew_stream`
+- `trigger_auto_claim`
+
+This list is verified against
+`grep -n "require_not_globally_paused\|require_not_creation_paused" contracts/stream/src/lib.rs`
+— re-run that grep after adding a new mutating entrypoint and update this list in the
+same PR, so it does not silently drift the way it previously had (see below).
 
 ### What the global pause does NOT block
 
 - `pause_stream`, `resume_stream` — sender can still manage their own streams.
 - All `*_as_admin` entrypoints — admin retains full control.
 - `global_resume`, `set_global_emergency_paused` — to allow clearing the pause.
+- `set_admin` — admin rotation is intentionally left available so a compromised
+  or unresponsive admin key can be replaced during an active emergency pause.
+- `reject_stream_offer` — recipients can always decline a pending offer; declining
+  returns escrowed funds to the sender and cannot be abused to move funds out
+  under pause.
 - All read-only / view functions.
 - `close_completed_stream`.
+
+> **Correction:** an earlier version of this table listed `set_admin` and
+> `reject_stream_offer` as blocked by the global pause. Neither entrypoint calls
+> `require_not_globally_paused`; both continue to work during an emergency pause.
+> `batch_withdraw_to` and several newer entrypoints (`delegate_recipient_share`,
+> `witnessed_cancel_stream`, `trigger_auto_claim`, `bulk_cancel_streams`, `clone_stream`,
+> and others listed above) were previously missing from this table entirely. Fixed
+> as part of #1327.
 
 ### Counter orthogonality
 
@@ -257,7 +279,7 @@ Both are stored in the `DataKey::Stream(stream_id)` persistent entry.
 
 ### Withdrawal from Paused
 
-`withdraw`, `withdraw_to`, `batch_withdraw`, and `withdraw_from_pool` all gate on:
+`withdraw`, `withdraw_to`, `batch_withdraw`, `batch_withdraw_to`, and `withdraw_from_pool` all gate on:
 
 ```rust
 if stream.status == StreamStatus::Paused && !is_terminal_state(&env, &stream) {
@@ -269,6 +291,10 @@ This means:
 - Withdrawal is **blocked** on a `Paused` stream that is not yet time-terminal.
 - Withdrawal is **allowed** on a `Paused` stream once `current_time >= end_time` (time-terminal override).
 - If the time-terminal withdrawal fully drains the stream, status transitions `Paused → Completed` and `PausedStreamCount` is decremented.
+- `batch_withdraw_to` (the keeper/auto-claim sweep path) applies the identical
+  per-item gate inside its batch loop — a stream cannot bypass its individual
+  pause by being swept through the batch entrypoint instead of `withdraw`.
+  Regression-pinned by `pause_semantics.rs::batch_withdraw_to_blocked_while_paused`.
 
 ### Top-up on Paused
 
@@ -277,6 +303,14 @@ This means:
 ### Rate and schedule changes on Paused
 
 `update_rate_per_second`, `decrease_rate_per_second`, `shorten_stream_end_time`, `extend_stream_end_time` all operate on non-terminal streams and are allowed while the stream is `Paused` (subject to their own cooldowns and validations).
+
+### Delegation on Paused
+
+`delegate_recipient_share` does not check `stream.status == Paused` — it only rejects `Completed`/`Cancelled` (terminal) and `now >= end_time`. A recipient can therefore split off a delegated child stream from a `Paused` parent:
+- The parent's `status` is left untouched (stays `Paused`) — only `checkpointed_amount`, `checkpointed_at`, `rate_per_second`, and `deposit_amount` are updated.
+- The child stream is always created with `status: Active`, regardless of the parent's status.
+
+This is consistent with the "rate and schedule changes on Paused" behavior above — pause gates withdrawals, not configuration/allocation changes. Regression-pinned by `pause_semantics.rs::delegate_recipient_share_allowed_while_paused`.
 
 ---
 
@@ -323,3 +357,5 @@ The following behaviors must not change across refactors. Each has at least one 
 | bulk_resume validates atomically | `bulk_resume_as_admin.rs::bulk_resume_mixed_cancelled_is_atomic` |
 | bulk_resume rejects duplicates | `bulk_resume_as_admin.rs::bulk_resume_rejects_duplicate_ids` |
 | bulk_resume rejects cooldown violation | `bulk_resume_as_admin.rs::bulk_resume_rejects_pause_cooldown` |
+| `batch_withdraw_to` blocks a Paused, non-time-terminal stream | `pause_semantics.rs::batch_withdraw_to_blocked_while_paused` |
+| `delegate_recipient_share` is unaffected by parent's Paused status | `pause_semantics.rs::delegate_recipient_share_allowed_while_paused` |

--- a/contracts/stream/src/types.rs
+++ b/contracts/stream/src/types.rs
@@ -494,28 +494,6 @@ pub struct StreamDecommissioned {
     pub decommissioned: bool,
 }
 
-/// Emitted when claim ownership is transferred on a stream.
-#[contracttype]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct ClaimOwnershipTransferred {
-    pub stream_id: u64,
-    pub old_owner: Option<Address>,
-    pub new_owner: Address,
-}
-
-/// Emitted when a recipient delegates a share of their stream.
-#[contracttype]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct RecipientShareDelegated {
-    pub parent_stream_id: u64,
-    pub child_stream_id: u64,
-    pub delegator: Address,
-    pub delegatee: Address,
-    pub share_bps: u32,
-    pub new_parent_rate: i128,
-    pub child_rate: i128,
-}
-
 /// Pagination result for paginated stream listings.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/contracts/stream/tests/pause_semantics.rs
+++ b/contracts/stream/tests/pause_semantics.rs
@@ -16,12 +16,16 @@
 //! - All four `PauseReason` variants are accepted without error
 //! - Global emergency pause blocks `withdraw` but does not block `pause_stream`
 //! - Admin-pause writes a `LastPauseRecord` while sender-pause does not
+//! - `batch_withdraw_to` honors the same per-stream Paused gate as the other
+//!   withdrawal entrypoints (issue #1327)
+//! - `delegate_recipient_share` is unaffected by a per-stream Paused status,
+//!   consistent with other non-withdrawal mutations (issue #1327)
 
 #![cfg(test)]
 
 use fluxora_stream::{
     ContractError, CreateStreamParams, FluxoraStream, FluxoraStreamClient, PauseReason, StreamKind,
-    StreamStatus,
+    StreamStatus, WithdrawToParam,
 };
 use soroban_sdk::{
     testutils::{Address as _, Ledger},
@@ -94,6 +98,31 @@ impl<'a> Ctx<'a> {
                 recipient: self.recipient.clone(),
                 deposit_amount: duration as i128,
                 rate_per_second: 1,
+                start_time: now,
+                cliff_time: now,
+                end_time: now + duration,
+                withdraw_dust_threshold: Some(0),
+                memo: None,
+                metadata: None,
+                kind: StreamKind::Linear,
+                irrevocable: None,
+                witness: None,
+            },
+        )
+    }
+
+    /// Create a linear stream at a caller-chosen `rate_per_second`, sized so
+    /// `delegate_recipient_share`'s integer-division math (`rate * share_bps
+    /// / 10000`) stays non-zero for a 50% split. `create_stream` above fixes
+    /// `rate_per_second == 1`, which underflows to a zero child rate.
+    fn create_stream_with_rate(&self, rate_per_second: i128, duration: u64) -> u64 {
+        let now = self.env.ledger().timestamp();
+        self.client.create_stream(
+            &self.sender,
+            &CreateStreamParams {
+                recipient: self.recipient.clone(),
+                deposit_amount: rate_per_second * duration as i128,
+                rate_per_second,
                 start_time: now,
                 cliff_time: now,
                 end_time: now + duration,
@@ -184,6 +213,31 @@ fn withdraw_blocked_while_paused() {
     assert_eq!(ctx.client.get_stream_state(&id).status, StreamStatus::Paused);
 
     let err = ctx.client.try_withdraw(&id);
+    assert_eq!(err, Err(Ok(ContractError::InvalidState)));
+}
+
+/// `batch_withdraw_to` is blocked on a Paused, non-time-terminal stream —
+/// same gate as `withdraw`/`withdraw_to`/`batch_withdraw`/`withdraw_from_pool`,
+/// just exercised through the keeper/auto-claim batch path. Regression guard
+/// for the per-stream Paused check at the `batch_withdraw_to` call site,
+/// which previously had no dedicated test (only global-pause coverage
+/// existed in `src/test.rs`).
+#[test]
+fn batch_withdraw_to_blocked_while_paused() {
+    let ctx = Ctx::setup();
+    let id = ctx.create_stream(1_000);
+
+    ctx.env.ledger().with_mut(|l| l.timestamp += 100);
+    ctx.sender_pause(id);
+
+    let destination = Address::generate(&ctx.env);
+    let param = WithdrawToParam {
+        stream_id: id,
+        destination,
+    };
+    let err = ctx
+        .client
+        .try_batch_withdraw_to(&ctx.recipient, &soroban_sdk::vec![&ctx.env, param]);
     assert_eq!(err, Err(Ok(ContractError::InvalidState)));
 }
 
@@ -500,12 +554,15 @@ fn global_resume_unblocks_withdraw() {
 // Admin-pause PauseRecord side-effect
 // ---------------------------------------------------------------------------
 
-/// `pause_stream` (sender path) does NOT store `DataKey::LastPauseRecord`.
-/// `pause_stream_as_admin` DOES store it, and the record can be retrieved via
-/// `get_pause_info` / the underlying storage.
+/// `pause_stream` (sender path) does NOT store `DataKey::LastPauseRecord(PauseKind::Stream)`.
+/// `pause_stream_as_admin` DOES store it.
 ///
-/// We verify the observable difference: after a sender pause there is no
-/// stored record; after an admin pause there is.
+/// `get_pause_info` is the **protocol-wide** (global) pause query — it is not
+/// the right accessor here, since `LastPauseRecord(PauseKind::Stream)` is a
+/// separate, per-mechanism instance-storage key with no public getter. We
+/// inspect it directly via `env.as_contract`, the same pattern already used
+/// by `paused_stream_count.rs` and `storage_key_compat.rs` for other
+/// storage-only keys.
 #[test]
 fn admin_pause_stores_pause_record_sender_pause_does_not() {
     let ctx = Ctx::setup();
@@ -513,11 +570,17 @@ fn admin_pause_stores_pause_record_sender_pause_does_not() {
 
     // Sender pause — no PauseRecord expected.
     ctx.sender_pause(id);
-    // `get_pause_info` returns None when no admin-pause record has been written.
-    let info = ctx.client.get_pause_info();
+    let has_record_after_sender_pause = ctx.env.as_contract(&ctx.contract_id, || {
+        ctx.env
+            .storage()
+            .instance()
+            .has(&fluxora_stream::DataKey::LastPauseRecord(
+                fluxora_stream::PauseKind::Stream,
+            ))
+    });
     assert!(
-        info.is_none(),
-        "sender pause must not write a PauseRecord; got: {info:?}"
+        !has_record_after_sender_pause,
+        "sender pause must not write a LastPauseRecord(Stream)"
     );
 
     // Resume, then admin-pause — PauseRecord expected.
@@ -525,11 +588,19 @@ fn admin_pause_stores_pause_record_sender_pause_does_not() {
     ctx.client.resume_stream(&id);
     ctx.admin_pause(id);
 
-    let info = ctx.client.get_pause_info();
+    let record_after_admin_pause = ctx.env.as_contract(&ctx.contract_id, || {
+        ctx.env
+            .storage()
+            .instance()
+            .get::<_, fluxora_stream::PauseRecord>(&fluxora_stream::DataKey::LastPauseRecord(
+                fluxora_stream::PauseKind::Stream,
+            ))
+    });
     assert!(
-        info.is_some(),
-        "admin pause must write a PauseRecord accessible via get_pause_info"
+        record_after_admin_pause.is_some(),
+        "admin pause must write a LastPauseRecord(Stream) accessible from instance storage"
     );
+    assert_eq!(record_after_admin_pause.unwrap().actor, ctx.admin);
 }
 
 // ---------------------------------------------------------------------------
@@ -568,4 +639,42 @@ fn resume_active_stream_returns_stream_not_paused() {
     let err = ctx.client.try_resume_stream(&id);
     assert_eq!(err, Err(Ok(ContractError::StreamNotPaused)));
     assert_eq!(ctx.client.get_paused_stream_count(), 0);
+}
+
+// ---------------------------------------------------------------------------
+// Non-withdrawal operations on a Paused stream
+// ---------------------------------------------------------------------------
+
+/// `delegate_recipient_share` is NOT blocked by a per-stream Paused status
+/// (only by the terminal-state and end_time guards it already checks).
+/// This mirrors the existing "rate/schedule changes are allowed on Paused"
+/// behavior documented for `update_rate_per_second` / `top_up_stream` — pause
+/// only gates withdrawals, not configuration changes. Pinned here so a future
+/// refactor that adds a `status == Active` guard to this entrypoint is a
+/// deliberate, reviewed behavior change rather than an accidental regression.
+#[test]
+fn delegate_recipient_share_allowed_while_paused() {
+    let ctx = Ctx::setup();
+    let id = ctx.create_stream_with_rate(10_000, 1_000);
+
+    ctx.sender_pause(id);
+    assert_eq!(
+        ctx.client.get_stream_state(&id).status,
+        StreamStatus::Paused
+    );
+
+    let new_recipient = Address::generate(&ctx.env);
+    let child_id =
+        ctx.client
+            .delegate_recipient_share(&id, &ctx.recipient, &5_000u32, &new_recipient);
+
+    // Parent stream remains Paused; child is created Active.
+    assert_eq!(
+        ctx.client.get_stream_state(&id).status,
+        StreamStatus::Paused
+    );
+    assert_eq!(
+        ctx.client.get_stream_state(&child_id).status,
+        StreamStatus::Active
+    );
 }


### PR DESCRIPTION
## Summary

Two independent, small fixes to `contracts/stream`:

- **#1112**: `types.rs` defined both `ClaimOwnershipTransferred` and `RecipientShareDelegated` twice (identical fields, different doc comments), which fails to compile the whole crate (E0428/E0119/E0592/E0034). The `lib.rs` import that #1112 originally reported as missing (`E0422`) already exists via `pub use crate::types::{ClaimOwnershipTransferred, ...}` plus a crate-root `pub use crate::types::*` wildcard re-export — so the real fix is removing the redundant struct definitions, not adding an import.
- **#1327**: hardened per-stream pause-semantics test coverage and fixed a regression test that didn't even compile.

## What changed

**`contracts/stream/src/types.rs`** (#1112)
- Removed the duplicate `ClaimOwnershipTransferred` and `RecipientShareDelegated` struct definitions (lines ~497–517), keeping the originals.
- Audited every `pub` item in `types.rs` against `lib.rs`'s imports — the crate-root `pub use crate::types::*` wildcard means everything is already reachable, so no other orphaned-import gaps exist.
- Confirmed `transfer_claim_ownership` and `delegate_recipient_share` construct these events with fields matching the (now singular) struct definitions.

**`contracts/stream/tests/pause_semantics.rs`** + **`contracts/stream/docs/pause-semantics.md`** (#1327)
- Fixed `admin_pause_stores_pause_record_sender_pause_does_not`, which called `.is_none()`/`.is_some()` on `PauseInfo` (a plain struct, not an `Option`) — a compile error (E0599) that blocked the entire `pause_semantics.rs` test binary (21 other tests) from running at all. Rewrote it to inspect `DataKey::LastPauseRecord(PauseKind::Stream)` directly via `env.as_contract()`, the same pattern used elsewhere in the suite (`paused_stream_count.rs`, `storage_key_compat.rs`) for storage-only keys with no public getter.
- Added `batch_withdraw_to_blocked_while_paused`: `batch_withdraw_to` already enforces the same per-stream Paused-and-not-terminal gate as the other withdrawal entrypoints, but had no dedicated regression test.
- Added `delegate_recipient_share_allowed_while_paused`: documents/pins that delegation is intentionally unaffected by a per-stream Paused status (consistent with other non-withdrawal mutations like rate/schedule changes).
- Corrected `docs/pause-semantics.md`'s "what the global pause blocks" table — it was missing ~12 entrypoints added since it was written (`batch_withdraw_to`, `delegate_recipient_share`, `witnessed_cancel_stream`, `trigger_auto_claim`, `bulk_cancel_streams`, `clone_stream`, etc.) and incorrectly listed `set_admin` and `reject_stream_offer` as blocked when neither actually calls `require_not_globally_paused`.
- No production/contract logic changed for #1327 — this PR closes documentation and test-coverage gaps only; the pause/unpause happy path and all existing edge-case behavior is unchanged.

## Verification performed

- `cargo check -p fluxora_stream`: the 24 duplicate-definition errors (E0428/E0119/E0592/E0034) are gone. Confirmed via before/after error-set diffing that no new errors were introduced.
- `cargo test -p fluxora_stream --features testutils --test pause_semantics --test paused_stream_count --test bulk_resume_as_admin --test delegation --test dust_threshold`: all 54 tests pass (22 + 9 + 7 + 4 + 12).
- `cargo test -p fluxora_stream --features testutils --lib`: 753 passed, 1 pre-existing unrelated failure (see below), 127 ignored.
- `cargo fmt -p fluxora_stream -- --check` and `cargo clippy -p fluxora_stream --features testutils --lib`: clean for all lines touched by this PR (pre-existing formatting/lint drift in unrelated files/lines was left untouched to keep the diff scoped).

### Known pre-existing issues (out of scope, not touched by this PR)

`contracts/stream` does not currently compile clean on `main` independent of this PR — two unrelated, pre-existing errors block `cargo check -p fluxora_stream`:
- `E0425`: `types.rs:77` uses `Map` without importing `soroban_sdk::Map` (the `StreamCreated.metadata` field).
- `E0560`: `lib.rs`'s `StreamCloned` struct is missing the `withdraw_dust_threshold` field that `clone_stream` already constructs it with (likely left over from the two duplicate "include withdraw_dust_threshold in StreamCloned event" commits, #1430/#1431).

Both were confirmed present on `main` before any change in this PR and are unrelated to #1112/#1327, so they were intentionally left alone per this batch's scope. (Validation above was performed by temporarily patching these two lines locally to obtain a compilable baseline, running the full suite, then reverting the patch before committing — the committed diff contains none of that workaround.)

Also pre-existing and unrelated: `test::test_create_stream_multiple_loop` (in `src/test.rs`) panics during the SDK's automatic test-snapshot Drop hook (`soroban_env_host` `DepthLimiter` in `to_test_snapshot_file`) after creating/reading 100 streams. Confirmed via isolated reproduction that this occurs identically with or without this PR's changes — it is unrelated to pause semantics or claim-ownership transfer.

## Test plan

- [x] `cargo test -p fluxora_stream --features testutils --test pause_semantics` — 22/22 pass
- [x] `cargo test -p fluxora_stream --features testutils --test paused_stream_count --test bulk_resume_as_admin --test delegation --test dust_threshold` — 32/32 pass
- [x] `cargo test -p fluxora_stream --features testutils --lib` — 753/754 pass (1 pre-existing, unrelated failure documented above)
- [x] `cargo check -p fluxora_stream` — confirmed only the two pre-existing, unrelated errors remain; the duplicate-definition errors this PR fixes are gone

Closes #1112
Closes #1327