### PR TITLE
Fixed  script/deploy-testnet.sh's own usage comments say

### DIFF
--- a/script/deploy-testnet.sh
+++ b/script/deploy-testnet.sh
@@ -21,11 +21,11 @@
 # Usage:
 #   cp .env.example .env          # fill in your values
 #   source .env
-#   bash scripts/deploy-testnet.sh
+#   bash script/deploy-testnet.sh
 #
 # Or inline:
 #   STELLAR_SECRET_KEY=S... STELLAR_TOKEN_ADDRESS=C... STELLAR_ADMIN_ADDRESS=G... \
-#     bash scripts/deploy-testnet.sh
+#     bash script/deploy-testnet.sh
 # =============================================================================
 
 set -euo pipefail


### PR DESCRIPTION
# Fix `scripts/` → `script/` typo in deploy-testnet.sh usage comments

## Summary
- Corrected two occurrences of `scripts/deploy-testnet.sh` to `script/deploy-testnet.sh` in the header comment block of `script/deploy-testnet.sh` (lines 24 and 28), which incorrectly referenced a plural `scripts/` directory that doesn't exist in this repo.
- Grepped the full repo (`*.md`, `*.sh`, `*.py`, `*.yml`, `*.yaml`) for the same `scripts/` (plural) typo — no other live instances found. `script/README.md` had the identical typo fixed previously in #1429.

## Why
The script's own usage instructions told readers to run `bash scripts/deploy-testnet.sh`, which fails with `No such file or directory` since the actual directory is `script/` (singular). Copy-pasting the documented command verbatim broke immediately for anyone deploying to testnet.

## Test plan
- [x] `grep -n "scripts/" script/deploy-testnet.sh` — confirms both occurrences now read `script/`
- [x] `grep -rn "scripts/" --include="*.md" --include="*.sh" --include="*.py" --include="*.yml" --include="*.yaml" .` — no remaining plural-typo references to files under `script/`


Closes #1123
