### PR TITLE
docs: add event schema evolution and versioning policy

### DIFF
--- a/contracts/stream/src/events.rs
+++ b/contracts/stream/src/events.rs
@@ -4,8 +4,83 @@
 //! the `symbol_short!` topic definitions co-located with the payload struct.
 //! This makes ABI review trivial: every event topic is in one file.
 //!
-//! Every helper in this module is wired up as the canonical call site for
-//! its corresponding event in `lib.rs` and `storage.rs`.
+//! Every helper in this module is the canonical call site for its
+//! corresponding event in `lib.rs` and `storage.rs`.
+//!
+//! # Schema evolution policy
+//!
+//! Event payloads in this module follow an **additive-only backward-compatibility**
+//! policy defined in [`docs/event-schema-evolution.md`](docs/event-schema-evolution.md).
+//!
+//! ## Core rules
+//!
+//! 1. **Topics are permanent** — Once a `symbol_short!` literal (e.g. `"created"`,
+//!    `"withdrew"`, `"rate_upd"`) is published to any non-local network, it must
+//!    never be renamed, reassigned, or removed.
+//! 2. **Fields are append-only** — New fields may only be added **at the end** of
+//!    an existing payload struct. Existing fields must never change type, name, or
+//!    position.
+//! 3. **New fields must have safe defaults** — Prefer `Option<T>` (which defaults
+//!    to `None`). Never add a required field that would break old deserialisers.
+//! 4. **One canonical emit helper per event** — Every event is emitted by exactly
+//!    one function in this file. No re-publishing inline elsewhere.
+//! 5. **Topic cardinality is fixed** — The number of topic elements for a given
+//!    symbol is part of the event identity and must not change.
+//!
+//! ## Deprecation lifecycle
+//!
+//! 1. **Announce** — Mark the field with `@deprecated` in the doc comment and
+//!    bump `CONTRACT_VERSION`. Minimum one version notice.
+//! 2. **Signal** — Emit the field as its sentinel value (e.g. `None` for
+//!    `Option<T>`, `0` for integers). Minimum two versions.
+//! 3. **Remove** — Delete the field from the struct. Only after market is
+//!    fully migrated.
+//!
+//! ## Topics in this module
+//!
+//! | Topic symbol | Cardinality | First emitted in |
+//! |-------------|-------------|-----------------|
+//! | `"created"`  | 2           | V1              |
+//! | `"withdrew"` | 2           | V1              |
+//! | `"wdraw_to"` | 2           | V1              |
+//! | `"cancelled"`| 2           | V1              |
+//! | `"completed"`| 2           | V1              |
+//! | `"closed"`   | 2           | V1              |
+//! | `"paused"`   | 2           | V1 (data changed in V3) |
+//! | `"resumed"`  | 2           | V1              |
+//! | `"rate_upd"` | 2           | V1              |
+//! | `"rate_dec"` | 2           | V8              |
+//! | `"rate_cap"` | 2           | V8              |
+//! | `"end_shrt"` | 2           | V1              |
+//! | `"end_ext"`  | 2           | V1              |
+//! | `"top_up"`   | 2           | V1              |
+//! | `"health"`   | 2           | V8              |
+//! | `"recp_upd"` | 2           | V1              |
+//! | `"gl_pause"` | 1           | V8              |
+//! | `"gl_resume"`| 1           | V8              |
+//! | `"ct_pause"` | 1           | V8              |
+//! | `"pr_pause"` | 2           | V8              |
+//! | `"pr_resume"`| 2           | V8              |
+//! | `"ac_set"`   | 2           | V8              |
+//! | `"ac_revoke"`| 2           | V8              |
+//! | `"ac_trig"`  | 2           | V8              |
+//! | `"ex_swept"` | 2           | V8              |
+//! | `"cloned"`   | 2           | V8              |
+//! | `"kp_cncl"`  | 2           | V8              |
+//! | `"decomm"`   | 2           | V8              |
+//! | `"sndr_xfr"` | 2           | V8              |
+//! | `"renewed"`  | 3           | V8              |
+//! | `"claim_own"`| 2           | V8              |
+//! | `"del_share"`| 2           | V8              |
+//! | `"offr_crt"` | 2           | V8              |
+//! | `"offr_acc"` | 2           | V8              |
+//! | `"offr_cxl"` | 2           | V8              |
+//! | `"upgraded"` | 1           | V8              |
+//! | `"AdminUpd"` | 1           | V1              |
+//! | `"migrated"` | 1           | Reserved        |
+//!
+//! See [`docs/event-schema-evolution.md`](docs/event-schema-evolution.md) for
+//! the full policy, deprecation process, and worked examples.
 
 use crate::*;
 use soroban_sdk::{symbol_short, Address, Env};

--- a/contracts/stream/tests/event_schema_consistency.rs
+++ b/contracts/stream/tests/event_schema_consistency.rs
@@ -539,6 +539,616 @@ fn parse_doc_schemas(doc: &str) -> Vec<EventSchema> {
 }
 
 // ---------------------------------------------------------------------------
+// Additive-only evolution tests
+// ---------------------------------------------------------------------------
+
+/// Baseline registry snapshot — a **hardcoded copy** of the canonical field list
+/// for every event struct at the current version. Used by the additive-only tests
+/// below to detect regressions (field removal, reordering, or type change).
+///
+/// This MUST be a literal copy (not a delegate to `stream_event_registry()`) so
+/// that the comparison between baseline and current registry actually detects
+/// changes. When a new optional field is legitimately appended to an existing
+/// event struct, update BOTH this baseline AND `stream_event_registry()` AND
+/// `docs/events.md`.
+fn baseline_event_registry() -> Vec<EventSchema> {
+    vec![
+        EventSchema {
+            struct_name: "StreamCreated".into(),
+            fields: vec![
+                field("stream_id", "u64"),
+                field("sender", "Address"),
+                field("recipient", "Address"),
+                field("deposit_amount", "i128"),
+                field("rate_per_second", "i128"),
+                field("start_time", "u64"),
+                field("cliff_time", "u64"),
+                field("end_time", "u64"),
+                field("withdraw_dust_threshold", "i128"),
+                field("memo", "Option<Bytes>"),
+                field("metadata", "Option<Map<Bytes,Bytes>>"),
+            ],
+        },
+        EventSchema {
+            struct_name: "StreamCloned".into(),
+            fields: vec![
+                field("new_stream_id", "u64"),
+                field("source_stream_id", "u64"),
+                field("sender", "Address"),
+                field("recipient", "Address"),
+                field("deposit_amount", "i128"),
+                field("rate_per_second", "i128"),
+                field("start_time", "u64"),
+                field("cliff_time", "u64"),
+                field("end_time", "u64"),
+                field("withdraw_dust_threshold", "i128"),
+            ],
+        },
+        EventSchema {
+            struct_name: "Withdrawal".into(),
+            fields: vec![
+                field("stream_id", "u64"),
+                field("recipient", "Address"),
+                field("amount", "i128"),
+            ],
+        },
+        EventSchema {
+            struct_name: "WithdrawalTo".into(),
+            fields: vec![
+                field("stream_id", "u64"),
+                field("recipient", "Address"),
+                field("destination", "Address"),
+                field("amount", "i128"),
+            ],
+        },
+        EventSchema {
+            struct_name: "RecipientUpdated".into(),
+            fields: vec![
+                field("stream_id", "u64"),
+                field("old_recipient", "Address"),
+                field("new_recipient", "Address"),
+            ],
+        },
+        EventSchema {
+            struct_name: "RateUpdated".into(),
+            fields: vec![
+                field("stream_id", "u64"),
+                field("old_rate_per_second", "i128"),
+                field("new_rate_per_second", "i128"),
+                field("effective_time", "u64"),
+            ],
+        },
+        EventSchema {
+            struct_name: "RateCapEnforced".into(),
+            fields: vec![
+                field("stream_id", "u64"),
+                field("attempted_rate", "i128"),
+                field("max_rate_per_second", "i128"),
+            ],
+        },
+        EventSchema {
+            struct_name: "RateDecreased".into(),
+            fields: vec![
+                field("stream_id", "u64"),
+                field("old_rate_per_second", "i128"),
+                field("new_rate_per_second", "i128"),
+                field("effective_time", "u64"),
+                field("checkpointed_amount", "i128"),
+                field("refund_amount", "i128"),
+            ],
+        },
+        EventSchema {
+            struct_name: "StreamEndShortened".into(),
+            fields: vec![
+                field("stream_id", "u64"),
+                field("old_end_time", "u64"),
+                field("new_end_time", "u64"),
+                field("refund_amount", "i128"),
+            ],
+        },
+        EventSchema {
+            struct_name: "StreamEndExtended".into(),
+            fields: vec![
+                field("stream_id", "u64"),
+                field("old_end_time", "u64"),
+                field("new_end_time", "u64"),
+            ],
+        },
+        EventSchema {
+            struct_name: "StreamToppedUp".into(),
+            fields: vec![
+                field("stream_id", "u64"),
+                field("top_up_amount", "i128"),
+                field("new_deposit_amount", "i128"),
+                field("new_end_time", "u64"),
+            ],
+        },
+        EventSchema {
+            struct_name: "StreamRenewed".into(),
+            fields: vec![field("old_stream_id", "u64"), field("new_stream_id", "u64")],
+        },
+        EventSchema {
+            struct_name: "SenderTransferred".into(),
+            fields: vec![
+                field("stream_id", "u64"),
+                field("old_sender", "Address"),
+                field("new_sender", "Address"),
+            ],
+        },
+        EventSchema {
+            struct_name: "StreamHealthChanged".into(),
+            fields: vec![
+                field("stream_id", "u64"),
+                field("is_underfunded", "bool"),
+                field("remaining_balance", "i128"),
+                field("seconds_remaining", "u64"),
+            ],
+        },
+        EventSchema {
+            struct_name: "GlobalEmergencyPauseChanged".into(),
+            fields: vec![field("paused", "bool")],
+        },
+        EventSchema {
+            struct_name: "ExcessSwept".into(),
+            fields: vec![field("to", "Address"), field("amount", "i128")],
+        },
+        EventSchema {
+            struct_name: "KeeperCancelled".into(),
+            fields: vec![
+                field("stream_id", "u64"),
+                field("keeper", "Address"),
+                field("keeper_fee", "i128"),
+                field("recipient_amount", "i128"),
+                field("sender_refund", "i128"),
+            ],
+        },
+        EventSchema {
+            struct_name: "StreamPaused".into(),
+            fields: vec![field("stream_id", "u64"), field("reason", "String")],
+        },
+        EventSchema {
+            struct_name: "GlobalResumed".into(),
+            fields: vec![field("resumed_at", "u64")],
+        },
+        EventSchema {
+            struct_name: "ContractPauseChanged".into(),
+            fields: vec![field("paused", "bool")],
+        },
+        EventSchema {
+            struct_name: "ProtocolPaused".into(),
+            fields: vec![field("reason", "String"), field("paused_at", "u64")],
+        },
+        EventSchema {
+            struct_name: "ProtocolResumed".into(),
+            fields: vec![field("resumed_at", "u64")],
+        },
+        EventSchema {
+            struct_name: "AutoClaimSet".into(),
+            fields: vec![field("stream_id", "u64"), field("destination", "Address")],
+        },
+        EventSchema {
+            struct_name: "AutoClaimRevoked".into(),
+            fields: vec![field("stream_id", "u64")],
+        },
+        EventSchema {
+            struct_name: "AutoClaimTriggered".into(),
+            fields: vec![
+                field("stream_id", "u64"),
+                field("destination", "Address"),
+                field("amount", "i128"),
+            ],
+        },
+        EventSchema {
+            struct_name: "ClaimOwnershipTransferred".into(),
+            fields: vec![
+                field("stream_id", "u64"),
+                field("old_owner", "Option<Address>"),
+                field("new_owner", "Address"),
+            ],
+        },
+        EventSchema {
+            struct_name: "StreamDecommissioned".into(),
+            fields: vec![field("stream_id", "u64"), field("decommissioned", "bool")],
+        },
+        EventSchema {
+            struct_name: "RecipientShareDelegated".into(),
+            fields: vec![
+                field("parent_stream_id", "u64"),
+                field("child_stream_id", "u64"),
+                field("delegator", "Address"),
+                field("delegatee", "Address"),
+                field("share_bps", "u32"),
+                field("new_parent_rate", "i128"),
+                field("child_rate", "i128"),
+            ],
+        },
+        EventSchema {
+            struct_name: "StreamOfferCreated".into(),
+            fields: vec![
+                field("offer_id", "u64"),
+                field("sender", "Address"),
+                field("recipient", "Address"),
+                field("deposit_amount", "i128"),
+                field("rate_per_second", "i128"),
+                field("start_time", "u64"),
+                field("cliff_time", "u64"),
+                field("end_time", "u64"),
+                field("expiry_time", "Option<u64>"),
+                field("created_at", "u64"),
+            ],
+        },
+        EventSchema {
+            struct_name: "StreamOfferAccepted".into(),
+            fields: vec![
+                field("offer_id", "u64"),
+                field("effective_start_time", "u64"),
+                field("recipient", "Address"),
+            ],
+        },
+        EventSchema {
+            struct_name: "StreamOfferCancelled".into(),
+            fields: vec![
+                field("offer_id", "u64"),
+                field("by", "Address"),
+                field("refund_amount", "i128"),
+            ],
+        },
+        EventSchema {
+            struct_name: "ContractUpgraded".into(),
+            fields: vec![
+                field("new_wasm_hash", "BytesN<32>"),
+                field("new_version", "u32"),
+                field("upgraded_at", "u64"),
+                field("upgraded_by", "Address"),
+            ],
+        },
+    ]
+}
+
+/// Verify that no existing event struct has had a field removed, reordered,
+/// or changed type. This enforces the additive-only evolution policy defined
+/// in `docs/event-schema-evolution.md`.
+///
+/// The current registry is compared against the baseline. If the baseline
+/// needs updating (because a new field was intentionally appended), update
+/// `baseline_event_registry()` to match.
+///
+/// # Panics
+/// - If a field name present in the baseline is absent from the current registry.
+/// - If a field's type changed between baseline and current registry.
+/// - If a field's ordinal position changed (reordering).
+#[test]
+fn test_additive_only_evolution() {
+    let baseline = baseline_event_registry();
+    let current = stream_event_registry();
+    let mut errors: Vec<String> = Vec::new();
+
+    for b in &baseline {
+        let c = match current.iter().find(|c| c.struct_name == b.struct_name) {
+            Some(c) => c,
+            None => {
+                errors.push(format!(
+                    "EVENT '{}' was present in the baseline but is MISSING from the current registry.\n\
+                     Events must not be removed. If this is intentional, update baseline_event_registry().",
+                    b.struct_name
+                ));
+                continue;
+            }
+        };
+
+        // Check each baseline field exists at the same ordinal with the same type.
+        for (i, bf) in b.fields.iter().enumerate() {
+            if i >= c.fields.len() {
+                errors.push(format!(
+                    "FIELD '{}' at ordinal {} of struct '{}' (type: {}) was present in the\n\
+                     baseline but is MISSING from the current registry. Fields must not be removed.\n\
+                     If this is an intentional deprecation, follow the process in\n\
+                     docs/event-schema-evolution.md and update the baseline.",
+                    bf.name, i, b.struct_name, bf.typ
+                ));
+                continue;
+            }
+
+            let cf = &c.fields[i];
+
+            // Check name match at this ordinal.
+            if cf.name != bf.name {
+                errors.push(format!(
+                    "FIELD REORDERING in struct '{}': at ordinal {} expected field '{}'\n\
+                     but found '{}'. Fields must not be reordered.",
+                    b.struct_name, i, bf.name, cf.name
+                ));
+            }
+
+            // Check type match at this ordinal.
+            if normalize_type(&cf.typ) != normalize_type(&bf.typ) {
+                errors.push(format!(
+                    "FIELD TYPE CHANGE in struct '{}': field '{}' changed from '{}'\n\
+                     to '{}'. Field types must not change.",
+                    b.struct_name, bf.name, bf.typ, cf.typ
+                ));
+            }
+        }
+
+        // Check that new fields are ONLY appended (i.e., the baseline prefix is preserved).
+        if c.fields.len() < b.fields.len() {
+            // Already reported above as missing fields.
+        }
+    }
+
+    if !errors.is_empty() {
+        let msg = errors.join("\n---\n");
+        panic!(
+            "\n\n=== ADDITIVE-ONLY EVOLUTION VIOLATIONS ===\n\
+             The following changes violate the additive-only event schema evolution\n\
+             policy defined in docs/event-schema-evolution.md:\n\n{}\n\n\
+             ACTION REQUIRED:\n\
+             - If you need to add a field, append it at the END of the struct.\n\
+             - If you need to deprecate a field, follow the process in the policy doc.\n\
+             - If the baseline itself needs updating, update baseline_event_registry().\n",
+            msg
+        );
+    }
+}
+
+/// Verify that every event struct's fields have safe default types for new
+/// (appended) fields. This enforces Rule 3 from docs/event-schema-evolution.md:
+/// new fields must always be `Option<T>` or have a safe zero-value default.
+///
+/// This test operates on the current registry. It checks that any field
+/// that is NOT present in the baseline (i.e., was appended later) uses a
+/// safe default type.
+#[test]
+fn test_new_fields_have_safe_defaults() {
+    let baseline = baseline_event_registry();
+    let current = stream_event_registry();
+    let mut errors: Vec<String> = Vec::new();
+
+    // Known safe default types
+    fn is_safe_default_type(typ: &str) -> bool {
+        let normalized = normalize_type(typ);
+        normalized.starts_with("Option<")
+            || normalized == "bool"
+            || normalized == "u64"
+            || normalized == "u32"
+            || normalized == "i128"
+    }
+
+    for c in &current {
+        let b = baseline.iter().find(|b| b.struct_name == c.struct_name);
+        let baseline_field_count = b.map(|b| b.fields.len()).unwrap_or(0);
+
+        // Check only fields beyond the baseline count (newly appended fields).
+        for i in baseline_field_count..c.fields.len() {
+            let f = &c.fields[i];
+            if !is_safe_default_type(&f.typ) {
+                errors.push(format!(
+                    "NEW FIELD '{}.{}: {}' (ordinal {}) does not have a safe default type.\n\
+                     Per docs/event-schema-evolution.md §4.1, new fields MUST use a safe\n\
+                     default type (Option<T>, bool, u64, u32, or i128).\n\
+                     Consider wrapping in Option<...> instead.",
+                    c.struct_name, f.name, f.typ, i
+                ));
+            }
+        }
+    }
+
+    if !errors.is_empty() {
+        let msg = errors.join("\n---\n");
+        panic!(
+            "\n\n=== SAFE DEFAULT TYPE VIOLATIONS ===\n\n{}\n",
+            msg
+        );
+    }
+}
+
+/// Verify that every topic symbol defined in docs/events.md matches a known
+/// set of permanently reserved topic symbols. This enforces the topic
+/// permanence rule from docs/event-schema-evolution.md §3.
+///
+/// The known topic list is sourced from `events.rs` and `lib.rs` emit calls.
+/// Any undocumented topic symbol in the docs is flagged.
+///
+/// NOTE: This test does NOT parse Rust source to extract topics (that would
+/// require a full Rust parser). Instead it relies on the hand-maintained
+/// registry of topic symbols below, which must be kept in sync with events.rs.
+#[test]
+fn test_topic_symbols_are_documented() {
+    // Hand-maintained list of every topic symbol in the contract.
+    // This MUST be kept in sync with `contracts/stream/src/events.rs`.
+    let known_topics: &[&str] = &[
+        "created",
+        "withdrew",
+        "wdraw_to",
+        "cancelled",
+        "completed",
+        "closed",
+        "paused",
+        "resumed",
+        "rate_upd",
+        "rate_dec",
+        "rate_cap",
+        "end_shrt",
+        "end_ext",
+        "top_up",
+        "health",
+        "recp_upd",
+        "gl_pause",
+        "gl_resume",
+        "ct_pause",
+        "pr_pause",
+        "pr_resume",
+        "ac_set",
+        "ac_revoke",
+        "ac_trig",
+        "ex_swept",
+        "cloned",
+        "kp_cncl",
+        "decomm",
+        "sndr_xfr",
+        "renewed",
+        "claim_own",
+        "del_share",
+        "offr_crt",
+        "offr_acc",
+        "offr_cxl",
+        "upgraded",
+        "AdminUpd",
+        // Reserved topics
+        "migrated",
+        "tmpl_def",
+        "res_rel",
+    ];
+
+    let doc_raw = include_str!("../../../docs/events.md");
+    let mut missing_from_docs: Vec<&str> = Vec::new();
+
+    for topic in known_topics {
+        // Check topic appears as a code-refenced string in docs/events.md.
+        // We look for the topic surrounded by quotes or backticks.
+        let search_patterns = [
+            &format!("\"{}\"", topic),
+            &format!("`{}`", topic),
+            &format!("[\"{}\"", topic),
+        ];
+        let found = search_patterns.iter().any(|p| doc_raw.contains(p.as_str()));
+        if !found {
+            // Also check for the topic in the event table or additional topics list
+            // by doing a more lenient search on the topic string alone
+            if !doc_raw.contains(topic) {
+                missing_from_docs.push(topic);
+            }
+        }
+    }
+
+    if !missing_from_docs.is_empty() {
+        panic!(
+            "\n\n=== UNDOCUMENTED TOPIC SYMBOLS ===\n\
+             The following topic symbols are defined in events.rs but not found\n\
+             in docs/events.md. Per the topic permanence policy, every active\n\
+             topic symbol must be documented:\n\
+             {:?}\n\
+             Add these topics to the event table or additional-topics list in\n\
+             docs/events.md.",
+            missing_from_docs
+        );
+    }
+}
+
+/// Verify that the number of topic elements (cardinality) documented in
+/// docs/events.md matches the canonical cardinality defined in events.rs.
+///
+/// This test uses a hand-maintained cardinality table that MUST be kept in
+/// sync with the emit helpers in events.rs.
+#[test]
+fn test_topic_cardinality_is_fixed() {
+    // Hand-maintained cardinality table for every topic symbol.
+    // Source: events.rs emit helper signatures.
+    // Format: (topic, expected_cardinality)
+    let expected_cardinality: &[(&str, usize)] = &[
+        ("created", 2),    // [symbol_short!("created"), stream_id]
+        ("withdrew", 2),   // [symbol_short!("withdrew"), stream_id]
+        ("wdraw_to", 2),   // [symbol_short!("wdraw_to"), stream_id]
+        ("cancelled", 2),  // [symbol_short!("cancelled"), stream_id]
+        ("completed", 2),  // [symbol_short!("completed"), stream_id]
+        ("closed", 2),     // [symbol_short!("closed"), stream_id]
+        ("paused", 2),     // [symbol_short!("paused"), stream_id]
+        ("resumed", 2),    // [symbol_short!("resumed"), stream_id]
+        ("rate_upd", 2),   // [symbol_short!("rate_upd"), stream_id]
+        ("rate_dec", 2),   // [symbol_short!("rate_dec"), stream_id]
+        ("rate_cap", 2),   // [symbol_short!("rate_cap"), stream_id]
+        ("end_shrt", 2),   // [symbol_short!("end_shrt"), stream_id]
+        ("end_ext", 2),    // [symbol_short!("end_ext"), stream_id]
+        ("top_up", 2),     // [symbol_short!("top_up"), stream_id]
+        ("health", 2),     // [symbol_short!("health"), stream_id]
+        ("recp_upd", 2),   // [symbol_short!("recp_upd"), stream_id]
+        ("gl_pause", 1),   // [symbol_short!("gl_pause")]
+        ("gl_resume", 1),  // [symbol_short!("gl_resume")]
+        ("ct_pause", 1),   // [symbol_short!("ct_pause")]
+        ("pr_pause", 2),   // [symbol_short!("pr_pause"), admin]
+        ("pr_resume", 2),  // [symbol_short!("pr_resume"), admin]
+        ("ac_set", 2),     // [symbol_short!("ac_set"), stream_id]
+        ("ac_revoke", 2),  // [symbol_short!("ac_revoke"), stream_id]
+        ("ac_trig", 2),    // [symbol_short!("ac_trig"), stream_id]
+        ("ex_swept", 2),   // [symbol_short!("ex_swept"), recipient]
+        ("cloned", 2),     // [symbol_short!("cloned"), stream_id]
+        ("kp_cncl", 2),    // [symbol_short!("kp_cncl"), stream_id]
+        ("decomm", 2),     // [symbol_short!("decomm"), stream_id]
+        ("sndr_xfr", 2),   // [symbol_short!("sndr_xfr"), stream_id]
+        ("renewed", 3),    // [symbol_short!("renewed"), old_stream_id, new_stream_id]
+        ("claim_own", 2),  // [symbol_short!("claim_own"), stream_id]
+        ("del_share", 2),  // [symbol_short!("del_share"), stream_id]
+        ("offr_crt", 2),   // [symbol_short!("offr_crt"), offer_id]
+        ("offr_acc", 2),   // [symbol_short!("offr_acc"), offer_id]
+        ("offr_cxl", 2),   // [symbol_short!("offr_cxl"), offer_id]
+        ("upgraded", 1),   // [symbol_short!("upgraded")]
+        ("AdminUpd", 1),   // [symbol_short!("AdminUpd")]
+        ("migrated", 1),   // Reserved
+    ];
+
+    let doc_raw = include_str!("../../../docs/events.md");
+    let mut errors: Vec<String> = Vec::new();
+
+    for (topic, expected_card) in expected_cardinality {
+        // We can't perfectly parse the markdown to extract cardinality, so
+        // we do a best-effort check: look for the topic in the event table
+        // and verify the topic entry matches expectations.
+        //
+        // We look for the pattern `| <topic>` or `| "<topic>"` in the table.
+        let table_patterns = [
+            format!("| `{}` |", topic),
+            format!("| `\"{}\"`", topic),
+            format!("`{}`", topic),
+        ];
+        let topic_found = table_patterns.iter().any(|p| doc_raw.contains(p.as_str()))
+            || doc_raw.contains(topic);
+
+        if !topic_found {
+            errors.push(format!(
+                "TOPIC '{}' (expected cardinality {}) not found in docs/events.md.",
+                topic, expected_card
+            ));
+            continue;
+        }
+
+        // Verify cardinality from the document: check topic patterns that
+        // indicate single vs. multi-topic cardinality.
+        //
+        // Single topic:   `["AdminUpd"]`           (topic, close bracket)
+        // Multi topic:    `["created", stream_id]` (topic, comma separator)
+        let single_topic_marker = format!("`\"{}\"]`", topic);   // matches `"AdminUpd"]` at end of topic list
+        let multi_topic_marker = format!("\"{}\",", topic);       // matches `"created",` with trailing comma
+
+        let has_single = doc_raw.contains(&single_topic_marker);
+        let has_multi = doc_raw.contains(&multi_topic_marker);
+
+        if *expected_card == 1 && has_multi && !has_single {
+            errors.push(format!(
+                "TOPIC '{}' has expected cardinality 1 but appears to be documented\n\
+                 with multiple topic elements (found comma-separated pattern) in docs/events.md.",
+                topic
+            ));
+        }
+        if *expected_card >= 2 && !has_multi && has_single {
+            errors.push(format!(
+                "TOPIC '{}' has expected cardinality {} but appears to be documented\n\
+                 with a single topic element (no comma-separated pattern) in docs/events.md.",
+                topic, expected_card
+            ));
+        }
+    }
+
+    if !errors.is_empty() {
+        let msg = errors.join("\n");
+        panic!(
+            "\n\n=== TOPIC CARDINALITY ISSUES ===\n\n{}\n\
+             Add the missing topics to docs/events.md.",
+            msg
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Cross-check logic
 // ---------------------------------------------------------------------------
 

--- a/docs/event-schema-evolution.md
+++ b/docs/event-schema-evolution.md
@@ -1,0 +1,673 @@
+# Event Schema Evolution Policy
+
+> **Status:** Adopted | **Applies to:** `contracts/stream/src/events.rs`, `contracts/stream/src/types.rs`, `contracts/stream/src/lib.rs`  
+> **Canonical reference:** [`docs/events.md`](./events.md) for the current schema catalogue  
+> **Enforcement:** `tests/event_schema_consistency.rs` (additive-only checks), `tests/event_snapshots_suite.rs` (topic/field immutability)
+
+## Table of contents
+
+1. [Motivation](#1-motivation)
+2. [Core rules](#2-core-rules)
+3. [Topic symbol permanence](#3-topic-symbol-permanence)
+4. [Additive-only field changes](#4-additive-only-field-changes)
+5. [Deprecation process](#5-deprecation-process)
+6. [Breaking changes (last resort)](#6-breaking-changes-last-resort)
+7. [Worked examples](#7-worked-examples)
+8. [Version bump checklist](#8-version-bump-checklist)
+9. [Security and testing](#9-security-and-testing)
+10. [FAQ](#10-faq)
+
+---
+
+## 1. Motivation
+
+The Fluxora stream contract emits structured Soroban events that off-chain
+indexers, dashboards, wallets, and treasury tooling consume. Once an event
+schema has been deployed to any network (testnet, mainnet) and indexed,
+changing its shape — field names, types, order, or topic symbols — silently
+breaks every downstream consumer that depends on stable field ordering and
+topic-based filtering.
+
+This document codifies the **additive-only backward-compatibility policy** that
+all contributors must follow when modifying event payloads. The policy
+guarantees that:
+
+- **No existing indexer ever breaks** from a contract upgrade.
+- **New fields are always optional** (or carry safe defaults) so old parsers
+  continue to decode the struct without error.
+- **Topic symbols are permanent** once deployed to any non-local network.
+- **Deprecation is signalled explicitly** in the payload itself before any
+  field is removed.
+
+### 1.1 Governance scope
+
+This policy covers all event payload structs and topics defined in:
+
+- `contracts/stream/src/events.rs` — Canonical topic definitions and emit helpers.
+- `contracts/stream/src/types.rs` — Event payload structs (`#[contracttype]`).
+- `contracts/stream/src/lib.rs` — Additional event types defined at the crate root.
+
+It does **not** cover:
+
+- Internal storage events (not indexed off-chain).
+- Factory or governance contract events (each has its own separate event
+  catalogue; see `docs/events.md` for the factory and governance sections).
+
+### 1.2 Relationship to other policies
+
+| Policy | Relationship |
+|--------|-------------|
+| [`docs/ABI_STABILITY.md`](./ABI_STABILITY.md) | Event fields are part of the contract ABI; ABI stability implies event-field stability. |
+| [`docs/storage.md`](./storage.md) | Storage keys use a separate `DataKey` discriminant policy; events are emission-only and do not share that discriminant space. |
+| [`docs/events.md`](./events.md) | Authoritative catalogue of every event, its topic(s), field types, and emission site. Updated in lockstep with this policy. |
+| [`CONTRACT_VERSION`](../contracts/stream/src/lib.rs) | Breaking event changes MUST bump this constant (see §6). |
+| `tests/event_schema_consistency.rs` | Programmatic cross-check that the code registry matches `docs/events.md`. |
+| `tests/event_snapshots_suite.rs` | Snapshot tests that pin exact topic+payload shapes. |
+
+---
+
+## 2. Core rules
+
+### Rule 1 — Topics are permanent
+
+Every topic symbol published via `symbol_short!(...)` in `events.rs` is
+**permanently reserved** once the contract has been deployed to any network
+other than a local ephemeral instance.
+
+> A topic symbol is the string literal inside `symbol_short!()` such as
+> `"created"`, `"withdrew"`, `"cancelled"`, `"rate_upd"`, etc.
+
+**What you may not do:**
+- Rename an existing topic symbol.
+- Reuse a retired topic symbol for a different event.
+- Change the number of topic elements for an existing symbol.
+
+**What you may do:**
+- Add a **new** topic symbol for a new event (always additive).
+- Annotate an existing topic as **deprecated** in documentation
+  (`docs/events.md` and the Rust doc comment on the emit helper).
+
+### Rule 2 — Fields are append-only
+
+New fields may only be added at the **end** of an existing event payload struct.
+Existing fields must never change type, name, or relative position.
+
+> Soroban `#[contracttype]` structs are serialised by field declaration order.
+> Inserting a field anywhere other than the end shifts every subsequent field's
+> ordinal, breaking every deserialiser built against the old layout.
+
+**What you may not do:**
+- Insert a new field before or between existing fields.
+- Reorder existing fields.
+- Change the type of an existing field (e.g. `u64` → `i128`).
+- Remove an existing field (see §5 deprecation process).
+- Rename an existing field (field *names* are not part of the XDR encoding but
+  are part of the documented contract; indexers that parse by name will break).
+
+**What you may do:**
+- Append new fields at the end of the struct.
+- Add new `Option<T>` fields (preferred) or fields with safe zero-defaults
+  (e.g. `u64::MIN`, `false`, `Address::default()`).
+- Deprecate an existing field via the process in §5.
+
+### Rule 3 — New fields must have safe defaults
+
+Every new field appended to an existing event struct must be **self-describing**
+or carry a **safe zero-value default** so that parsers built before the field
+was added continue to function correctly.
+
+| Type | Safe default | Notes |
+|------|-------------|-------|
+| `Option<T>` | `None` | **Preferred** — explicitly signals absence. |
+| `bool` | `false` | Only when `false` is the safe backward-compatible state. |
+| `u64`, `u32` | `0` | Only when `0` is semantically neutral (e.g. zero fee, zero balance impact). |
+| `i128` | `0` | Same as `u64`. |
+| `Address` | ❌ Not safe | Wrap in `Option<Address>` instead. |
+| `Bytes`, `String` | ❌ Not safe | Wrap in `Option<Bytes>`, `Option<String>`. |
+| `Map<K,V>` | ❌ Not safe | Wrap in `Option<Map<K,V>>`. |
+
+### Rule 4 — Every event has one canonical emit helper
+
+Each event is emitted by exactly one public helper function in `events.rs`.
+The emit helper owns the `symbol_short!()` topic definition and the
+`env.events().publish(...)` call.
+
+> Rationale: Co-locating the topic symbol with the payload type makes ABI
+> review trivial — every topic in the contract is visible by reading only
+> `events.rs`. Splitting an event's emission across multiple sites risks
+> inconsistency and silent topic drift.
+
+If a new code path needs to emit an existing event, it must call the existing
+emit helper — not re-publish the event inline.
+
+### Rule 5 — Topic cardinality (number of elements) is fixed
+
+The number of topic elements for a given topic symbol is part of the event's
+identity. For example, `"created"` always has topics `["created", stream_id]`
+(2 elements). Adding a third topic element would break parsers that filter by
+`topics[1]` to extract the stream ID.
+
+| Topic symbol | Current cardinality | Rationale |
+|-------------|-------------------|-----------|
+| `"created"` | 2 (`[symbol, stream_id]`) | Stream-level events use `stream_id` as second topic. |
+| `"AdminUpd"` | 1 (`[symbol]`) | Contract-level events have no stream. |
+| `"renewed"` | 3 (`[symbol, old_id, new_id]`) | Carries both stream IDs for correlation. |
+| `"fct_init"` | 1 (`[symbol]`) | Factory init is a one-time event. |
+
+---
+
+## 3. Topic symbol permanence
+
+### 3.1 Lifetime guarantee
+
+Once a topic symbol (e.g. `"created"`, `"withdrew"`, `"rate_upd"`) appears in
+a deployed contract's event output, it **must never be reassigned, renamed,
+or removed** from the source tree. The symbol is part of the permanent event
+namespace of the protocol.
+
+Rationale:
+
+- Indexers use `topics[0]` as the primary event-type discriminator. Changing
+  it would cause all historical events of that type to be silently dropped.
+- Off-chain analytics pipelines build type registries keyed by topic symbol.
+- Wallet UIs filter event streams by topic symbol.
+
+### 3.2 Reserved topic namespace
+
+The following topic symbols are reserved for future use and must not be
+assigned to a different event type:
+
+| Reserved symbol | Reserved for |
+|----------------|-------------|
+| `"migrated"` | Future migration checkpoints. |
+| `"tmpl_def"` | Template definition events. |
+
+These symbols are documented in `docs/events.md` as "reserved" and are not
+currently emitted by any function.
+
+### 3.3 Adding a new topic symbol
+
+To add a new topic symbol for a new event:
+
+1. Choose a symbol ≤ 9 characters (`symbol_short!` constraint).
+2. Follow the naming conventions from existing symbols:
+   - Use `snake_case` abbreviations where possible (e.g. `rate_upd`, `end_shrt`, `ac_set`).
+   - Avoid symbols that differ only in case (Soroban symbols are case-sensitive).
+   - Use meaningful prefixes for related event families (e.g. `ac_set`, `ac_revoke`, `ac_trig` for auto-claim).
+3. Add the emit helper to `events.rs` with the new `symbol_short!` call.
+4. Document the new event in `docs/events.md`.
+5. Add the new event struct to the test registry in `tests/event_schema_consistency.rs`.
+6. Add a snapshot test in `tests/event_snapshots_suite.rs` that pins the exact topic+payload.
+
+---
+
+## 4. Additive-only field changes
+
+### 4.1 Adding a field to an existing event
+
+The only permitted mutation to an existing event payload struct is appending
+one or more new fields at the end. Follow this checklist:
+
+1. **Choose the type** — Prefer `Option<T>` so old parsers see `None`.
+2. **Append the field** — Add the new field after all existing fields in the
+   `#[contracttype]` struct definition.
+3. **Update the emit helper** — If the new field requires a new parameter, add
+   it to the emit helper function signature. The old call sites must compile
+   unchanged — this means either:
+   - Give the parameter a default (not possible in Rust without a second
+     function or builder), **or**
+   - Create a new emit helper with a different name and keep the old one
+     (preferred for minor additions).
+4. **Document the field** — Add it to the struct's doc comment and to
+   `docs/events.md`.
+5. **Update the test registry** — Add the field to the struct's entry in
+   `tests/event_schema_consistency.rs`.
+6. **Add snapshot coverage** — Update the snapshot test to include the new
+   field in at least one fixture.
+7. **Do NOT bump `CONTRACT_VERSION`** for purely additive field additions
+   (they are backward-compatible by definition).
+
+> **Exception:** If the new field changes the semantics of an existing field
+> for downstream consumers (e.g., in V9, `Withdrawal.amount` now reports the
+> *net* amount for `delegated_withdraw` calls instead of the gross), then
+> `CONTRACT_VERSION` MUST be bumped. See §6.3 for the full policy.
+
+### 4.2 Upgrade-aware emit helpers
+
+When a field is added that only applies to streams created at or after a
+certain `CONTRACT_VERSION`, the emit helper should document this:
+
+```rust
+/// Emit the `created` event for a new stream.
+///
+/// ## Versioning notes
+///
+/// - Since V1: `stream_id`, `sender`, `recipient`, `deposit_amount`,
+///   `rate_per_second`, `start_time`, `cliff_time`, `end_time`,
+///   `withdraw_dust_threshold`
+/// - Since V2: `memo: Option<Bytes>` (appended).
+/// - Since V3: `metadata: Option<Map<Bytes,Bytes>>` (appended).
+pub(crate) fn emit_stream_created(env: &Env, stream_id: u64, payload: StreamCreated) {
+    // ...
+}
+```
+
+---
+
+## 5. Deprecation process
+
+When an event field is no longer relevant but cannot be removed without
+breaking existing parsers, follow this deprecation process.
+
+### 5.1 Deprecation lifecycle
+
+```
+Phase 1: Announce         Phase 2: Signal           Phase 3: Remove
+  (docs only)              (in-band marker)           (major version)
+
+      |                         |                          |
+      v                         v                          v
+  Notice period ─────────► Deprecation ──────────────► Removal
+  (≥ 1 version bump)      field set to sentinel       after ≥ N versions
+                            value for N versions       of deprecation
+```
+
+### 5.2 Phase 1 — Announce (notice period)
+
+Duration: **At least one `CONTRACT_VERSION` bump** (i.e., the field is
+announced as deprecated but still populated with real values).
+
+Actions:
+
+1. Update the field's doc comment in the Rust struct to include `@deprecated`
+   in the doc comment.
+2. Add a `#[deprecated]` Rust attribute if feasible (note: may not be possible
+   on `#[contracttype]` struct fields; use doc comment only as fallback).
+3. Update `docs/events.md` to mark the field as **DEPRECATED** with the
+   version in which deprecation was announced and the planned removal version.
+4. Bump `CONTRACT_VERSION` (deprecation is a user-facing change that indexers
+   may act on).
+
+### 5.3 Phase 2 — Signal (in-band marker)
+
+Duration: **At least two full `CONTRACT_VERSION` bumps after Phase 1** (unless
+an emergency requires faster removal).
+
+Starting at version `V_deprecated + 1`, the field is set to its **sentinel
+value** instead of a real value:
+
+| Original type | Sentinel value | Rationale |
+|-------------|---------------|-----------|
+| `Option<T>` | `None` | Already the safe default. |
+| `u64` | `0` | Indexers can check for sentinel. |
+| `i128` | `0` | Same. |
+| `bool` | `false` | Same. |
+| `Address` | `Address::default()` (zero address) | Must switch to `Option<Address>` first. |
+| `String` | Empty string `""` | Must switch to `Option<String>` first. |
+| `Bytes` | Empty `Bytes` | Must switch to `Option<Bytes>` first. |
+
+Actions:
+
+1. Modify the emit helper to write the sentinel value.
+2. Update the struct doc comment to state that the field is now sentinel-only.
+3. Update `docs/events.md` to reflect the sentinel behaviour.
+4. Add a test that confirms the sentinel is emitted correctly.
+
+### 5.4 Phase 3 — Removal (major version)
+
+After the field has been in sentinel mode for at least two version bumps,
+it may be removed from the struct definition entirely.
+
+> **Warning:** Removing a field from a `#[contracttype]` struct is a **binary
+> breaking change** — old deserialisers will fail to decode the new struct.
+> This should only be done when the protocol has an explicit mechanism for
+> retiring old contract instances (e.g. a migration to a new contract ID).
+
+Before removing:
+
+1. Confirm that no indexed data on any live network still references the field.
+2. Communicate the removal timeline to all known indexer operators.
+3. Update `docs/events.md` to remove the field.
+4. Bump `CONTRACT_VERSION`.
+5. Remove the field from the Rust struct.
+6. Remove the field from the test registry and snapshot tests.
+
+### 5.5 Deprecation metadata payload
+
+When deprecating a field, **do not** embed the deprecation signal in a
+separate metadata field. The sentinel value in the field itself is the signal.
+This keeps the event flat and parseable without secondary lookups.
+
+---
+
+## 6. Breaking changes (last resort)
+
+A breaking change is any modification to an event payload that violates the
+additive-only rules in §2. Breaking changes are strongly discouraged but may
+be unavoidable in extreme circumstances (e.g., critical security fix that
+requires changing a field type).
+
+### 6.1 When breaking changes are permitted
+
+- **Security vulnerability**: An existing field's type or semantics creates a
+  security hole that cannot be fixed additively.
+- **Protocol redesign**: A new major protocol version (e.g. V2 where V1 is
+  fully deprecated) where old instances are no longer indexed.
+
+### 6.2 Breaking change protocol
+
+If a breaking change is absolutely necessary:
+
+1. **Bump `CONTRACT_VERSION`** (required by the versioning policy in `lib.rs`).
+2. **Update `docs/ABI_STABILITY.md`** with the full description of what changed
+   and why.
+3. **Update `docs/events.md`** to reflect the new schema.
+4. **Annotate the old schema** in `docs/events.md` as a historical note with
+   the last version it appeared in.
+5. **Document the migration path** for indexers (e.g., "parse `amount` as net
+   for delegated_withdraw paths from V9 onward; see `docs/events.md` §9").
+6. **Add a version-sensitive snapshot test** that verifies the event shape
+   differs by contract version.
+7. **Communicate** the breaking change to all known downstream consumers at
+   least two weeks before deployment to a non-local network.
+
+### 6.3 The V9 precedent: `Withdrawal.amount` semantics change
+
+The V9 release changed the semantics of `Withdrawal.amount` specifically for
+the `delegated_withdraw` path — it now reports the **net** amount
+(gross − relayer_fee) instead of the gross total. This was handled as follows:
+
+| Step | Action | Location |
+|------|--------|----------|
+| 1 | `CONTRACT_VERSION` bumped from 8 to 9 | `lib.rs` |
+| 2 | `docs/events.md` updated with a `v9 breaking event-payload change` callout | `docs/events.md` § Parsing recommendations |
+| 3 | Legacy pre-V9 snapshots preserved as reference | `tests/event_snapshots_suite.rs` |
+| 4 | Version-sensitive snapshot test added | `tests/event_snapshots_suite.rs` |
+
+This remains the **only** permitted form of a "semantic" breaking change:
+field *names*, *types*, and *order* are unchanged; only the documented
+interpretation of an existing field's value changes for a specific code path.
+
+---
+
+## 7. Worked examples
+
+### 7.1 Compliant change: Appending an optional field
+
+**Scenario:** We want to add a `claim_deadline: Option<u64>` field to the
+`StreamCreated` event so indexers know when a stream's initial claim expires.
+
+**Current struct** (simplified):
+```rust
+pub struct StreamCreated {
+    pub stream_id: u64,
+    pub sender: Address,
+    // ... other fields ...
+    pub metadata: Option<Map<Bytes, Bytes>>,
+}
+```
+
+**Compliant diff** ✅ — new field appended at end, safe default (`None`):
+```diff
+ pub struct StreamCreated {
+     pub stream_id: u64,
+     pub sender: Address,
+     // ... other fields (unchanged) ...
+     pub metadata: Option<Map<Bytes, Bytes>>,
++    /// Block number (or Unix timestamp) after which the initial claim
++    /// expires. `None` means no deadline.
++    /// Added in CONTRACT_VERSION 10.
++    pub claim_deadline: Option<u64>,
+ }
+```
+
+**Why this is safe:** Old parsers that deserialise `StreamCreated` expecting
+the old field count will still work because Soroban's XDR deserialisation
+ignores trailing fields. New parsers see `None` for streams created before
+this field existed (handled by the emit helper populating the default).
+
+### 7.2 Non-compliant change: Inserting a field in the middle
+
+**Scenario:** A developer wants to group all address fields together.
+
+**Non-compliant diff** ❌ — field inserted between existing fields:
+```diff
+ pub struct StreamCreated {
+     pub stream_id: u64,
+     pub sender: Address,
++    pub claim_deadline: Option<u64>,   // INSERTED HERE — BREAKING!
+     pub recipient: Address,
+     // ...
+ }
+```
+
+**Why this breaks:** Soroban XDR serialises struct fields by ordinal. The
+recipient field moves from ordinal 2 to ordinal 3. Every indexer built
+against the old layout now reads `recipient` data from the `claim_deadline`
+slot and vice versa, producing corrupted data.
+
+### 7.3 Non-compliant change: Changing a field type
+
+**Non-compliant diff** ❌ — type changed:
+```diff
+ pub struct Withdrawal {
+     pub stream_id: u64,
+     pub recipient: Address,
+-    pub amount: i128,
++    pub amount: u64,   // TYPE CHANGE — BREAKING!
+ }
+```
+
+**Why this breaks:** The XDR wire format for `i128` and `u64` differs in both
+size and encoding. Deserialisers expecting `i128` will read the wrong number
+of bytes and fail to parse the rest of the struct.
+
+### 7.4 Non-compliant change: Removing a field without deprecation
+
+**Non-compliant diff** ❌ — field removed:
+```diff
+ pub struct WithdrawalTo {
+     pub stream_id: u64,
+     pub recipient: Address,
+-    pub destination: Address,   // REMOVED — BREAKING!
+     pub amount: i128,
+ }
+```
+
+**Why this breaks:** All existing parsers expect `destination` at ordinal 2.
+They will read `amount` data as `destination` and the first word of the next
+struct element (if any) as `amount`.
+
+### 7.5 Compliant change: Adding a new event
+
+**Scenario:** Add a `StreamAudited` event.
+
+**Compliant** ✅:
+```rust
+// 1. Add topic symbol and emit helper in events.rs.
+pub(crate) fn emit_stream_audited(env: &Env, stream_id: u64, payload: StreamAudited) {
+    env.events()
+        .publish((symbol_short!("audited"), stream_id), payload);
+}
+
+// 2. Define the payload struct at the crate root (lib.rs or types.rs).
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct StreamAudited {
+    pub stream_id: u64,
+    pub auditor: Address,
+    pub passed: bool,
+    pub report_hash: Option<BytesN<32>>,
+}
+
+// 3. Document in docs/events.md.
+// 4. Add to test registry in event_schema_consistency.rs.
+// 5. Add snapshot test in event_snapshots_suite.rs.
+```
+
+### 7.6 Compliant deprecation: Marking a field as deprecated
+
+**Scenario:** The `memo` field on `StreamCreated` is no longer needed.
+
+**Phase 1 — Announce (V10)**:
+```diff
+ pub struct StreamCreated {
+     pub stream_id: u64,
+     pub sender: Address,
+     // ... other fields ...
++    /// @deprecated Since V10. Use the `metadata` field instead.
++    /// Will be removed in V12.
+     pub memo: Option<Bytes>,
+     pub metadata: Option<Map<Bytes, Bytes>>,
+ }
+```
+
+**Phase 2 — Signal (V11)**:
+```diff
+ pub(crate) fn emit_stream_created(env: &Env, stream_id: u64, payload: StreamCreated) {
++    // V11+: memo is deprecated and always emitted as None.
++    // Remove the memo field from the struct in V12.
+     env.events()
+         .publish((symbol_short!("created"), stream_id), payload);
+ }
+```
+
+**Phase 3 — Removal (V12)**:
+```diff
+ pub struct StreamCreated {
+     pub stream_id: u64,
+     pub sender: Address,
+     // ... other fields ...
+-    pub memo: Option<Bytes>,        // REMOVED
+     pub metadata: Option<Map<Bytes, Bytes>>,
+ }
+```
+
+---
+
+## 8. Version bump checklist
+
+When `CONTRACT_VERSION` is bumped, update the following in addition to the
+constants and documents listed in `lib.rs`:
+
+| Artifact | Action |
+|----------|--------|
+| `lib.rs` — `CONTRACT_VERSION` | Increment. |
+| `lib.rs` — `const FROZEN_DISCRIMINANTS_V*` | Add the new version's enumerant if `DataKey` changed. |
+| `docs/events.md` | Version header at the top: "Current version: V<N>". |
+| `docs/events.md` — version callout | Add a **Version N** subsection if event shapes changed. |
+| `docs/event-schema-evolution.md` | Update the version history table (§8.1). |
+| `docs/ABI_STABILITY.md` | Update event catalogue reference. |
+| `docs/upgrade.md` | Append version-history row. |
+| `tests/event_schema_consistency.rs` | Update event registry if structs changed. |
+| `tests/event_snapshots_suite.rs` | Add or update snapshot fixtures. |
+
+### 8.1 Version history
+
+| Version | Date | Breaking event change | Summary |
+|---------|------|----------------------|---------|
+| 1 | — | — | Initial event schema. |
+| 3 | — | Yes (`StreamPaused` replaced `Paused(u64)`) | `"paused"` data changed from `StreamEvent::Paused(id)` to `StreamPaused { stream_id, reason }`. |
+| 9 | — | Yes (semantic) | `Withdrawal.amount` reports net for `delegated_withdraw`. |
+| 9+ | — | No | All future changes are additive-only per this policy. |
+
+---
+
+## 9. Security and testing
+
+### 9.1 Security assumptions
+
+1. **Event data is public.** Soroban events are visible to all network
+   participants. No sensitive data should ever be placed in an event payload.
+2. **Event emission is not a security control.** Events are informational;
+   they cannot be forged by an attacker to alter contract state. However,
+   events that leak information about stream health or finances should be
+   reviewed for privacy implications.
+3. **Deprecation sentinels must be verifiable.** Indexers that switch on
+   sentinel values must be able to distinguish "not yet implemented" from
+   "deprecated" — the version in which deprecation was announced is the
+   discriminator.
+
+### 9.2 Test requirements
+
+Every change to an event schema (additive or otherwise) must include:
+
+| Test | Location | What it verifies |
+|------|----------|-----------------|
+| Registry-vs-docs consistency | `tests/event_schema_consistency.rs` | Code struct fields match `docs/events.md`. |
+| Topic immutability | `tests/event_schema_consistency.rs` (see `test_additive_only_evolution`) | No existing field was removed, reordered, or changed type. |
+| Snapshot pinning | `tests/event_snapshots_suite.rs` | Exact topic+payload shape is pinned and does not change without explicit test update. |
+| Sentinel emission | `tests/event_schema_consistency.rs` (deprecation tests) | Deprecated fields emit the correct sentinel value. |
+| Version-sensitive shape | `tests/event_snapshots_suite.rs` | Event shape differs by contract version when a breaking change is intentional. |
+
+### 9.3 CI enforcement
+
+The following CI gates prevent accidental event-schema drift:
+
+1. **`test_event_schemas_consistent_with_docs`** — Fails if the code registry
+   and `docs/events.md` disagree on field names, types, or struct membership.
+2. **`test_additive_only_evolution`** — Fails if an existing event struct's
+   fields are reordered, removed (without going through the deprecation
+   process), or changed in type.
+3. **`event_snapshots_suite.rs` tests** — Fails if a snapshot fixture's
+   event output differs from the pinned expected output.
+
+---
+
+## 10. FAQ
+
+**Q: What if I need to add a required (non-Option) field?**
+
+A: Don't. A required field with no safe default would cause old parsers to
+either panic or produce undefined data. If the field is genuinely always
+present, make it `Option<T>` and document that indexers should treat `None`
+as "information not available for this stream" rather than a default.
+
+**Q: Can I rename an event struct?**
+
+A: No — the struct name is embedded in Soroban's XDR type metadata and is
+used by SDK-generated clients. Renaming breaks those clients. Document the
+old name as a deprecated alias instead.
+
+**Q: What about the `StreamEvent` enum variants?**
+
+A: The `StreamEvent` enum (with variants `Paused(u64)`, `Resumed(u64)`,
+`StreamCancelled(u64)`, `StreamCompleted(u64)`, `StreamClosed(u64)`) is
+part of the event schema. The same additive-only rules apply — new variants
+may be appended, existing variants may not be reordered or removed.
+
+> **Historical note:** The `Paused` variant was already replaced by the
+> `StreamPaused` struct in V3. The `Paused(u64)` variant is retained in the
+> enum for ABI compatibility but is no longer emitted.
+
+**Q: Do snapshot tests need to be updated for additive changes?**
+
+A: Yes. At least one snapshot fixture in `tests/event_snapshots_suite.rs`
+must include the new field populated with a non-default value. This prevents
+the field from being silently dropped by the serialiser.
+
+**Q: What if two PRs add fields to the same struct concurrently?**
+
+A: The second PR to merge will need to rebase and append its field after the
+first PR's field. The CI test `test_event_schemas_consistent_with_docs` will
+catch ordering mismatches between the registry and `docs/events.md`.
+
+**Q: How does this policy interact with the `DataKey` storage evolution policy?**
+
+A: The `DataKey` policy (documented in `types.rs` and `docs/storage.md`)
+governs storage-key discriminant stability — an entirely separate concern.
+Event payloads do not use `DataKey` discriminants and follow the rules in
+this document instead. The only overlap is the shared requirement to bump
+`CONTRACT_VERSION` for breaking changes.
+
+---
+
+## References
+
+- [Event catalogue (`docs/events.md`)](./events.md) — Current schema for every event.
+- [ABI stability policy (`docs/ABI_STABILITY.md`)](./ABI_STABILITY.md) — Broader ABI stability rules.
+- [Storage key evolution (`docs/storage.md`)](./storage.md) — `DataKey` discriminant policy.
+- [Manifest versioning (`docs/manifest-versioning.md`)](./manifest-versioning.md) — Versioning of the entire contract.
+- [Event emission helpers (`contracts/stream/src/events.rs`)](../contracts/stream/src/events.rs) — Canonical emit call sites.
+- [Event schema consistency tests (`contracts/stream/tests/event_schema_consistency.rs`)](../contracts/stream/tests/event_schema_consistency.rs) — Automated policy enforcement.
+- [Event snapshot tests (`contracts/stream/tests/event_snapshots_suite.rs`)](../contracts/stream/tests/event_snapshots_suite.rs) — Topic+payload pinning tests.

--- a/docs/events.md
+++ b/docs/events.md
@@ -805,6 +805,19 @@ This file is derived from `contracts/stream/src/lib.rs`, `contracts/stream/src/e
 
 Event emit helpers are in `contracts/stream/src/events.rs`. The test in `tests/event_schema_consistency.rs` cross-checks every event struct against the documented shapes below. Both the test and this document must be updated when event payloads change.
 
+## Event schema evolution policy
+
+The contract follows an **additive-only backward-compatibility policy** for all
+event payloads. See [`docs/event-schema-evolution.md`](./event-schema-evolution.md)
+for the complete rules:
+
+- New optional fields may only be appended at the end of existing structs
+- Existing fields must never change type, name, or position
+- Topic symbols are permanent once released
+- Deprecation follows a three-phase lifecycle (announce → signal → remove)
+
+All changes to event payloads must comply with this policy.
+
 If you change event topics or payloads in the contract, please update this
 document to match and include example snapshots.
 


### PR DESCRIPTION
## Summary

Writes a formal **additive-only backward-compatibility policy** governing how event payloads in `contracts/stream/src/events.rs` may change over time without breaking indexers that depend on stable field ordering and topic IDs. The policy is codified in a new documentation file and enforced by 4 new automated tests.

Closes #1479

---

## Motivation

The Fluxora stream contract emits 35+ structured Soroban events consumed by off-chain indexers, dashboards, wallets, and treasury tooling. Until now there was no written policy governing how event payloads could evolve across contract versions. This created risk of:

- **Silent indexer breakage** from field reordering, type changes, or topic symbol reassignment
- **Inconsistent deprecation practices** across contributors
- **No clear migration path** for downstream consumers when fields become obsolete

This PR closes that gap by defining clear rules, a deprecation lifecycle, worked examples, and automated test enforcement.

---

## Changes

### 1. `docs/event-schema-evolution.md` (NEW) - 3,000+ word policy document

| Section | Content |
|---------|---------|
| **1. Motivation** | Why a written policy is needed, governance scope, relationship to existing policies |
| **2. Core Rules** | 5 immutable rules: topic permanence, append-only fields, safe defaults, one canonical emit helper, fixed cardinality |
| **3. Topic Symbol Permanence** | Lifetime guarantee, reserved namespace, checklist for adding new topics |
| **4. Additive-Only Field Changes** | Checklist for appending fields, upgrade-aware emit helpers |
| **5. Deprecation Process** | 3-phase lifecycle (Announce -> Signal -> Remove) with durations, sentinel values table, and phase-by-phase actions |
| **6. Breaking Changes (Last Resort)** | When permitted, required protocol, the V9 precedent (Withdrawal.amount semantics change) |
| **7. Worked Examples** | 6 examples: 3 compliant (appending Option&lt;T&gt;, adding new event, deprecation lifecycle) + 3 non-compliant (field insertion, type change, removal) - all with Rust diffs and explanations |
| **8. Version Bump Checklist** | 9-item checklist for CONTRACT_VERSION bumps, version history table |
| **9. Security & Testing** | Security assumptions, 6 test requirements, CI enforcement gates |
| **10. FAQ** | 6 common questions answered |

### 2. `contracts/stream/src/events.rs` (UPDATED)

Extended the module-level doc comment with:
- **5 core rules** summary inline (so developers never have to leave the file)
- **Deprecation lifecycle** overview (3 phases)
- **Canonical topic table**: all 37 topic symbols with cardinality and first-emitted-in version
- **Cross-reference** to the full policy document

### 3. `contracts/stream/tests/event_schema_consistency.rs` (UPDATED)

Added **4 new enforcement tests**:

| Test | What it enforces | How |
|------|-----------------|-----|
| `test_additive_only_evolution` | Field removal, reordering, type change prohibited | Compares current registry against a hardcoded baseline copy - catches regressions immediately |
| `test_new_fields_have_safe_defaults` | New fields must use Option&lt;T&gt;, bool, u64, u32, or i128 | Checks fields beyond the baseline count for safe types |
| `test_topic_symbols_are_documented` | Every topic symbol appears in docs/events.md | Cross-references a hand-maintained topic list against doc content |
| `test_topic_cardinality_is_fixed` | Topic cardinality documented correctly | Best-effort check using pattern matching in docs |

The critical design decision: `baseline_event_registry()` is a **hardcoded literal copy** of the registry, not a delegate to `stream_event_registry()`. This ensures that stripping a field from the registry without also updating the baseline is caught as a test failure.

### 4. `docs/events.md` (UPDATED)

Added a cross-reference to the new evolution policy document under the "Keeping this doc in sync" section.

---

## Design Decisions

1. **Hardcoded baseline over snapshot file**: A `baseline_event_registry()` function with literal values was chosen over an `include_str!()` snapshot file because it keeps all test data in one file and makes violation error messages immediately actionable.

2. **Best-effort cardinality test over markdown parser**: Rather than building a full markdown table parser, the `test_topic_cardinality_is_fixed` test uses string pattern matching to distinguish single-topic from multi-topic patterns. This is pragmatic - if it ever produces a false positive, the fix is a one-line adjustment.

3. **One canonical call site per event**: The policy codifies the existing convention from `events.rs` as a hard rule - every event is emitted by exactly one helper function. This prevents topic drift from ad-hoc inline `publish()` calls.

4. **Three-phase deprecation**: The announce -> signal -> remove lifecycle gives indexer operators a predictable migration window with minimum version notice periods.

---

## Security Considerations

- **Event data is public**: Soroban events are visible to all network participants. The policy document explicitly notes this and cautions against placing sensitive data in payloads.
- **Deprecation sentinels are verifiable**: Indexers can distinguish "not yet implemented" from "deprecated" by checking CONTRACT_VERSION.
- **No new attack surface**: The changes are documentation and tests only; no contract logic was modified.

---

## Testing

| Test | Status | Notes |
|------|--------|-------|
| `test_event_schemas_consistent_with_docs` | Existing - unchanged | Cross-checks code registry vs docs/events.md |
| `test_additive_only_evolution` | **New** | Compares against hardcoded baseline |
| `test_new_fields_have_safe_defaults` | **New** | Safe type verification |
| `test_topic_symbols_are_documented` | **New** | Topic presence in docs |
| `test_topic_cardinality_is_fixed` | **New** | Cardinality pattern matching |
| `event_snapshots_suite.rs` | Existing - unchanged | Topic+payload pinning |

All existing snapshot, storage, and integration tests are unaffected since no contract code changed.

**To run:**
```
cargo test -p fluxora-stream event_schema_consistency
cargo test -p fluxora-stream event_snapshots_suite
```

---

## Related Documents

| Document | Relationship |
|----------|-------------|
| [docs/ABI_STABILITY.md](docs/ABI_STABILITY.md) | Broader ABI stability rules; event fields are part of the ABI |
| [docs/storage.md](docs/storage.md) | Separate DataKey discriminant policy for storage keys |
| [docs/events.md](docs/events.md) | Canonical event catalogue - updated with policy reference |
| [docs/manifest-versioning.md](docs/manifest-versioning.md) | Versioning of the entire contract |
| [contracts/stream/src/lib.rs](contracts/stream/src/lib.rs) | CONTRACT_VERSION and version-bump checklist |

---

## Checklist

- [x] New policy document `docs/event-schema-evolution.md` created
- [x] `contracts/stream/src/events.rs` updated with evolution-policy doc comments
- [x] 4 new enforcement tests in `tests/event_schema_consistency.rs`
- [x] `docs/events.md` updated with policy reference
- [x] Code review completed - baseline no-op issue fixed, cardinality detection refined
- [x] All existing tests unchanged (no contract logic modified)
