### PR TITLE
feat(stream): add get_stream_lineage view for split/delegated streams (#1474)

### DIFF
--- a/contracts/stream/src/lib.rs
+++ b/contracts/stream/src/lib.rs
@@ -205,6 +205,13 @@ pub const MAX_ID_RESERVATION: u32 = 100;
 /// Maximum allowed depth for recursive stream delegation.
 pub const MAX_DELEGATION_DEPTH: u32 = 3;
 
+/// Maximum number of ancestors `get_stream_lineage` will walk. A delegated
+/// stream tree is depth-bounded by `MAX_DELEGATION_DEPTH`, so the longest
+/// possible root-to-leaf chain is `MAX_DELEGATION_DEPTH + 1` streams. Bounding
+/// the walk caps the lineage read cost even against an unexpectedly long or
+/// malformed parent chain.
+pub const MAX_LINEAGE_DEPTH: u32 = MAX_DELEGATION_DEPTH + 1;
+
 /// Maximum byte length for pause-reason strings passed to `pause_stream`,
 /// `pause_stream_as_admin`, and `pause_protocol`.
 ///
@@ -4539,6 +4546,57 @@ impl FluxoraStream {
     ///   - `Cancelled`: Terminated early, unstreamed tokens refunded, terminal state
     pub fn get_stream_state(env: Env, stream_id: u64) -> Result<Stream, ContractError> {
         load_stream(&env, stream_id)
+    }
+
+    /// Returns the ancestry chain of a stream, from the root ancestor down to
+    /// `stream_id` itself (inclusive), in root-to-leaf order.
+    ///
+    /// Streams produced by `delegate_recipient_share` record their origin in
+    /// `parent_stream_id`; this view walks that chain so indexers, auditors, and
+    /// downstream contracts can reconstruct a stream's lineage in a single call.
+    /// A stream with no parent returns a single-element vector holding only its
+    /// own id.
+    ///
+    /// The walk is bounded by [`MAX_LINEAGE_DEPTH`], so the read cost is capped
+    /// even against an unexpectedly long or malformed parent chain. The
+    /// delegation tree is itself depth-bounded and cycle-free by construction
+    /// (see `delegate_recipient_share`), so a well-formed lineage is never
+    /// truncated by this bound.
+    ///
+    /// # Parameters
+    /// - `stream_id`: Unique identifier of the stream whose lineage is requested.
+    ///
+    /// # Returns
+    /// - `Ok(Vec<u64>)`: ancestor ids from root to leaf, ending with `stream_id`.
+    ///
+    /// # Errors
+    /// - Propagates the `load_stream` error if `stream_id` does not exist.
+    pub fn get_stream_lineage(
+        env: Env,
+        stream_id: u64,
+    ) -> Result<soroban_sdk::Vec<u64>, ContractError> {
+        // Walk up the parent chain, collecting leaf-first, bounded by depth.
+        let mut leaf_first: soroban_sdk::Vec<u64> = soroban_sdk::Vec::new(&env);
+        let mut current = Some(stream_id);
+        let mut depth: u32 = 0;
+        while let Some(id) = current {
+            if depth >= MAX_LINEAGE_DEPTH {
+                break;
+            }
+            let stream = load_stream(&env, id)?;
+            leaf_first.push_back(id);
+            current = stream.parent_stream_id;
+            depth += 1;
+        }
+
+        // Reverse into root-to-leaf order for the returned chain.
+        let mut root_first: soroban_sdk::Vec<u64> = soroban_sdk::Vec::new(&env);
+        let mut i = leaf_first.len();
+        while i > 0 {
+            i -= 1;
+            root_first.push_back(leaf_first.get(i).unwrap());
+        }
+        Ok(root_first)
     }
 
     /// Returns a structured health summary for a stream.

--- a/contracts/stream/tests/delegation.rs
+++ b/contracts/stream/tests/delegation.rs
@@ -215,3 +215,60 @@ fn test_delegate_recipient_share_cyclic() {
         .unwrap();
     assert_eq!(err2, ContractError::CyclicDelegation);
 }
+
+#[test]
+fn test_get_stream_lineage_walks_root_to_leaf() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|li| {
+        li.timestamp = 1000;
+        li.sequence_number = 10;
+    });
+
+    let contract_id = env.register_contract(None, fluxora_stream::FluxoraStream {});
+    let client = FluxoraStreamClient::new(&env, &contract_id);
+
+    let token_admin = Address::generate(&env);
+    let token_id = env.register_stellar_asset_contract(token_admin);
+    client.init(&token_id, &Address::generate(&env));
+
+    let sender = Address::generate(&env);
+    let recipient1 = Address::generate(&env);
+    let recipient2 = Address::generate(&env);
+    let recipient3 = Address::generate(&env);
+
+    let root = create_stream(&env, &client, &token_id, &sender, &recipient1, 10000);
+
+    // A root stream (no parent) is its own single-element lineage.
+    assert_eq!(client.get_stream_lineage(&root), soroban_sdk::vec![&env, root]);
+
+    // Delegate twice to build the chain root -> child1 -> child2.
+    let child1 = client.delegate_recipient_share(&root, &recipient1, &5000, &recipient2);
+    let child2 = client.delegate_recipient_share(&child1, &recipient2, &5000, &recipient3);
+
+    // Lineage is returned root-to-leaf, inclusive of the queried stream.
+    assert_eq!(
+        client.get_stream_lineage(&child1),
+        soroban_sdk::vec![&env, root, child1]
+    );
+    assert_eq!(
+        client.get_stream_lineage(&child2),
+        soroban_sdk::vec![&env, root, child1, child2]
+    );
+}
+
+#[test]
+fn test_get_stream_lineage_unknown_stream_errors() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, fluxora_stream::FluxoraStream {});
+    let client = FluxoraStreamClient::new(&env, &contract_id);
+    client.init(
+        &env.register_stellar_asset_contract(Address::generate(&env)),
+        &Address::generate(&env),
+    );
+
+    // A non-existent stream id has no lineage and errors rather than panicking.
+    assert!(client.try_get_stream_lineage(&999u64).is_err());
+}

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -383,6 +383,23 @@ Security and accounting rules:
 - The parent is checkpointed at the current ledger timestamp before its rate is reduced, preserving all already-accrued and already-withdrawn entitlement.
 - The child stream starts at the checkpoint timestamp and receives only the delegated future accrual. No hostnames, off-chain identifiers, or private metadata are introduced by the delegation event.
 - The child is indexed for both `new_recipient` and the original sender portfolio, so it behaves as an independent stream for reads and later withdrawals.
+- Each child records its origin in `parent_stream_id` (regular non-delegated streams leave it `None`), and the `RecipientShareDelegated` event carries both `parent_stream_id` and `child_stream_id`, so indexers can reconstruct lineage without a second read.
+
+### Stream lineage (`get_stream_lineage`)
+
+`get_stream_lineage(stream_id) -> Vec<u64>` returns a stream's ancestry chain in
+**root-to-leaf** order, inclusive of the queried stream, by following the
+`parent_stream_id` links recorded on delegated child streams.
+
+- A root stream (no parent) returns a single-element vector `[stream_id]`.
+- A delegated child returns `[root, …, stream_id]`, e.g. a stream two delegations
+  deep returns `[root, child1, child2]`.
+- The walk is bounded by `MAX_LINEAGE_DEPTH` (`MAX_DELEGATION_DEPTH + 1 = 4`) so
+  read cost is capped even against a malformed chain; because the delegation tree
+  is depth-bounded and cycle-free by construction, a well-formed lineage is never
+  truncated.
+- Querying a non-existent `stream_id` returns the standard `load_stream` error
+  rather than panicking.
 
 ### Cancellation Semantics (Issue Scope)
 


### PR DESCRIPTION
Closes #1474

Adds the `get_stream_lineage` view and the `MAX_LINEAGE_DEPTH` bound.

## Note on "split_stream"
This contract has no `split_stream` entrypoint; the mechanism that divides a stream between recipients is `delegate_recipient_share`, which creates a child stream. That path **already** records the origin on each child (`Stream.parent_stream_id`, set at `lib.rs`) and **already** emits the parent link in its event (`RecipientShareDelegated { parent_stream_id, child_stream_id, .. }`). So requirement 1 (the `parent_stream_id` field) and requirement 3 (parent link in the event) are already satisfied. What was missing is the bounded lineage view, which this PR adds on top of the existing chain.

## Changes
- `MAX_LINEAGE_DEPTH: u32 = MAX_DELEGATION_DEPTH + 1` — the delegation tree is depth-bounded at 3, so the longest possible root-to-leaf chain is 4 streams; the walk is capped at this to bound read cost even against a malformed chain.
- `get_stream_lineage(env, stream_id: u64) -> Result<Vec<u64>, ContractError>` — walks `parent_stream_id` up from the stream, then returns the chain **root-to-leaf** (inclusive). A root stream returns `[stream_id]`; a two-deep child returns `[root, child1, child2]`. An unknown id propagates the `load_stream` error (mirrors `get_stream_state`) rather than panicking.
- Tests in `contracts/stream/tests/delegation.rs`: a two-delegation chain asserting exact root-to-leaf order at each level, plus an unknown-id error case.
- `docs/streaming.md`: a "Stream lineage" subsection.

## Verification
`cargo test -p fluxora_stream --test delegation` -> 6 passed, 0 failed. (Note: the crate is `fluxora_stream`, not `fluxora-stream` as the issue's command reads.)

No struct field, event, or state changes — purely an additive read view plus a constant.
