### PR TITLE
fix(stream): typed errors on withdraw/cancel fund paths

### DIFF
--- a/contracts/stream/src/error.rs
+++ b/contracts/stream/src/error.rs
@@ -38,6 +38,10 @@ pub enum Error {
 
     // --- State machine ---
     /// Action requires an `Active` stream.
+    ///
+    /// Reserved in the frozen ABI; current entry points use the more specific
+    /// [`Self::StreamNotPaused`] / [`Self::StreamAlreadyPaused`] /
+    /// [`Self::StreamTerminated`] variants instead. Do not renumber.
     StreamNotActive = 11,
     /// `resume` called on a stream that is not `Paused`.
     StreamNotPaused = 12,

--- a/contracts/stream/src/lib.rs
+++ b/contracts/stream/src/lib.rs
@@ -337,9 +337,14 @@ impl FluxoraStream {
     ///
     /// # Errors
     ///
-    /// * [`Error::NothingToWithdraw`] — withdrawable balance is zero. A typed
-    ///   error rather than a silent no-op, so a caller can tell the difference
-    ///   between "nothing yet" and "transferred zero".
+    /// * [`Error::StreamNotFound`] — no stream with this id.
+    /// * [`Error::StreamTerminated`] — stream is `Cancelled` or `Depleted` and
+    ///   has nothing left to pay. Distinct from [`Error::NothingToWithdraw`] so
+    ///   a client can tell "wait for accrual" apart from "this stream is over"
+    ///   without a second round-trip.
+    /// * [`Error::NothingToWithdraw`] — stream is still live but the
+    ///   withdrawable balance is zero (pre-start, pre-cliff, or fully drawn
+    ///   for now). A typed error rather than a silent no-op.
     /// * [`Error::InsufficientWithdrawable`] — explicit amount exceeds the
     ///   withdrawable balance.
     pub fn withdraw(env: Env, stream_id: u64, amount: Option<i128>) -> Result<i128, Error> {
@@ -349,6 +354,12 @@ impl FluxoraStream {
         let now = env.ledger().timestamp();
         let available = accrual::withdrawable(&stream, now)?;
         if available == 0 {
+            // Terminal with nothing left is a different precondition from a
+            // live stream that simply has not accrued (or is fully drawn for
+            // now). Integrators must be able to branch without guessing.
+            if stream.status.is_terminal() {
+                return Err(Error::StreamTerminated);
+            }
             return Err(Error::NothingToWithdraw);
         }
 
@@ -404,6 +415,11 @@ impl FluxoraStream {
         // Quadratic, but bounded by MAX_BATCH_SIZE and it avoids allocating a
         // set. A duplicate id would load the stream twice and apply the second
         // withdrawal to a stale copy, silently over-paying.
+        //
+        // Invariant: `i` and `j` are always in `0..count`, and `count` is
+        // `stream_ids.len()`, so `get_unchecked` cannot be out of range. A
+        // bounds-checked `get` would only ever return `None` if the Vec were
+        // mutated mid-loop, which it is not.
         for i in 0..count {
             for j in (i + 1)..count {
                 if stream_ids.get_unchecked(i) == stream_ids.get_unchecked(j) {
@@ -450,6 +466,12 @@ impl FluxoraStream {
     ///
     /// Cancelling before the cliff refunds everything: pre-cliff the recipient's
     /// entitlement is zero by definition.
+    ///
+    /// # Errors
+    ///
+    /// * [`Error::StreamNotFound`] — no stream with this id.
+    /// * [`Error::NotCancellable`] — created with `cancellable == false`.
+    /// * [`Error::StreamTerminated`] — already cancelled or depleted.
     pub fn cancel(env: Env, stream_id: u64) -> Result<(), Error> {
         let mut stream = storage::load_stream(&env, stream_id)?;
         stream.sender.require_auth();

--- a/contracts/stream/src/storage.rs
+++ b/contracts/stream/src/storage.rs
@@ -150,6 +150,9 @@ pub fn save_stream(env: &Env, stream_id: u64, stream: &Stream) {
 /// Ids are monotonic and never reused, so an id is a stable handle an indexer
 /// can key on forever.
 pub fn next_stream_id(env: &Env) -> Result<u64, Error> {
+    // Missing counter means no stream has been created yet — equivalent to 0.
+    // This is a default, not a precondition failure: create_stream is what
+    // initialises the counter, and there is no separate `init` entry point.
     let current: u64 = env
         .storage()
         .instance()
@@ -172,6 +175,9 @@ pub fn stream_exists(env: &Env, stream_id: u64) -> bool {
 
 /// Total number of streams ever created.
 pub fn stream_count(env: &Env) -> u64 {
+    // Same default as `next_stream_id`: an untouched instance has created
+    // zero streams. Not a recoverable precondition — callers treat 0 as the
+    // honest answer.
     env.storage()
         .instance()
         .get(&DataKey::NextStreamId)

--- a/contracts/stream/src/test/cancel.rs
+++ b/contracts/stream/src/test/cancel.rs
@@ -138,10 +138,12 @@ fn cancel_at_the_instant_of_creation_refunds_everything() {
     h.assert_pool_exact();
 
     // The collapsed zero-length schedule must stay readable, not panic.
+    // Status is Cancelled with nothing left → StreamTerminated, not the
+    // live-stream NothingToWithdraw path.
     h.advance(200 * DAY);
     assert_eq!(h.client.vested_of(&id), 0);
     let err = h.client.try_withdraw(&id, &None).unwrap_err().unwrap();
-    assert_eq!(err, Error::NothingToWithdraw);
+    assert_eq!(err, Error::StreamTerminated);
 }
 
 /// Cancelling before the stream even opens must not produce a negative-length
@@ -245,6 +247,14 @@ fn a_depleted_stream_cannot_be_cancelled() {
 
     let err = h.client.try_cancel(&id).unwrap_err().unwrap();
     assert_eq!(err, Error::StreamTerminated);
+}
+
+/// Missing stream on cancel must be a decodable contract error, not a trap.
+#[test]
+fn cancelling_unknown_stream_is_stream_not_found() {
+    let h = Harness::new();
+    let err = h.client.try_cancel(&999).unwrap_err().unwrap();
+    assert_eq!(err, Error::StreamNotFound);
 }
 
 /// Cancelling a paused stream must settle against the frozen clock, not the

--- a/contracts/stream/src/test/withdraw.rs
+++ b/contracts/stream/src/test/withdraw.rs
@@ -164,8 +164,9 @@ fn draining_a_stream_marks_it_depleted() {
     assert_eq!(h.get(id).withdrawn, 1_000 * ONE);
 }
 
-/// A depleted stream must return a typed error, never panic and never pay
-/// twice.
+/// A depleted stream must return `StreamTerminated`, never panic and never
+/// pay twice. Distinct from `NothingToWithdraw` so a client does not confuse
+/// "not accrued yet" with "this stream is over".
 #[test]
 fn withdrawing_from_a_depleted_stream_is_a_typed_error() {
     let h = Harness::new();
@@ -174,13 +175,22 @@ fn withdrawing_from_a_depleted_stream_is_a_typed_error() {
     h.client.withdraw(&id, &None);
 
     let err = h.client.try_withdraw(&id, &None).unwrap_err().unwrap();
-    assert_eq!(err, Error::NothingToWithdraw);
+    assert_eq!(err, Error::StreamTerminated);
     assert_eq!(h.balance(&h.recipient), 1_000 * ONE);
 
     h.advance(10 * YEAR);
     let err = h.client.try_withdraw(&id, &None).unwrap_err().unwrap();
-    assert_eq!(err, Error::NothingToWithdraw);
+    assert_eq!(err, Error::StreamTerminated);
     h.assert_pool_exact();
+}
+
+/// Missing stream on a fund-moving path must be a decodable contract error,
+/// not a host trap from an unwrap on storage.
+#[test]
+fn withdrawing_unknown_stream_is_stream_not_found() {
+    let h = Harness::new();
+    let err = h.client.try_withdraw(&999, &None).unwrap_err().unwrap();
+    assert_eq!(err, Error::StreamNotFound);
 }
 
 /// A one-second stream is the tightest possible schedule and must still behave.

--- a/docs/ABI.md
+++ b/docs/ABI.md
@@ -114,6 +114,14 @@ Discriminants are ABI and are never renumbered; new variants are appended.
 
 The CLI and RPC render these as `Error(Contract, #N)`.
 
+`StreamNotActive` (11) is reserved in the frozen ABI; current entry points
+return the more specific pause/terminated variants instead.
+
+`withdraw` distinguishes empty balances: a live stream with nothing accrued
+yet returns `NothingToWithdraw` (17); a `Cancelled` or `Depleted` stream with
+nothing left returns `StreamTerminated` (14). Clients must not treat those as
+equivalent.
+
 ---
 
 ## Entry points


### PR DESCRIPTION
﻿## Summary

- Classify and clear unwrap/expect/panic sites on the **withdraw + cancel** fund-moving paths in `fluxora-stream` (this repo has no factory/governance crates).
- `withdraw` on a terminal stream with nothing left now returns `StreamTerminated` (14), not `NothingToWithdraw` (17), so clients can distinguish "wait for accrual" from "stream is over".
- Annotate bucket-2 survivors (`get_unchecked`, `NextStreamId` defaults); add `StreamNotFound` tests for withdraw/cancel.

## Classification

| Bucket | Count | Notes |
|---|---:|---|
| Recoverable precondition (contract production) | **0** remaining in scope | Storage reads already go through `load_stream` / `peek_stream` → `StreamNotFound`. This PR closes the empty-balance ambiguity on withdraw. |
| Genuine invariant (contract production) | **1** annotated | `Vec::get_unchecked` in `batch_withdraw` duplicate scan — indices always in `0..len`. |
| Defaults (not traps) | **2** annotated | `unwrap_or(0)` on `NextStreamId` — missing counter means zero streams created. |
| Test-module | **72** | Left untouched (was 70; +2 from new `try_*` assertions). Excluded from action count. |
| `#[ignore]` | **0** | Unchanged. |

**Scope choice:** `fluxora-stream` withdraw + cancel (and shared helpers they already use). These are the paths where opaque traps hurt integrators most. Remaining crates in the ticket text (factory/governance) are not in this repository; remaining stream entry points already return typed `Error` via the same accessors.

## ABI compatibility

**Append-safe / discriminants unchanged.** No variants added or renumbered. Enum diff is docs-only on `StreamNotActive = 11`. Behavior change: depleted/cancelled-empty withdraw now returns existing discriminant **14** instead of **17**.

## Wasm size

| | bytes |
|---|---:|
| Before | 46,872 |
| After | 47,592 |
| Delta | **+720** |

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --all-features` (159 passed, 0 ignored)
- [x] `cargo build -p fluxora-stream --target wasm32v1-none --release`
- [x] New tests: `withdrawing_unknown_stream_is_stream_not_found`, `cancelling_unknown_stream_is_stream_not_found`, depleted/cancelled-empty → `StreamTerminated`

## Follow-up

- No bucket-1 production sites remain in `fluxora-stream`.
- Auth failures still trap via `require_auth()` (host behaviour; not convertible to `Error` without redesign).
- `StreamNotActive` stays reserved in the frozen ABI.

Part of typed-error hardening for fund-moving paths.

Closes: #1522 
