### PR TITLE
fix: restore CliffStatus/cliff_status so main compiles again

### DIFF
--- a/contracts/stream/src/accrual.rs
+++ b/contracts/stream/src/accrual.rs
@@ -420,6 +420,193 @@ mod rate_segment_packing_tests {
     }
 }
 
+/// Maximum expected Stellar ledger close-time drift, in seconds.
+///
+/// Stellar ledger close times average 5-6 seconds but are not fixed to an
+/// exact cadence. A cliff timestamp that lands exactly on an expected ledger
+/// boundary can therefore unlock a few seconds later than an off-chain
+/// integrator's naive fixed-cadence expectation, even though the underlying
+/// `>= cliff_time` comparison is correct. This constant documents that
+/// worst-case drift so downstream integrators can reason about it explicitly
+/// (via [`get_cliff_status`]) instead of assuming exact-timestamp unlock.
+///
+/// # Security
+/// This constant is purely informational/observational. It does **not**
+/// alter the `>= cliff_time` unlock condition used by withdrawal or accrual
+/// math — see [`CliffStatus`] and `get_cliff_status` in `lib.rs`.
+pub const MAX_LEDGER_CLOSE_SKEW_SECS: u64 = 10;
+
+/// Observability status for a `CliffOnly` / `CliffSlope` stream's cliff unlock,
+/// distinguishing "not due yet" from "due imminently, within normal ledger
+/// close-time variance" from "unlocked".
+///
+/// See [`MAX_LEDGER_CLOSE_SKEW_SECS`] for the documented drift window.
+#[contracttype]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum CliffStatus {
+    /// `now < cliff_time - MAX_LEDGER_CLOSE_SKEW_SECS`: not due soon.
+    Pending,
+    /// `cliff_time - MAX_LEDGER_CLOSE_SKEW_SECS <= now < cliff_time`: due
+    /// imminently — within normal ledger close-time variance of unlocking.
+    WithinSkewWindow,
+    /// `now >= cliff_time`: unlocked (matches the actual `>= cliff_time`
+    /// withdrawal/accrual gate — see [`calculate_accrued_amount_checkpointed`]).
+    Unlocked,
+}
+
+/// Classifies the current ledger time against a stream's `cliff_time` for
+/// observability purposes.
+///
+/// This is a pure, read-only classification — it never changes withdrawal
+/// correctness. The actual unlock gate remains the strict
+/// `now >= cliff_time` comparison in [`calculate_accrued_amount_checkpointed`].
+///
+/// # Units
+/// `now` and `cliff_time` are ledger timestamps in seconds.
+pub fn cliff_status(now: u64, cliff_time: u64) -> CliffStatus {
+    if now >= cliff_time {
+        return CliffStatus::Unlocked;
+    }
+
+    if now >= cliff_time.saturating_sub(MAX_LEDGER_CLOSE_SKEW_SECS) {
+        return CliffStatus::WithinSkewWindow;
+    }
+
+    CliffStatus::Pending
+}
+
+#[cfg(test)]
+mod cliff_status_tests {
+    use super::{cliff_status, CliffStatus, MAX_LEDGER_CLOSE_SKEW_SECS};
+
+    #[test]
+    fn skew_constant_is_ten_seconds() {
+        assert_eq!(MAX_LEDGER_CLOSE_SKEW_SECS, 10);
+    }
+
+    // -----------------------------------------------------------------------
+    // Pending: strictly more than the skew window remains before cliff_time
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn pending_well_before_cliff() {
+        assert_eq!(cliff_status(0, 1_000), CliffStatus::Pending);
+    }
+
+    #[test]
+    fn pending_one_second_outside_skew_window() {
+        // cliff_time - skew - 1 is still outside the window (one second short).
+        let cliff_time = 1_000u64;
+        let now = cliff_time - MAX_LEDGER_CLOSE_SKEW_SECS - 1;
+        assert_eq!(cliff_status(now, cliff_time), CliffStatus::Pending);
+    }
+
+    // -----------------------------------------------------------------------
+    // WithinSkewWindow: inside the tolerance window, not yet unlocked
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn within_skew_window_at_lower_boundary() {
+        // now == cliff_time - MAX_LEDGER_CLOSE_SKEW_SECS is the first in-window instant.
+        let cliff_time = 1_000u64;
+        let now = cliff_time - MAX_LEDGER_CLOSE_SKEW_SECS;
+        assert_eq!(cliff_status(now, cliff_time), CliffStatus::WithinSkewWindow);
+    }
+
+    #[test]
+    fn within_skew_window_one_second_before_cliff() {
+        let cliff_time = 1_000u64;
+        assert_eq!(
+            cliff_status(cliff_time - 1, cliff_time),
+            CliffStatus::WithinSkewWindow
+        );
+    }
+
+    #[test]
+    fn within_skew_window_midpoint() {
+        let cliff_time = 1_000u64;
+        let now = cliff_time - (MAX_LEDGER_CLOSE_SKEW_SECS / 2);
+        assert_eq!(cliff_status(now, cliff_time), CliffStatus::WithinSkewWindow);
+    }
+
+    // -----------------------------------------------------------------------
+    // Unlocked: now >= cliff_time, matches the real withdrawal gate
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn unlocked_exactly_at_cliff() {
+        assert_eq!(cliff_status(1_000, 1_000), CliffStatus::Unlocked);
+    }
+
+    #[test]
+    fn unlocked_after_cliff() {
+        assert_eq!(cliff_status(1_500, 1_000), CliffStatus::Unlocked);
+    }
+
+    #[test]
+    fn unlocked_far_after_cliff() {
+        assert_eq!(cliff_status(u64::MAX, 1_000), CliffStatus::Unlocked);
+    }
+
+    // -----------------------------------------------------------------------
+    // Edge cases: cliff_time == 0, and cliff_time < MAX_LEDGER_CLOSE_SKEW_SECS
+    // -----------------------------------------------------------------------
+
+    /// `cliff_time == 0`: any `now >= 0` is unlocked (there is no meaningful
+    /// pre-cliff window at all).
+    #[test]
+    fn cliff_time_zero_is_always_unlocked() {
+        assert_eq!(cliff_status(0, 0), CliffStatus::Unlocked);
+    }
+
+    /// `cliff_time` smaller than the skew window: `saturating_sub` prevents
+    /// underflow, so the window's lower boundary clamps to 0 instead of
+    /// wrapping. Every `now` in `[0, cliff_time)` must classify as
+    /// `WithinSkewWindow`, never panic and never `Pending`.
+    #[test]
+    fn cliff_time_smaller_than_skew_window_saturates_without_panicking() {
+        let cliff_time = 3u64; // < MAX_LEDGER_CLOSE_SKEW_SECS (10)
+        for now in 0..cliff_time {
+            assert_eq!(
+                cliff_status(now, cliff_time),
+                CliffStatus::WithinSkewWindow,
+                "now={now}, cliff_time={cliff_time}"
+            );
+        }
+        assert_eq!(cliff_status(cliff_time, cliff_time), CliffStatus::Unlocked);
+    }
+
+    // -----------------------------------------------------------------------
+    // Property-style: classification never panics and is total over u64
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn property_total_and_monotonic_by_severity() {
+        // As `now` increases toward and past `cliff_time`, status only ever
+        // moves Pending -> WithinSkewWindow -> Unlocked, never backwards.
+        fn severity(status: CliffStatus) -> u8 {
+            match status {
+                CliffStatus::Pending => 0,
+                CliffStatus::WithinSkewWindow => 1,
+                CliffStatus::Unlocked => 2,
+            }
+        }
+
+        let cliff_time = 10_000u64;
+        let mut prev = severity(cliff_status(0, cliff_time));
+        let mut now = 0u64;
+        while now < cliff_time + MAX_LEDGER_CLOSE_SKEW_SECS + 5 {
+            let current = severity(cliff_status(now, cliff_time));
+            assert!(
+                current >= prev,
+                "severity regressed at now={now}: {current} < {prev}"
+            );
+            prev = current;
+            now += 1;
+        }
+    }
+}
+
 /// Assert that ledger-backed accrual time has not moved backwards.
 ///
 /// # Security


### PR DESCRIPTION
Fixes #1513.

`main` has not compiled since 2026-07-30. `contracts/stream/src/lib.rs` calls `accrual::cliff_status` and returns `accrual::CliffStatus`; neither exists in `contracts/stream/src/accrual.rs`. This is the **library**, not a test, so nothing in the workspace builds.

```
error[E0425]: cannot find type `CliffStatus` in module `accrual`
    --> contracts/stream/src/lib.rs:4696:74
error[E0425]: cannot find function `cliff_status` in module `accrual`
    --> contracts/stream/src/lib.rs:4705:21
error: could not compile `fluxora_stream` (lib) due to 2 previous errors
```

## What this changes

One file, additions only: `contracts/stream/src/accrual.rs`, +187 / −0.

Restores exactly what was dropped, byte-for-byte from `30f5ed7`:

- `MAX_LEDGER_CLOSE_SKEW_SECS`
- the `CliffStatus` enum
- `cliff_status()`
- the 12 accompanying unit tests

No other file is touched and no behaviour changes — `cliff_status` is purely observational and does not affect the `>= cliff_time` unlock gate. It can land independently of anything else in flight.

## Why it went missing

A **semantic merge conflict**, not anyone's mistake. Full analysis in #1513, but in short: PR #1508 added both halves together and compiled (verified by building `30f5ed7`). PR #1507's merge, `75b15ca`, then resolved a real textual conflict in `accrual.rs` by taking its own branch's wholesale rewrite of that file (+249/−120) — a branch that predated #1508 and so did not contain the symbols. `lib.rs` was untouched by #1507, so the caller survived from the other parent.

Both PRs were complete and compiled on their own. Neither review could have seen this. Building the merge result would have.

## Verification

```
cargo build --workspace                          # succeeds
cargo test -p fluxora_stream --lib cliff_status  # 12 passed
```

## Not included, deliberately

Two related problems are left for their own PRs so this one stays trivially reviewable:

- **The CI gap that let this land** — `Test` and `Build` are `needs: lint`, and `Lint` was already failing on `cargo fmt`, so both were *skipped* rather than run and the merge reported no failure. Tracked separately; that is the more valuable fix.
- **`contracts/governance/tests/signer_index_proptest.rs`** calls `try_add_signer` / `try_remove_signer`, renamed to `test_only_*` by `5a526b9` without updating the test. Breaks `cargo test --workspace` but not the build.
