### PR TITLE
feat: add cliff close-time skew status view and documented tolerance

### DIFF
--- a/contracts/stream/src/accrual.rs
+++ b/contracts/stream/src/accrual.rs
@@ -103,6 +103,60 @@ pub fn validate_rate_schedule(segments: &[RateSegment]) -> Result<(), ContractEr
     Ok(())
 }
 
+/// Maximum expected Stellar ledger close-time drift, in seconds.
+///
+/// Stellar ledger close times average 5-6 seconds but are not fixed to an
+/// exact cadence. A cliff timestamp that lands exactly on an expected ledger
+/// boundary can therefore unlock a few seconds later than an off-chain
+/// integrator's naive fixed-cadence expectation, even though the underlying
+/// `>= cliff_time` comparison is correct. This constant documents that
+/// worst-case drift so downstream integrators can reason about it explicitly
+/// (via [`get_cliff_status`]) instead of assuming exact-timestamp unlock.
+///
+/// # Security
+/// This constant is purely informational/observational. It does **not**
+/// alter the `>= cliff_time` unlock condition used by withdrawal or accrual
+/// math — see [`CliffStatus`] and `get_cliff_status` in `lib.rs`.
+pub const MAX_LEDGER_CLOSE_SKEW_SECS: u64 = 10;
+
+/// Observability status for a `CliffOnly` / `CliffSlope` stream's cliff unlock,
+/// distinguishing "not due yet" from "due imminently, within normal ledger
+/// close-time variance" from "unlocked".
+///
+/// See [`MAX_LEDGER_CLOSE_SKEW_SECS`] for the documented drift window.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum CliffStatus {
+    /// `now < cliff_time - MAX_LEDGER_CLOSE_SKEW_SECS`: not due soon.
+    Pending,
+    /// `cliff_time - MAX_LEDGER_CLOSE_SKEW_SECS <= now < cliff_time`: due
+    /// imminently — within normal ledger close-time variance of unlocking.
+    WithinSkewWindow,
+    /// `now >= cliff_time`: unlocked (matches the actual `>= cliff_time`
+    /// withdrawal/accrual gate — see [`calculate_accrued_amount_checkpointed`]).
+    Unlocked,
+}
+
+/// Classifies the current ledger time against a stream's `cliff_time` for
+/// observability purposes.
+///
+/// This is a pure, read-only classification — it never changes withdrawal
+/// correctness. The actual unlock gate remains the strict
+/// `now >= cliff_time` comparison in [`calculate_accrued_amount_checkpointed`].
+///
+/// # Units
+/// `now` and `cliff_time` are ledger timestamps in seconds.
+pub fn cliff_status(now: u64, cliff_time: u64) -> CliffStatus {
+    if now >= cliff_time {
+        return CliffStatus::Unlocked;
+    }
+
+    if now >= cliff_time.saturating_sub(MAX_LEDGER_CLOSE_SKEW_SECS) {
+        return CliffStatus::WithinSkewWindow;
+    }
+
+    CliffStatus::Pending
+}
+
 /// Assert that ledger-backed accrual time has not moved backwards.
 ///
 /// # Security

--- a/contracts/stream/src/accrual.rs
+++ b/contracts/stream/src/accrual.rs
@@ -1,5 +1,6 @@
 use crate::ContractError;
 use crate::StreamKind;
+use soroban_sdk::contracttype;
 
 /// Maximum number of segments in a piecewise rate schedule.
 ///
@@ -124,6 +125,7 @@ pub const MAX_LEDGER_CLOSE_SKEW_SECS: u64 = 10;
 /// close-time variance" from "unlocked".
 ///
 /// See [`MAX_LEDGER_CLOSE_SKEW_SECS`] for the documented drift window.
+#[contracttype]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum CliffStatus {
     /// `now < cliff_time - MAX_LEDGER_CLOSE_SKEW_SECS`: not due soon.
@@ -155,6 +157,138 @@ pub fn cliff_status(now: u64, cliff_time: u64) -> CliffStatus {
     }
 
     CliffStatus::Pending
+}
+
+#[cfg(test)]
+mod cliff_status_tests {
+    use super::{cliff_status, CliffStatus, MAX_LEDGER_CLOSE_SKEW_SECS};
+
+    #[test]
+    fn skew_constant_is_ten_seconds() {
+        assert_eq!(MAX_LEDGER_CLOSE_SKEW_SECS, 10);
+    }
+
+    // -----------------------------------------------------------------------
+    // Pending: strictly more than the skew window remains before cliff_time
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn pending_well_before_cliff() {
+        assert_eq!(cliff_status(0, 1_000), CliffStatus::Pending);
+    }
+
+    #[test]
+    fn pending_one_second_outside_skew_window() {
+        // cliff_time - skew - 1 is still outside the window (one second short).
+        let cliff_time = 1_000u64;
+        let now = cliff_time - MAX_LEDGER_CLOSE_SKEW_SECS - 1;
+        assert_eq!(cliff_status(now, cliff_time), CliffStatus::Pending);
+    }
+
+    // -----------------------------------------------------------------------
+    // WithinSkewWindow: inside the tolerance window, not yet unlocked
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn within_skew_window_at_lower_boundary() {
+        // now == cliff_time - MAX_LEDGER_CLOSE_SKEW_SECS is the first in-window instant.
+        let cliff_time = 1_000u64;
+        let now = cliff_time - MAX_LEDGER_CLOSE_SKEW_SECS;
+        assert_eq!(cliff_status(now, cliff_time), CliffStatus::WithinSkewWindow);
+    }
+
+    #[test]
+    fn within_skew_window_one_second_before_cliff() {
+        let cliff_time = 1_000u64;
+        assert_eq!(
+            cliff_status(cliff_time - 1, cliff_time),
+            CliffStatus::WithinSkewWindow
+        );
+    }
+
+    #[test]
+    fn within_skew_window_midpoint() {
+        let cliff_time = 1_000u64;
+        let now = cliff_time - (MAX_LEDGER_CLOSE_SKEW_SECS / 2);
+        assert_eq!(cliff_status(now, cliff_time), CliffStatus::WithinSkewWindow);
+    }
+
+    // -----------------------------------------------------------------------
+    // Unlocked: now >= cliff_time, matches the real withdrawal gate
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn unlocked_exactly_at_cliff() {
+        assert_eq!(cliff_status(1_000, 1_000), CliffStatus::Unlocked);
+    }
+
+    #[test]
+    fn unlocked_after_cliff() {
+        assert_eq!(cliff_status(1_500, 1_000), CliffStatus::Unlocked);
+    }
+
+    #[test]
+    fn unlocked_far_after_cliff() {
+        assert_eq!(cliff_status(u64::MAX, 1_000), CliffStatus::Unlocked);
+    }
+
+    // -----------------------------------------------------------------------
+    // Edge cases: cliff_time == 0, and cliff_time < MAX_LEDGER_CLOSE_SKEW_SECS
+    // -----------------------------------------------------------------------
+
+    /// `cliff_time == 0`: any `now >= 0` is unlocked (there is no meaningful
+    /// pre-cliff window at all).
+    #[test]
+    fn cliff_time_zero_is_always_unlocked() {
+        assert_eq!(cliff_status(0, 0), CliffStatus::Unlocked);
+    }
+
+    /// `cliff_time` smaller than the skew window: `saturating_sub` prevents
+    /// underflow, so the window's lower boundary clamps to 0 instead of
+    /// wrapping. Every `now` in `[0, cliff_time)` must classify as
+    /// `WithinSkewWindow`, never panic and never `Pending`.
+    #[test]
+    fn cliff_time_smaller_than_skew_window_saturates_without_panicking() {
+        let cliff_time = 3u64; // < MAX_LEDGER_CLOSE_SKEW_SECS (10)
+        for now in 0..cliff_time {
+            assert_eq!(
+                cliff_status(now, cliff_time),
+                CliffStatus::WithinSkewWindow,
+                "now={now}, cliff_time={cliff_time}"
+            );
+        }
+        assert_eq!(cliff_status(cliff_time, cliff_time), CliffStatus::Unlocked);
+    }
+
+    // -----------------------------------------------------------------------
+    // Property-style: classification never panics and is total over u64
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn property_total_and_monotonic_by_severity() {
+        // As `now` increases toward and past `cliff_time`, status only ever
+        // moves Pending -> WithinSkewWindow -> Unlocked, never backwards.
+        fn severity(status: CliffStatus) -> u8 {
+            match status {
+                CliffStatus::Pending => 0,
+                CliffStatus::WithinSkewWindow => 1,
+                CliffStatus::Unlocked => 2,
+            }
+        }
+
+        let cliff_time = 10_000u64;
+        let mut prev = severity(cliff_status(0, cliff_time));
+        let mut now = 0u64;
+        while now < cliff_time + MAX_LEDGER_CLOSE_SKEW_SECS + 5 {
+            let current = severity(cliff_status(now, cliff_time));
+            assert!(
+                current >= prev,
+                "severity regressed at now={now}: {current} < {prev}"
+            );
+            prev = current;
+            now += 1;
+        }
+    }
 }
 
 /// Assert that ledger-backed accrual time has not moved backwards.

--- a/contracts/stream/src/lib.rs
+++ b/contracts/stream/src/lib.rs
@@ -4650,6 +4650,61 @@ impl FluxoraStream {
         load_stream(&env, stream_id)
     }
 
+    /// Classifies the current ledger time against a stream's `cliff_time`,
+    /// exposing the documented ledger close-time skew tolerance
+    /// (`accrual::MAX_LEDGER_CLOSE_SKEW_SECS`) so clients can distinguish
+    /// "not yet due" from "due imminently, within normal ledger close-time
+    /// variance" instead of assuming a fixed unlock cadence.
+    ///
+    /// # Why this exists
+    /// Stellar ledger close times average 5-6 seconds but are not fixed to
+    /// an exact cadence. A cliff timestamp that lands exactly on an expected
+    /// ledger boundary can unlock a few seconds later than an off-chain
+    /// integrator's naive fixed-cadence expectation, even though the
+    /// underlying `>= cliff_time` comparison is correct. This view makes
+    /// that expected drift explicit and queryable instead of leaving
+    /// integrators to guess.
+    ///
+    /// # Returns
+    /// - `CliffStatus::Pending` — more than `MAX_LEDGER_CLOSE_SKEW_SECS`
+    ///   seconds remain before `cliff_time`.
+    /// - `CliffStatus::WithinSkewWindow` — within `MAX_LEDGER_CLOSE_SKEW_SECS`
+    ///   seconds of `cliff_time`, but not yet reached.
+    /// - `CliffStatus::Unlocked` — `now >= cliff_time`. This matches exactly
+    ///   the `>= cliff_time` gate used by `calculate_accrued`/`withdraw`.
+    ///
+    /// # Errors
+    /// - `ContractError::StreamNotFound` if `stream_id` does not exist.
+    ///
+    /// # Security
+    /// This is a pure, read-only observability view. It does **not** alter
+    /// the strict `>= cliff_time` unlock condition used by withdrawal or
+    /// accrual math — see `accrual::cliff_status` and
+    /// `calculate_accrued_amount_checkpointed`. Calling this function can
+    /// never change withdrawable amounts, stream state, or token balances.
+    ///
+    /// # Usage Notes
+    /// - This is a view function (read-only, no state changes); no
+    ///   authorization required (public information).
+    /// - Meaningful for all stream kinds. For `Linear` streams without a
+    ///   distinct cliff (`cliff_time == start_time`), this simply reports
+    ///   `Unlocked` once `now >= start_time`.
+    /// - For `Cancelled` streams, uses `cancelled_at` as the evaluation
+    ///   timestamp, consistent with `calculate_accrued`'s frozen-accrual
+    ///   semantics — a cancelled stream's cliff status does not keep
+    ///   advancing with wall-clock time after cancellation.
+    pub fn get_cliff_status(env: Env, stream_id: u64) -> Result<accrual::CliffStatus, ContractError> {
+        let stream = load_stream(&env, stream_id)?;
+
+        let now = if stream.status == StreamStatus::Cancelled {
+            stream.cancelled_at.ok_or(ContractError::InvalidState)?
+        } else {
+            current_accrual_timestamp(&env)?
+        };
+
+        Ok(accrual::cliff_status(now, stream.cliff_time))
+    }
+
     /// Returns the total duration (in seconds) the stream has been in Paused state.
     ///
     /// This includes all past pause cycles. If the stream is currently paused,

--- a/contracts/stream/src/types.rs
+++ b/contracts/stream/src/types.rs
@@ -473,9 +473,6 @@ pub struct Stream {
     pub irrevocable: Option<bool>,
     /// Optional compliance witness authorized to cancel via signed attestation.
     pub witness: Option<Address>,
-    /// If true, blocks all cancellation and shortening paths.
-    /// Defaults to false (None) for backward compatibility.
-    pub irrevocable: Option<bool>,
     /// Whether this stream is a pooled multi-recipient stream.
     pub is_pooled: Option<bool>,
     /// Ledger sequence number of the last rate change (or creation).

--- a/contracts/stream/tests/cliff_close_time_skew.rs
+++ b/contracts/stream/tests/cliff_close_time_skew.rs
@@ -1,0 +1,419 @@
+//! Tests for `get_cliff_status` and the documented ledger close-time skew
+//! tolerance window (`accrual::MAX_LEDGER_CLOSE_SKEW_SECS`).
+//!
+//! # Motivation (issue #1486)
+//!
+//! `StreamKind::CliffOnly` and `CliffSlope` streams gate accrual on a strict
+//! `env.ledger().timestamp() >= cliff_time` comparison. Stellar ledger close
+//! times average 5-6 seconds but are not fixed to an exact cadence, so a
+//! cliff set to land exactly on an expected ledger boundary can unlock a few
+//! seconds later than an off-chain integrator's naive fixed-cadence
+//! expectation, even though the contract logic is correct. `get_cliff_status`
+//! exposes `Pending` / `WithinSkewWindow` / `Unlocked` so clients can
+//! distinguish "not yet due" from "due imminently" instead of guessing.
+//!
+//! # What is tested
+//!
+//! 1. `Pending` well before the cliff, and just outside the skew window.
+//! 2. `WithinSkewWindow` at the lower boundary and just before the cliff.
+//! 3. `Unlocked` at and after the cliff.
+//! 4. `get_cliff_status` never alters withdrawal correctness: `Unlocked`
+//!    status coincides exactly with the moment `withdraw`/`calculate_accrued`
+//!    start paying out, and `WithinSkewWindow` still blocks withdrawal.
+//! 5. `Cancelled` streams freeze cliff status at `cancelled_at`, consistent
+//!    with `calculate_accrued`'s frozen-accrual semantics.
+//! 6. `StreamNotFound` for a nonexistent stream.
+//! 7. Behavior across all three `StreamKind` variants (Linear, CliffOnly,
+//!    CliffSlope).
+//!
+//! # Running
+//!
+//! ```bash
+//! cargo test -p fluxora_stream --test cliff_close_time_skew
+//! ```
+
+#![cfg(test)]
+
+use fluxora_stream::accrual::{CliffStatus, MAX_LEDGER_CLOSE_SKEW_SECS};
+use fluxora_stream::{ContractError, CreateStreamParams, FluxoraStream, FluxoraStreamClient, StreamKind};
+use soroban_sdk::{
+    testutils::{Address as _, Ledger},
+    token::{Client as TokenClient, StellarAssetClient},
+    Address, Env,
+};
+
+struct Ctx {
+    env: Env,
+    contract_id: Address,
+    sender: Address,
+    recipient: Address,
+}
+
+impl Ctx {
+    fn setup() -> Self {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register_contract(None, FluxoraStream);
+        let token_admin = Address::generate(&env);
+        let token_id = env
+            .register_stellar_asset_contract_v2(token_admin)
+            .address();
+
+        let admin = Address::generate(&env);
+        let sender = Address::generate(&env);
+        let recipient = Address::generate(&env);
+
+        FluxoraStreamClient::new(&env, &contract_id).init(&token_id, &admin);
+        StellarAssetClient::new(&env, &token_id).mint(&sender, &1_000_000_i128);
+        TokenClient::new(&env, &token_id).approve(&sender, &contract_id, &i128::MAX, &200_000u32);
+
+        env.ledger().set_timestamp(0);
+
+        Ctx {
+            env,
+            contract_id,
+            sender,
+            recipient,
+        }
+    }
+
+    fn client(&self) -> FluxoraStreamClient<'_> {
+        FluxoraStreamClient::new(&self.env, &self.contract_id)
+    }
+
+    fn create_cliff_only(&self, deposit: i128, start: u64, cliff: u64, end: u64) -> u64 {
+        self.client().create_stream(
+            &self.sender,
+            &CreateStreamParams {
+                recipient: self.recipient.clone(),
+                deposit_amount: deposit,
+                rate_per_second: 0, // CliffOnly requires rate=0
+                start_time: start,
+                cliff_time: cliff,
+                end_time: end,
+                withdraw_dust_threshold: Some(0),
+                memo: None,
+                metadata: None,
+                kind: StreamKind::CliffOnly,
+                irrevocable: None,
+                witness: None,
+            },
+        )
+    }
+
+    fn create_cliff_slope(
+        &self,
+        deposit: i128,
+        rate: i128,
+        start: u64,
+        cliff: u64,
+        end: u64,
+    ) -> u64 {
+        self.client().create_stream(
+            &self.sender,
+            &CreateStreamParams {
+                recipient: self.recipient.clone(),
+                deposit_amount: deposit,
+                rate_per_second: rate,
+                start_time: start,
+                cliff_time: cliff,
+                end_time: end,
+                withdraw_dust_threshold: Some(0),
+                memo: None,
+                metadata: None,
+                kind: StreamKind::CliffSlope,
+                irrevocable: None,
+                witness: None,
+            },
+        )
+    }
+
+    fn create_linear(&self, deposit: i128, rate: i128, start: u64, cliff: u64, end: u64) -> u64 {
+        self.client().create_stream(
+            &self.sender,
+            &CreateStreamParams {
+                recipient: self.recipient.clone(),
+                deposit_amount: deposit,
+                rate_per_second: rate,
+                start_time: start,
+                cliff_time: cliff,
+                end_time: end,
+                withdraw_dust_threshold: Some(0),
+                memo: None,
+                metadata: None,
+                kind: StreamKind::Linear,
+                irrevocable: None,
+                witness: None,
+            },
+        )
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Named constant is exposed and matches the documented value (10 seconds)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn skew_constant_is_documented_ten_seconds() {
+    assert_eq!(MAX_LEDGER_CLOSE_SKEW_SECS, 10);
+}
+
+// ---------------------------------------------------------------------------
+// Pending / WithinSkewWindow / Unlocked classification via the live contract
+// ---------------------------------------------------------------------------
+
+#[test]
+fn pending_well_before_cliff() {
+    let ctx = Ctx::setup();
+    let id = ctx.create_cliff_only(1_000, 0, 1_000, 2_000);
+
+    ctx.env.ledger().set_timestamp(500);
+    assert_eq!(ctx.client().get_cliff_status(&id), CliffStatus::Pending);
+}
+
+#[test]
+fn pending_one_second_outside_skew_window() {
+    let ctx = Ctx::setup();
+    let id = ctx.create_cliff_only(1_000, 0, 1_000, 2_000);
+
+    ctx.env
+        .ledger()
+        .set_timestamp(1_000 - MAX_LEDGER_CLOSE_SKEW_SECS - 1);
+    assert_eq!(ctx.client().get_cliff_status(&id), CliffStatus::Pending);
+}
+
+#[test]
+fn within_skew_window_at_lower_boundary() {
+    let ctx = Ctx::setup();
+    let id = ctx.create_cliff_only(1_000, 0, 1_000, 2_000);
+
+    ctx.env
+        .ledger()
+        .set_timestamp(1_000 - MAX_LEDGER_CLOSE_SKEW_SECS);
+    assert_eq!(
+        ctx.client().get_cliff_status(&id),
+        CliffStatus::WithinSkewWindow
+    );
+}
+
+#[test]
+fn within_skew_window_one_second_before_cliff() {
+    let ctx = Ctx::setup();
+    let id = ctx.create_cliff_only(1_000, 0, 1_000, 2_000);
+
+    ctx.env.ledger().set_timestamp(999);
+    assert_eq!(
+        ctx.client().get_cliff_status(&id),
+        CliffStatus::WithinSkewWindow
+    );
+}
+
+#[test]
+fn unlocked_exactly_at_cliff() {
+    let ctx = Ctx::setup();
+    let id = ctx.create_cliff_only(1_000, 0, 1_000, 2_000);
+
+    ctx.env.ledger().set_timestamp(1_000);
+    assert_eq!(ctx.client().get_cliff_status(&id), CliffStatus::Unlocked);
+}
+
+#[test]
+fn unlocked_after_cliff() {
+    let ctx = Ctx::setup();
+    let id = ctx.create_cliff_only(1_000, 0, 1_000, 2_000);
+
+    ctx.env.ledger().set_timestamp(1_500);
+    assert_eq!(ctx.client().get_cliff_status(&id), CliffStatus::Unlocked);
+}
+
+// ---------------------------------------------------------------------------
+// get_cliff_status never alters withdrawal correctness
+// ---------------------------------------------------------------------------
+
+/// While `WithinSkewWindow`, withdrawal must still be exactly as blocked as
+/// `Pending` — the skew window is purely observational and must not advance
+/// the real `>= cliff_time` unlock gate by even one second.
+#[test]
+fn within_skew_window_still_blocks_withdrawal() {
+    let ctx = Ctx::setup();
+    let id = ctx.create_cliff_only(1_000, 0, 1_000, 2_000);
+
+    ctx.env
+        .ledger()
+        .set_timestamp(1_000 - MAX_LEDGER_CLOSE_SKEW_SECS);
+    assert_eq!(
+        ctx.client().get_cliff_status(&id),
+        CliffStatus::WithinSkewWindow
+    );
+    assert_eq!(ctx.client().calculate_accrued(&id), 0);
+    assert_eq!(ctx.client().get_withdrawable(&id), 0);
+}
+
+/// The instant `get_cliff_status` reports `Unlocked` must coincide exactly
+/// with the moment `calculate_accrued`/`get_withdrawable` start paying out —
+/// the skew-window view and the real unlock gate must never disagree.
+#[test]
+fn unlocked_status_coincides_with_real_unlock_gate() {
+    let ctx = Ctx::setup();
+    let id = ctx.create_cliff_only(1_000, 0, 1_000, 2_000);
+
+    // One second before the cliff: still not unlocked in either view.
+    ctx.env.ledger().set_timestamp(999);
+    assert_ne!(ctx.client().get_cliff_status(&id), CliffStatus::Unlocked);
+    assert_eq!(ctx.client().calculate_accrued(&id), 0);
+
+    // Exactly at the cliff: both views flip to unlocked simultaneously.
+    ctx.env.ledger().set_timestamp(1_000);
+    assert_eq!(ctx.client().get_cliff_status(&id), CliffStatus::Unlocked);
+    assert_eq!(ctx.client().calculate_accrued(&id), 1_000);
+    assert_eq!(ctx.client().get_withdrawable(&id), 1_000);
+}
+
+/// A full withdraw() succeeds once `Unlocked`, and the reported status is
+/// unaffected by whether a withdrawal has already happened.
+#[test]
+fn withdraw_succeeds_once_unlocked_and_status_is_consistent_after() {
+    let ctx = Ctx::setup();
+    let id = ctx.create_cliff_only(1_000, 0, 1_000, 2_000);
+
+    ctx.env.ledger().set_timestamp(1_000);
+    assert_eq!(ctx.client().get_cliff_status(&id), CliffStatus::Unlocked);
+
+    let withdrawn = ctx.client().withdraw(&id, &None);
+    assert_eq!(withdrawn, 1_000);
+
+    // Status remains Unlocked after withdrawal (it reflects time, not balance).
+    assert_eq!(ctx.client().get_cliff_status(&id), CliffStatus::Unlocked);
+}
+
+// ---------------------------------------------------------------------------
+// Cancelled streams: cliff status freezes at cancelled_at
+// ---------------------------------------------------------------------------
+
+/// A stream cancelled while still `WithinSkewWindow` must keep reporting
+/// `WithinSkewWindow` forever after — it must not silently flip to
+/// `Unlocked` just because wall-clock time keeps advancing past the cliff,
+/// mirroring `calculate_accrued`'s frozen-accrual-at-cancellation semantics.
+#[test]
+fn cancelled_stream_freezes_status_at_cancellation_time() {
+    let ctx = Ctx::setup();
+    // CliffSlope so cancellation before the cliff is meaningful (no lump sum).
+    let id = ctx.create_cliff_slope(1_000, 1, 0, 1_000, 2_000);
+
+    ctx.env
+        .ledger()
+        .set_timestamp(1_000 - MAX_LEDGER_CLOSE_SKEW_SECS);
+    assert_eq!(
+        ctx.client().get_cliff_status(&id),
+        CliffStatus::WithinSkewWindow
+    );
+
+    ctx.client().cancel_stream(&id);
+
+    // Advance far past the cliff after cancellation.
+    ctx.env.ledger().set_timestamp(5_000);
+    assert_eq!(
+        ctx.client().get_cliff_status(&id),
+        CliffStatus::WithinSkewWindow,
+        "cancelled stream's cliff status must stay frozen at cancelled_at, not track wall-clock time"
+    );
+}
+
+/// A stream cancelled after the cliff was already reached keeps reporting
+/// `Unlocked` (frozen, not re-evaluated), matching `calculate_accrued`.
+#[test]
+fn cancelled_stream_after_cliff_stays_unlocked() {
+    let ctx = Ctx::setup();
+    let id = ctx.create_cliff_slope(1_000, 1, 0, 1_000, 2_000);
+
+    ctx.env.ledger().set_timestamp(1_500);
+    ctx.client().cancel_stream(&id);
+
+    ctx.env.ledger().set_timestamp(9_999);
+    assert_eq!(ctx.client().get_cliff_status(&id), CliffStatus::Unlocked);
+}
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+#[test]
+fn nonexistent_stream_returns_stream_not_found() {
+    let ctx = Ctx::setup();
+    let result = ctx.client().try_get_cliff_status(&999);
+    assert_eq!(result, Err(Ok(ContractError::StreamNotFound)));
+}
+
+// ---------------------------------------------------------------------------
+// All stream kinds
+// ---------------------------------------------------------------------------
+
+#[test]
+fn cliff_slope_pending_within_and_unlocked() {
+    let ctx = Ctx::setup();
+    let id = ctx.create_cliff_slope(1_000, 1, 0, 1_000, 2_000);
+
+    ctx.env.ledger().set_timestamp(500);
+    assert_eq!(ctx.client().get_cliff_status(&id), CliffStatus::Pending);
+
+    ctx.env.ledger().set_timestamp(995);
+    assert_eq!(
+        ctx.client().get_cliff_status(&id),
+        CliffStatus::WithinSkewWindow
+    );
+
+    ctx.env.ledger().set_timestamp(1_000);
+    assert_eq!(ctx.client().get_cliff_status(&id), CliffStatus::Unlocked);
+}
+
+/// `Linear` streams (no meaningful cliff: `cliff_time == start_time`) report
+/// `Unlocked` immediately at `start_time`, since there is no pre-cliff window.
+#[test]
+fn linear_stream_with_no_cliff_is_unlocked_from_start() {
+    let ctx = Ctx::setup();
+    let id = ctx.create_linear(1_000, 1, 0, 0, 1_000);
+
+    ctx.env.ledger().set_timestamp(0);
+    assert_eq!(ctx.client().get_cliff_status(&id), CliffStatus::Unlocked);
+
+    ctx.env.ledger().set_timestamp(500);
+    assert_eq!(ctx.client().get_cliff_status(&id), CliffStatus::Unlocked);
+}
+
+/// `Linear` stream with a real cliff still classifies Pending/WithinSkewWindow
+/// before it, exactly like CliffOnly/CliffSlope.
+#[test]
+fn linear_stream_with_cliff_classifies_before_unlock() {
+    let ctx = Ctx::setup();
+    // deposit must cover rate * (end - start) = 1 * 2_000 = 2_000.
+    let id = ctx.create_linear(2_000, 1, 0, 1_000, 2_000);
+
+    ctx.env.ledger().set_timestamp(200);
+    assert_eq!(ctx.client().get_cliff_status(&id), CliffStatus::Pending);
+
+    ctx.env.ledger().set_timestamp(995);
+    assert_eq!(
+        ctx.client().get_cliff_status(&id),
+        CliffStatus::WithinSkewWindow
+    );
+
+    ctx.env.ledger().set_timestamp(1_000);
+    assert_eq!(ctx.client().get_cliff_status(&id), CliffStatus::Unlocked);
+}
+
+// ---------------------------------------------------------------------------
+// Determinism
+// ---------------------------------------------------------------------------
+
+/// Repeated calls at the same timestamp return the same status (pure view).
+#[test]
+fn get_cliff_status_is_deterministic() {
+    let ctx = Ctx::setup();
+    let id = ctx.create_cliff_only(1_000, 0, 1_000, 2_000);
+
+    ctx.env.ledger().set_timestamp(995);
+    let a = ctx.client().get_cliff_status(&id);
+    let b = ctx.client().get_cliff_status(&id);
+    assert_eq!(a, b);
+}

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -1072,6 +1072,43 @@ loop {
 - Before `cliff_time`: accrued = 0, no withdrawals
 - At or after `cliff_time`: accrual uses elapsed time from `start_time`, not cliff
 
+### Ledger Close-Time Skew and `get_cliff_status`
+
+Stellar ledger close times average 5-6 seconds but are **not** fixed to an exact cadence. A
+cliff timestamp that lands exactly on an expected ledger boundary can therefore unlock a few
+seconds later than an off-chain integrator's naive fixed-cadence expectation, even though the
+contract's `>= cliff_time` comparison is correct and unchanged. `MAX_LEDGER_CLOSE_SKEW_SECS`
+(`contracts/stream/src/accrual.rs`, value `10`) documents that worst-case expected drift as a
+named constant, and `get_cliff_status(stream_id)` exposes it as a queryable view so clients can
+distinguish "not yet due" from "due imminently, within normal close-time variance" instead of
+guessing.
+
+```rust
+pub enum CliffStatus {
+    Pending,          // now < cliff_time - MAX_LEDGER_CLOSE_SKEW_SECS
+    WithinSkewWindow, // cliff_time - MAX_LEDGER_CLOSE_SKEW_SECS <= now < cliff_time
+    Unlocked,         // now >= cliff_time
+}
+```
+
+**This is observability only.** `get_cliff_status` is a pure, read-only view computed from
+`accrual::cliff_status(now, cliff_time)`. It never changes withdrawal correctness: the actual
+unlock gate used by `withdraw`, `calculate_accrued`, and `get_withdrawable` remains the exact
+same strict `now >= cliff_time` comparison it always was. `WithinSkewWindow` still fully blocks
+withdrawal — it is a hint to clients that the unlock is imminent, not an early-unlock state.
+
+- **Applies to all `StreamKind`s.** It is primarily meaningful for `CliffOnly` and `CliffSlope`
+  streams, where the cliff gates a lump-sum unlock or the start of accrual, but works uniformly
+  for `Linear` streams too. A `Linear` stream with no meaningful cliff (`cliff_time == start_time`)
+  reports `Unlocked` immediately once `now >= start_time`.
+- **Cancelled streams.** Uses `cancelled_at` as the evaluation timestamp, consistent with
+  `calculate_accrued`'s frozen-accrual-at-cancellation semantics — a cancelled stream's cliff
+  status stays frozen at whatever it was at cancellation time and does not keep advancing with
+  wall-clock time afterward.
+- **Errors.** Returns `ContractError::StreamNotFound` for an invalid `stream_id`.
+- **Auth.** No authorization required — this is public, read-only information, same as
+  `calculate_accrued` and `get_stream_state`.
+
 ### end_time
 
 - Must satisfy `start_time < end_time`


### PR DESCRIPTION
Closes #1486

## Summary

Adds an explicit, documented tolerance window for `StreamKind::CliffOnly` and `CliffSlope` cliff unlocks, so downstream integrators can reason about worst-case Stellar ledger close-time drift instead of assuming exact-timestamp unlock — completing the view wiring, tests, and docs the issue asked for.

## What's implemented

- `MAX_LEDGER_CLOSE_SKEW_SECS` — named constant (10 seconds) documenting the maximum expected ledger close-time drift, replacing what would otherwise be a magic number (`contracts/stream/src/accrual.rs`)
- `CliffStatus` enum (`Pending`, `WithinSkewWindow`, `Unlocked`), now a `#[contracttype]` so it can cross the contract ABI as a return value
- `accrual::cliff_status(now, cliff_time) -> CliffStatus` — pure classifier
- `get_cliff_status(env, stream_id) -> Result<CliffStatus, ContractError>` — the public contract view, wired into `contracts/stream/src/lib.rs` right after `get_stream_state`
- `docs/streaming.md` — new "Ledger Close-Time Skew and `get_cliff_status`" section documenting the constant, the enum, and the observability-only guarantee

## Files changed

- `contracts/stream/src/accrual.rs` — `MAX_LEDGER_CLOSE_SKEW_SECS`, `CliffStatus` (now `#[contracttype]`), `cliff_status()` classifier, and a new `cliff_status_tests` unit test module (12 tests)
- `contracts/stream/src/lib.rs` — `get_cliff_status(env, stream_id)` view, documented with NatSpec-style doc comments
- `contracts/stream/tests/cliff_close_time_skew.rs` — new integration test file (17 tests) exercising the view through the live contract
- `docs/streaming.md` — new documentation section
- `contracts/stream/src/types.rs` — see "Unrelated fix" below

## Implementation details

`get_cliff_status` loads the stream, picks the evaluation timestamp the same way `calculate_accrued` does (`cancelled_at` for `Cancelled` streams, `current_accrual_timestamp(&env)` otherwise), and delegates to the pure `accrual::cliff_status(now, cliff_time)` classifier:

```rust
pub enum CliffStatus {
    Pending,          // now < cliff_time - MAX_LEDGER_CLOSE_SKEW_SECS
    WithinSkewWindow, // cliff_time - MAX_LEDGER_CLOSE_SKEW_SECS <= now < cliff_time
    Unlocked,         // now >= cliff_time
}
```

The lower boundary uses `cliff_time.saturating_sub(MAX_LEDGER_CLOSE_SKEW_SECS)` so a `cliff_time` smaller than the skew window (e.g. `cliff_time = 3`) can never underflow — it just means the whole `[0, cliff_time)` range reports `WithinSkewWindow`.

**This is observability only.** `get_cliff_status`/`cliff_status` never touch the actual unlock gate. `withdraw`, `calculate_accrued`, and `get_withdrawable` still use the exact same `now >= cliff_time` comparison as before this change — nothing in `calculate_accrued_amount_checkpointed` was modified. Tests explicitly assert `WithinSkewWindow` still fully blocks withdrawal, and that `Unlocked` coincides exactly with the ledger second `calculate_accrued`/`get_withdrawable` start paying out.

## Tests added

`contracts/stream/src/accrual.rs::cliff_status_tests` (12 tests, pure-function level):
- Skew constant equals the documented 10 seconds
- `Pending` well before cliff, and one second outside the skew window
- `WithinSkewWindow` at the lower boundary, one second before cliff, and at the midpoint
- `Unlocked` at, after, and far after the cliff
- `cliff_time == 0` always reports `Unlocked`
- `cliff_time` smaller than the skew window saturates instead of underflowing/panicking
- Property test: severity (`Pending` → `WithinSkewWindow` → `Unlocked`) never regresses as `now` increases

`contracts/stream/tests/cliff_close_time_skew.rs` (17 tests, live-contract level):
- `Pending`/`WithinSkewWindow`/`Unlocked` classification via `get_cliff_status` on a real `CliffOnly` stream
- **Correctness guarantee**: `WithinSkewWindow` still fully blocks withdrawal (`calculate_accrued`/`get_withdrawable` both `0`); `Unlocked` status coincides exactly with `calculate_accrued`/`get_withdrawable` flipping to the full amount; `withdraw()` succeeds once `Unlocked` and the status stays consistent afterward
- **Cancelled streams**: a stream cancelled while `WithinSkewWindow` keeps reporting `WithinSkewWindow` forever after, even as wall-clock time advances far past the cliff (frozen at `cancelled_at`, matching `calculate_accrued`); a stream cancelled after the cliff stays `Unlocked`
- `StreamNotFound` for a nonexistent stream (via `try_get_cliff_status`)
- All three `StreamKind`s: `CliffOnly`, `CliffSlope`, and `Linear` (both with and without a meaningful cliff)
- Determinism: repeated calls at the same timestamp return the same status

## How to test

```bash
cargo test -p fluxora_stream --lib accrual
cargo test -p fluxora_stream --test cliff_close_time_skew
```

## Security notes

- Purely observational/read-only: `get_cliff_status` cannot mutate state, transfer tokens, or change any other view's result. No authorization required, matching `calculate_accrued`/`get_stream_state`.
- Verified (not just asserted) that the skew window doesn't leak into withdrawal correctness — see the "still blocks withdrawal" and "coincides with real unlock gate" tests above.
- The `saturating_sub` guards against integer underflow for a `cliff_time` smaller than 10, with an explicit test.

## Unrelated fix (required to build at all)

While validating this change, the crate did not compile: `Stream` in `contracts/stream/src/types.rs` had the `irrevocable` field declared **twice** (added independently by two different merged PRs — `git blame` shows `27065f6` and `0a8c2888` each added it), a hard Rust compile error. I removed the duplicate so the crate builds; no behavior change (both declarations were identical `Option<bool>`). This is the same pre-existing issue noted on PR #1507.

**Note on broader pre-existing test health**: once the crate compiles, `cargo test -p fluxora_stream --lib` surfaces a pre-existing stress test (`test_create_stream_multiple_loop` in `src/test.rs`) that aborts the whole test binary via a Soroban budget-exceeded double-panic, plus five other pre-existing failures unrelated to cliff status (rate-per-second overflow, recipient-index binary search, withdraw idempotency). None of these touch `accrual::cliff_status`/`get_cliff_status` — they were never actually exercised before since the crate didn't compile, and are left for a separate fix rather than expanding this PR's scope.
