### PR TITLE
fix: correct gas regression measurement labels and function calls

### DIFF
--- a/contracts/stream/tests/gas_regression.rs
+++ b/contracts/stream/tests/gas_regression.rs
@@ -759,13 +759,20 @@ fn test_extend_stream_end_time_gas() {
         },
     );
 
-    ctx.env.ledger().set_timestamp(1_000 + KEEPER_GRACE + 1);
+    ctx.env.ledger().set_timestamp(300);
 
     let cost = measure_gas(&ctx, |ctx| {
-        ctx.client.keeper_cancel(&stream_id, &ctx.keeper);
+        ctx.client.extend_stream_end_time(&stream_id, &1_500u64);
     });
 
-    println!("GAS_MEASUREMENT: keeper_cancel: fully_accrued: {}", cost);
+    assert!(
+        cost <= PER_INVOCATION_CPU_BUDGET,
+        "extend_stream_end_time exceeded per-invocation CPU budget: {} > {}",
+        cost,
+        PER_INVOCATION_CPU_BUDGET,
+    );
+
+    println!("GAS_MEASUREMENT: extend_stream_end_time: single: {}", cost);
 }
 
 // ---------------------------------------------------------------------------
@@ -1293,7 +1300,7 @@ fn test_withdraw_partial_accrual_gas() {
     ctx.env.ledger().set_timestamp(300);
 
     let cost = measure_gas(&ctx, |ctx| {
-        ctx.client.extend_stream_end_time(&stream_id, &1_500u64);
+        ctx.client.withdraw(&stream_id);
     });
 
     assert!(
@@ -1509,7 +1516,7 @@ fn test_batch_withdraw_max_page_size_gas() {
     );
 
     println!(
-        "GAS_MEASUREMENT: withdraw_partial_accrual: single: {}",
+        "GAS_MEASUREMENT: batch_withdraw_max_page_size: 100: {}",
         cost
     );
 }


### PR DESCRIPTION
fix: correct gas regression measurement label/body mismatches
  
  Three tests in contracts/stream/tests/gas_regression.rs had a mismatch between what the test
  body actually measured and what it printed as a GAS_MEASUREMENT label. This caused
  validate_gas.py to silently compare the wrong operation against the wrong baseline — a real
  regression on any of these three paths could pass CI undetected.
  
  Changes
  
  ┌──────┬───────────────┬─────────────────┬─────┐
  │ Test                                  │ Was measuring │ Was labelled as │ Now │
  ├────────────────────────────────┼───────────────────────────┼──────────────────────┼─────┤
  ├──────────────────────┼───────────────────┼───────────────┼───────────────────────────────┤
  │ test_batch_withdraw_ │ batch_withdraw at │ withdraw_part │ Labels correctly as           │
  │ max_page_size_gas    │ MAX_PAGE_SIZE     │ ial_accrual   │ batch_withdraw_max_page_size: │
  │                      │                   │               │ 100                           │
  ├──────────────────────┼───────────────────┼───────────────┼───────────────────────────────┤
  │ test_withdraw_partia │ extend_stream_end │ withdraw_part │ Body now calls withdraw to    │
  │ l_accrual_gas        │ _time             │ ial_accrual   │ match label                   │
  ├──────────────────────┼───────────────────┼───────────────┼───────────────────────────────┤
  │ test_extend_stream_e │ keeper_cancel     │ (extend       │ Body now calls                │
  │ nd_time_gas          │                   │ label)        │ extend_stream_end_time to     │
  │                      │                   │               │ match label                   │
  └──────────────────────┴───────────────────┴───────────────┴───────────────────────────────┘
  
  No behaviour change. Contract logic, storage layout, error codes, event schemas, and ABI are
  untouched. Only test body calls and their printed labels are corrected.
  
  Why it matters. validate_gas.py parses GAS_MEASUREMENT lines and compares them against the JSON
  baseline in docs/gas.md. A mismatched label means the baseline comparison is running against
  the wrong entry, so a cost increase on batch_withdraw at MAX_PAGE_SIZE, withdraw partial
  accrual, or extend_stream_end_time would not be flagged as a regression. This fix closes that
  gap without touching the baseline values themselves.
  
  Testing. Run cargo test -p fluxora_stream --test gas_regression -- --nocapture and confirm each
  corrected test prints the expected label.

Closes #1339 